### PR TITLE
fix: remove foreign command from postinstall script

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,7 +35,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Init env
-        run: yarn install
+        run: |
+          yarn install
+          forge soldeer install
 
       - name: Build
         run: yarn build
@@ -58,7 +60,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Init env
-        run: yarn install
+        run: |
+          yarn install
+          forge soldeer install
 
       - name: Run tests
         env:
@@ -101,7 +105,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Init env
-        run: yarn install
+        run: | 
+          yarn install
+          forge soldeer install
 
       - name: Generate Coverage Report
         env:

--- a/.github/workflows/tpl-lint.yml
+++ b/.github/workflows/tpl-lint.yml
@@ -78,7 +78,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Init env
-        run: yarn install
+        run: |
+          yarn install
+          forge soldeer install
 
       - name: Run Slither
         shell: "bash {0}"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ forge soldeer install
 ```
 
 We're using `soldeer` as dependency manager for Solidity contracts, which allows us to manage Solidity versions and dependencies in a consistent manner.
-We have added Soldeer execution as a postinstall script in `package.json`, so it will run automatically after installing Node.js dependencies. Unfortunately it will not run if node dependencies are already installed.
 
 3. Configure environment:
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "./remappings.txt"
   ],
   "scripts": {
-    "postinstall": "forge soldeer install",
     "format": "prettier --config .prettierrc --plugin=prettier-plugin-solidity '{script,src,test,verification}/**/*.sol' -w",
     "format:check": "prettier --config .prettierrc --plugin=prettier-plugin-solidity '{script,src,test,verification}/**/*.sol' -c",
     "lint": "solhint './{src,scripts,test}/**/*.sol'",


### PR DESCRIPTION
The postinstall script is used as part of the package life cyle and called when installing the package.

It is not necessary or appropriate to make setup commands in this context.

An alternative could be to use something like a Makefile which can manage multiple tools for running project commands