### PR TITLE
fix(security): prevent whitelist circumvention via delegation

### DIFF
--- a/src/regen/RegenStaker.sol
+++ b/src/regen/RegenStaker.sol
@@ -101,6 +101,7 @@ contract RegenStaker is RegenStakerBase {
     ///      costing ~250k-350k gas. Subsequent operations with the same delegatee reuse existing surrogate.
     ///      Consider pre-deploying surrogates for frequently used delegatees during low gas price periods.
     function _fetchOrDeploySurrogate(address _delegatee) internal override returns (DelegationSurrogate _surrogate) {
+        _checkWhitelisted(sharedState.stakerWhitelist, _delegatee);
         _surrogate = _surrogates[_delegatee];
         if (address(_surrogate) == address(0)) {
             _surrogate = new DelegationSurrogateVotes(VOTING_TOKEN, _delegatee);


### PR DESCRIPTION
#### Vulnerability Explanation
In the current implementation of `RegenStaker.sol`, the whitelisting system enforces access controls based on the deposit owner to restrict staking and related operations (e.g., voting power) to approved users only. However, the delegation feature allows a whitelisted owner to delegate their voting power to a non-whitelisted address via surrogate contracts (`DelegationSurrogate`).

This creates a circumvention path:
- A whitelisted user (e.g., Alice) stakes tokens, passing the owner-based whitelist check.
- Alice delegates to a non-whitelisted user (e.g., Bob), transferring effective control (e.g., voting influence) without checking Bob's whitelist status.
- Bob gains unauthorized benefits, enabling sybil attacks or governance manipulation, undermining the security model (as noted in `RegenStakerBase.sol` NatSpecs: "prevent whitelist circumvention").

**Impact**: High severity—enables Sybil attacks that disrupt quadratic funding in allocation mechanisms, leading to unfair resource distribution, economic manipulation, and erosion of system trust.

#### Remediation Explanation
This PR adds explicit whitelist checks for delegatees in key delegation function:
- In `_fetchOrDeploySurrogate(address _delegatee)`: Adds the same check before deploying or fetching a surrogate.

These changes ensure delegatees must be whitelisted, closing the gap while preserving delegation for approved users. Reuses the existing `stakerWhitelist` for consistency.