### PR TITLE
Revert Foundry Fuzz Settings to Default in Default Profile

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -12,7 +12,7 @@ fs_permissions = [{ access = "read-write", path = "./cache/test-artifacts/" },{ 
 build_info = true
 extra_output = ["storageLayout"]
 seed = "0xDEADC0DE"
-fuzz = {runs = 2560, max_test_rejects=655360}
+fuzz = {runs = 256, max_test_rejects=65536}
 
 [profile.ci]
 verbosity = 4


### PR DESCRIPTION
In my M2 Macbook Air, the test suite runs in 78 seconds with default settings. And in the current settings, it takes 750 seconds. I often hack the fuzz run count temporarily in my local environment only to be able to keep working since I can't be productive if I wait for 750 seconds after each change to test if it's all right. Ideally, I need the opposite: I should be getting feedback rapidly. [The idea is to keep the feedback loops as tight as possible to enable more efficient development.](https://www.crafted.solutions/blog-feeds/drive-speed-build-confidence-and-increase-transparency-with-test-driven-development#:~:text=With%20TDD%2C%20the%20software%20developer,to%20enable%20more%20efficient%20development.) Also, these numbers are going to increase as we add more tests. So my argument is, unless you have a super speedy computer, this configuration encourages you to hack the Foundry config to be able to work. Therefore, I suggest we revert it to defaults.