### PR TITLE
[OSU-812] feat: combine strategy proxy abis

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "lint": "solhint './{src,scripts,test}/**/*.sol'",
     "precommit": "lint-staged",
     "build": "forge clean && forge compile --sizes",
-    "build:contracts": "forge clean && forge compile --sizes --skip test --skip script",
+    "build:contracts": "forge clean && forge compile --sizes --skip test --skip script && ./scripts/combine-proxy-abis.sh",
     "test": "forge clean && forge test",
     "test:ci": "forge clean && mkdir -p reports && (forge test --junit > reports/junit.xml || forge test --summary)",
     "gas": "forge snapshot --isolate --gas-report --diff .gas-snapshot > gasreport.txt",

--- a/scripts/combine-proxy-abis.sh
+++ b/scripts/combine-proxy-abis.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+# Combine ABIs from SkyCompounderStrategy and YieldDonatingTokenizedStrategy
+jq -s '{"abi": (.[0].abi + .[1].abi)|unique}' \
+  out/SkyCompounderStrategy.sol/SkyCompounderStrategy.json \
+  out/YieldDonatingTokenizedStrategy.sol/YieldDonatingTokenizedStrategy.json \
+  > out/SkyCompounderStrategy.sol/SkyCompounderYieldDonatingTokenizedStrategy.json
+
+# Combine ABIs from MorphoCompounderStrategy and YieldDonatingTokenizedStrategy
+jq -s '{"abi": (.[0].abi + .[1].abi)|unique}' \
+  out/MorphoCompounderStrategy.sol/MorphoCompounderStrategy.json \
+  out/YieldDonatingTokenizedStrategy.sol/YieldDonatingTokenizedStrategy.json \
+  > out/MorphoCompounderStrategy.sol/MorphoCompounderYieldDonatingTokenizedStrategy.json
+
+# Combine ABIs from LidoStrategy and YieldSkimmingTokenizedStrategy
+jq -s '{"abi": (.[0].abi + .[1].abi)|unique}' \
+  out/LidoStrategy.sol/LidoStrategy.json \
+  out/YieldSkimmingTokenizedStrategy.sol/YieldSkimmingTokenizedStrategy.json \
+  > out/LidoStrategy.sol/LidoYieldSkimmingTokenizedStrategy.json
+
+# Combine ABIs from MorphoStrategy and YieldSkimmingTokenizedStrategy
+jq -s '{"abi": (.[0].abi + .[1].abi)|unique}' \
+  out/MorphoCompounderStrategy.sol/MorphoCompounderStrategy.json \
+  out/YieldSkimmingTokenizedStrategy.sol/YieldSkimmingTokenizedStrategy.json \
+  > out/MorphoCompounderStrategy.sol/MorphoCompounderYieldSkimmingTokenizedStrategy.json
+
+# Combine ABIs from RocketPoolStrategy and YieldSkimmingTokenizedStrategy
+jq -s '{"abi": (.[0].abi + .[1].abi)|unique}' \
+  out/RocketPoolStrategy.sol/RocketPoolStrategy.json \
+  out/YieldSkimmingTokenizedStrategy.sol/YieldSkimmingTokenizedStrategy.json \
+  > out/RocketPoolStrategy.sol/RocketPoolYieldSkimmingTokenizedStrategy.json


### PR DESCRIPTION
Combines strategy proxies into a single abi.

Currently the MorphoCompounder name is shared by two contracts so the abi of one is clobbering the other. This script will need to be updated when the contract is renamed