### PR TITLE
Refactor LinearAllowance

### DIFF
--- a/src/dragons/LinearAllowanceExecutor.sol
+++ b/src/dragons/LinearAllowanceExecutor.sol
@@ -16,7 +16,7 @@ contract LinearAllowanceExecutor {
         LinearAllowanceSingletonForGnosisSafe allowanceModule,
         address safe,
         address token
-    ) external returns (uint256) {
+    ) external returns (uint112) {
         return allowanceModule.executeAllowanceTransfer(safe, token, payable(address(this)));
     }
 

--- a/src/dragons/modules/LinearAllowanceSingletonForGnosisSafe.sol
+++ b/src/dragons/modules/LinearAllowanceSingletonForGnosisSafe.sol
@@ -111,7 +111,7 @@ contract LinearAllowanceSingletonForGnosisSafe is ReentrancyGuard {
         address safe,
         address token,
         address payable to
-    ) external nonReentrant returns (uint256) {
+    ) external nonReentrant returns (uint112) {
         LinearAllowance storage a = allowances[safe][msg.sender][token];
         updateAllowance(a);
 


### PR DESCRIPTION
- [Compress allowance struct to use 1 storage slot instead of 2](https://linear.app/golemfoundation/issue/OSU-569/optimize-linear-allowance-contract).


Fixes #74 

Some variables are compressed by trimming the least significant 32 bits. This creates a precision loss of a maximum of 2^32-1. To avoid precision loss, simply input values that are divisible by 2^32. 

As a result of compression, gas expenses are greatly reduced. Allowance struct now uses only one storage slot instead of four, which means up to 75% gas cost reduction.