### PR TITLE
feature: add package details to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "octant-v2-core",
+  "name": "@octant/v2-core",
   "version": "0.0.1",
   "description": "",
   "packageManager": "yarn@4.7.0+sha512.5a0afa1d4c1d844b3447ee3319633797bcd6385d9a44be07993ae52ff4facabccafb4af5dcd1c2f9a94ac113e5e9ff56f6130431905884414229e284e37bb7c9",
@@ -7,6 +7,12 @@
     "npm": "please-use-yarn",
     "node": ">=22.0.0"
   },
+  "files": [
+    "out",
+    "src",
+    "script",
+    "lib"
+  ],
   "scripts": {
     "format": "prettier --config .prettierrc --plugin=prettier-plugin-solidity '{contracts,src,test}/**/*.sol' -w",
     "format:check": "prettier --config .prettierrc --plugin=prettier-plugin-solidity '{contracts,src,test}/**/*.sol' -c",
@@ -46,5 +52,9 @@
     "solhint": "^5.0.3",
     "solhint-plugin-prettier": "^0.1.0",
     "typescript": "5.3.3"
+  },
+  "publishConfig": {
+    "access": "restricted",
+    "provenance": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -661,6 +661,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@octant/v2-core@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "@octant/v2-core@workspace:."
+  dependencies:
+    "@gnosis.pm/safe-contracts": "npm:^1.3.0"
+    "@openzeppelin/upgrades-core": "npm:^1.41.0"
+    dotenv: "npm:^16.4.5"
+    ethers: "npm:5"
+    forge-stack-tracer: "npm:^1.0.3"
+    husky: "npm:^9.1.7"
+    lint-staged: "npm:^15.2.10"
+    prettier: "npm:^3.3.3"
+    prettier-plugin-solidity: "npm:^1.4.1"
+    shx: "npm:^0.3.4"
+    solhint: "npm:^5.0.3"
+    solhint-plugin-prettier: "npm:^0.1.0"
+    typescript: "npm:5.3.3"
+  languageName: unknown
+  linkType: soft
+
 "@openzeppelin/upgrades-core@npm:^1.41.0":
   version: 1.42.1
   resolution: "@openzeppelin/upgrades-core@npm:1.42.1"
@@ -2520,26 +2540,6 @@ __metadata:
   checksum: 10c0/124df74820c40c2eb9a8612a254ea1d557ddfab1581c3e751f825e3e366d9f00b0d76a3c94ecd8398e7f3eee193018622677e95816e8491f0797b21e30b2deba
   languageName: node
   linkType: hard
-
-"octant-v2-core@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "octant-v2-core@workspace:."
-  dependencies:
-    "@gnosis.pm/safe-contracts": "npm:^1.3.0"
-    "@openzeppelin/upgrades-core": "npm:^1.41.0"
-    dotenv: "npm:^16.4.5"
-    ethers: "npm:5"
-    forge-stack-tracer: "npm:^1.0.3"
-    husky: "npm:^9.1.7"
-    lint-staged: "npm:^15.2.10"
-    prettier: "npm:^3.3.3"
-    prettier-plugin-solidity: "npm:^1.4.1"
-    shx: "npm:^0.3.4"
-    solhint: "npm:^5.0.3"
-    solhint-plugin-prettier: "npm:^0.1.0"
-    typescript: "npm:5.3.3"
-  languageName: unknown
-  linkType: soft
 
 "once@npm:^1.3.0":
   version: 1.4.0


### PR DESCRIPTION
This PR adds attributes to the package.json so that it can be packaged. It also scopes the package to the @octant 

This isn't strictly necessary for local development because installing via portal copies the whole directory but it would be required for distribution.

Installing via `file` will fail because husky can't be found. This would require some modifications to allow the postinstall script to silently fail. 

```"postinstall": "shx chmod +x .husky/* || true"```

I believe the "prepare" lifecycle hook is no longer valid and can be removed. It is also worth considering refactoring the postinstall script more because it won't necessary when installing the package.