### PR TITLE
wip

### DIFF
--- a/src/interfaces/IPaymentSplitter.sol
+++ b/src/interfaces/IPaymentSplitter.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+interface IPaymentSplitter {
+    function recordProfit(uint256 amount) external;
+
+    /**
+     * @dev Record loss for the current epoch.
+     * @param amount The amount of loss to record.
+     * @return The amount of shares that were burned.
+     */
+    function recordLoss(uint256 amount) external returns (uint256);
+}


### PR DESCRIPTION
# PR: Implement Epoch-Based Distribution to Prevent MEV Attacks in YieldSkimmingStrategy

## Problem Statement

The current `YieldSkimmingTokenizedStrategy`/`YieldSkimmingTokenizedStrategy` implementation have critical vulnerabilities when handling losses through the dragonRouter (PaymentSplitter):

### 1. **Race Condition / MEV Attack Vector**
When a loss is about to be reported, payees can monitor the mempool and front-run the loss transaction by withdrawing their shares. This allows malicious actors to avoid their proportional share of losses, leaving honest participants to bear a disproportionate burden.

### 2. **Unfair Loss Distribution**
The current mechanism burns shares from the dragonRouter without considering:
- Which payees have already withdrawn their profits
- The timing of withdrawals relative to losses
- This creates an inequitable system where late withdrawers are disproportionately penalized

## Solution: Epoch-Based Distribution System

This PR implements a time-based epoch system that provides MEV protection and fair profit/loss distribution.

### Key Changes

1. **PaymentSplitter Refactoring**
   - Removed native ETH support (focus on ERC20 as our strategies dont support native tokens anymore)
   - Introduced 7-day epochs with automatic transitions (could be a different number)
   - Added `recordProfit()` and `recordLoss()` functions for the strategy to report P&L
   - Profits and losses are netted within each epoch before distribution

2. **Temporal Separation**
   - Payees can only claim from finalized epochs (not the current active epoch)
   - All P&L for an epoch must be recorded before any distributions occur
   - Eliminates the ability to front-run losses by enforcing temporal boundaries

3. **Fair Distribution Mechanism**
   - Each epoch tracks `totalProfit`, `totalLoss`, and `netDistributable`
   - If losses exceed profits in an epoch, no distribution occurs (netDistributable = 0)
   - All payees are treated equally regardless of withdrawal timing
   - Historical claims are tracked to prevent double-claiming

### Implementation Details

```solidity
// Strategy reports profit/loss to PaymentSplitter
IPaymentSplitter(dragonRouter).recordProfit(profitAmount);
// payment splitter tells the strategy how many shares it can burn from it
uint256 burnableShare = IPaymentSplitter(dragonRouter).recordLoss(lossAmount);

// Payees claim after epoch ends
splitter.release(IERC20(token), payeeAddress);
```

### Architecture Overview

```
┌─────────────────┐    recordProfit()    ┌──────────────────┐
│ YieldSkimming   │ ──────────────────→  │  PaymentSplitter │
│ Strategy        │    recordLoss()      │  (dragonRouter)  │
└─────────────────┘ ──────────────────→  └──────────────────┘
                                                    │
                                                    │ Epoch-based
                                                    │ Distribution
                                                    ▼
                                         ┌──────────────────┐
                                         │     Payees       │
                                         │ (can only claim  │
                                         │ from past epochs)│
                                         └──────────────────┘
```


### Benefits

1. **MEV Protection**: Impossible to front-run losses as they affect the current epoch which isn't claimable
2. **Fairness**: All payees share profits and losses proportionally within each epoch
3. **Transparency**: Clear accounting periods make it easy to audit distributions
4. **Gas Efficiency**: Batch claiming of multiple epochs in a single transaction
5. **Multi-Token Support**: Each token has independent epoch tracking


### Cons 

1. **Losses are epoch related**: Strategy cannot recover a loss from profit from another epoch

## Future Considerations

This architecture sets the foundation for additional features:
- Configurable epoch durations


