### PR TITLE
OSU-279: deposits revert during emergency shutdown - tests

### DIFF
--- a/src/dragons/DragonTokenizedStrategy.sol
+++ b/src/dragons/DragonTokenizedStrategy.sol
@@ -9,6 +9,7 @@ import {
     ZeroLockupDuration,
     InsufficientLockupDuration,
     SharesStillLocked,
+    StrategyInShutdown,
     RageQuitInProgress
 } from "src/errors.sol";
 
@@ -347,6 +348,8 @@ contract DragonTokenizedStrategy is TokenizedStrategy {
             assets = S.asset.balanceOf(msg.sender);
         }
 
+        // Check for shutdown first to enable better error msg.
+        if (S.shutdown) revert StrategyInShutdown();
         // Checking max deposit will also check if shutdown.
         require(assets <= _maxDeposit(S, receiver), "ERC4626: deposit more than max");
         // Check for rounding error.
@@ -370,6 +373,8 @@ contract DragonTokenizedStrategy is TokenizedStrategy {
         // Get the storage slot for all following calls.
         StrategyData storage S = _strategyStorage();
 
+        // Check for shutdown first to enable better error msg.
+        if (S.shutdown) revert StrategyInShutdown();
         // Checking max mint will also check if shutdown.
         require(shares <= _maxMint(S, receiver), "ERC4626: mint more than max");
         // Check for rounding error.
@@ -402,6 +407,8 @@ contract DragonTokenizedStrategy is TokenizedStrategy {
             assets = S.asset.balanceOf(msg.sender);
         }
 
+        // Check for shutdown first to enable better error msg.
+        if (S.shutdown) revert StrategyInShutdown();
         // Checking max deposit will also check if shutdown.
         require(assets <= _maxDeposit(S, receiver), "ERC4626: deposit more than max");
         // Check for rounding error.
@@ -431,6 +438,9 @@ contract DragonTokenizedStrategy is TokenizedStrategy {
         StrategyData storage S = _strategyStorage();
 
         if (S.voluntaryLockups[msg.sender].isRageQuit) revert RageQuitInProgress();
+
+        // Check for shutdown first to enable better error msg.
+        if (S.shutdown) revert StrategyInShutdown();
         // Checking max mint will also check if shutdown.
         require(shares <= _maxMint(S, receiver), "ERC4626: mint more than max");
         // Check for rounding error.

--- a/src/errors.sol
+++ b/src/errors.sol
@@ -21,3 +21,5 @@ error WithdrawMoreThanMax();
 error RedeemMoreThanMax();
 error SharesStillLocked();
 error RageQuitInProgress();
+
+error StrategyInShutdown();

--- a/test/vaults/Lockups.t.sol
+++ b/test/vaults/Lockups.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.18;
 
 import "forge-std/console.sol";
 import { Setup } from "./Setup.sol";
-import { InsufficientLockupDuration, RageQuitInProgress, SharesStillLocked } from "src/errors.sol";
+import { InsufficientLockupDuration, RageQuitInProgress, SharesStillLocked, StrategyInShutdown } from "src/errors.sol";
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
@@ -1014,7 +1014,7 @@ contract LockupsTest is Setup {
         vm.startPrank(user);
 
         // Try to deposit after shutdown
-        vm.expectRevert("ERC4626: deposit more than max");
+        vm.expectRevert(StrategyInShutdown.selector);
         strategy.depositWithLockup(depositAmount, user, 100 days);
 
         vm.stopPrank();
@@ -1030,7 +1030,7 @@ contract LockupsTest is Setup {
         vm.startPrank(user);
 
         // Try to mint after shutdown
-        vm.expectRevert("ERC4626: mint more than max");
+        vm.expectRevert(StrategyInShutdown.selector);
         strategy.mintWithLockup(mintAmount, user, 100 days);
 
         vm.stopPrank();
@@ -1046,7 +1046,7 @@ contract LockupsTest is Setup {
         vm.startPrank(user);
 
         // Try to deposit after shutdown
-        vm.expectRevert("ERC4626: mint more than max");
+        vm.expectRevert(StrategyInShutdown.selector);
         strategy.deposit(depositAmount, user);
 
         vm.stopPrank();


### PR DESCRIPTION
This only adds a test, since deposits were already reverting. 

Second commit is a stab at "ERC4626: mint more than max" instead of something like "Strategy is in shutdown". I've considered changing the behavior of `_maxMint` and `_maxDeposit`, but it seemed to introduce too much of a change comparing to behavior of yarns' TokenizedStrategy, so I went with a bit clunkier solution.

EDIT: for clarity. Yarn's TokenizedStrategy throws "ERC4626: mint more than max" if strategy is in shutdown and there is a deposit. Second commit changes this behavior!