### PR TITLE
fix: use camel case for mutable variable

### DIFF
--- a/src/dragons/DragonRouter.sol
+++ b/src/dragons/DragonRouter.sol
@@ -35,8 +35,8 @@ contract DragonRouter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, L
                             STATE VARIABLES
     //////////////////////////////////////////////////////////////*/
 
-    uint256 public DRAGON_SPLIT_COOLDOWN_PERIOD;
-    uint256 public SPLIT_DELAY;
+    uint256 public coolDownPeriod;
+    uint256 public splitDelay;
     ISplitChecker public splitChecker;
     address public opexVault;
     address public metapool;
@@ -59,7 +59,7 @@ contract DragonRouter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, L
     /// @dev owner of this module will the safe multisig that calls setUp function
     /// @param initializeParams Parameters of initialization encoded
     function setUp(bytes memory initializeParams) public initializer {
-        DRAGON_SPLIT_COOLDOWN_PERIOD = 30 days;
+        coolDownPeriod = 30 days;
         (address _owner, bytes memory data) = abi.decode(initializeParams, (address, bytes));
 
         (
@@ -229,7 +229,7 @@ contract DragonRouter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, L
      * @inheritdoc IDragonRouter
      */
     function setSplit(ISplitChecker.Split memory _split) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        if (block.timestamp - lastSetSplitTime < DRAGON_SPLIT_COOLDOWN_PERIOD) revert CooldownPeriodNotPassed();
+        if (block.timestamp - lastSetSplitTime < coolDownPeriod) revert CooldownPeriodNotPassed();
         splitChecker.checkSplit(_split, opexVault, metapool);
 
         for (uint256 i = 0; i < strategies.length; i++) {
@@ -309,8 +309,8 @@ contract DragonRouter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, L
      * @param _cooldownPeriod New cooldown period in seconds
      */
     function _setCooldownPeriod(uint256 _cooldownPeriod) internal {
-        emit CooldownPeriodUpdated(DRAGON_SPLIT_COOLDOWN_PERIOD, _cooldownPeriod);
-        DRAGON_SPLIT_COOLDOWN_PERIOD = _cooldownPeriod;
+        emit CooldownPeriodUpdated(coolDownPeriod, _cooldownPeriod);
+        coolDownPeriod = _cooldownPeriod;
     }
 
     /**
@@ -341,8 +341,8 @@ contract DragonRouter is AccessControlUpgradeable, ReentrancyGuardUpgradeable, L
      * @param _splitDelay New split delay in seconds
      */
     function _setSplitDelay(uint256 _splitDelay) internal {
-        emit SplitDelayUpdated(SPLIT_DELAY, _splitDelay);
-        SPLIT_DELAY = _splitDelay;
+        emit SplitDelayUpdated(splitDelay, _splitDelay);
+        splitDelay = _splitDelay;
     }
 
     /**

--- a/test/unit/DragonRouter.t.sol
+++ b/test/unit/DragonRouter.t.sol
@@ -147,7 +147,7 @@ contract DragonRouterTest is Test {
         routerTesting.setCooldownPeriod(newPeriod);
 
         // Test successful change
-        assertEq(routerTesting.DRAGON_SPLIT_COOLDOWN_PERIOD(), newPeriod);
+        assertEq(routerTesting.coolDownPeriod(), newPeriod);
     }
 
     function test_setCooldownPeriod_reverts() public {
@@ -288,7 +288,7 @@ contract DragonRouterTest is Test {
         uint256 newDelay = 7 days;
 
         // Get the current split delay for emit comparison
-        uint256 currentDelay = routerTesting.SPLIT_DELAY();
+        uint256 currentDelay = routerTesting.splitDelay();
 
         vm.prank(owner);
         vm.expectEmit(true, true, true, true);
@@ -296,7 +296,7 @@ contract DragonRouterTest is Test {
         routerTesting.setSplitDelay(newDelay);
 
         // Verify the split delay was updated
-        assertEq(routerTesting.SPLIT_DELAY(), newDelay);
+        assertEq(routerTesting.splitDelay(), newDelay);
     }
 
     function test_setSplitChecker() public {
@@ -529,7 +529,7 @@ contract DragonRouterTest is Test {
         allocations[1] = 70; // 70% to metapool
 
         // Need to wait for cooldown period
-        uint256 cooldownPeriod = routerTesting.DRAGON_SPLIT_COOLDOWN_PERIOD();
+        uint256 cooldownPeriod = routerTesting.coolDownPeriod();
         vm.warp(block.timestamp + cooldownPeriod + 1);
 
         // No need to mock - using routerTesting which has real implementation


### PR DESCRIPTION
Since the cooldown period can be changed it is more readable for it to be camelCase instead of shouting snake case