### PR TITLE
test(unit): update treasury address variable name

### DIFF
--- a/test/unit/zodiac-core/modules/OctantRewardsSafeModule.t.sol
+++ b/test/unit/zodiac-core/modules/OctantRewardsSafeModule.t.sol
@@ -7,7 +7,7 @@ import { FailSafe } from "test/mocks/MockFailSafe.sol";
 
 contract OctantRewardsSafeModule is BaseTest {
     address keeper = makeAddr("keeper");
-    address treasury = makeAddr("treasury");
+    address treasury = makeAddr("treasuryWallet");
     address dragonRouter = makeAddr("dragonRouter");
     uint256 totalValidators = 2;
     uint256 maxYield = 31 ether;


### PR DESCRIPTION
files changed:
- test/unit/zodiac-core/modules/OctantRewardsSafeModule.t.sol renaming treasury to treasuryWallet since someone on mainnet figured out how to deploy malicious code to  `makeAddr("treasury")`