### PR TITLE
Parallelize pull request ci jobs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -22,8 +22,6 @@ jobs:
 
   build:
     name: Build
-    needs:
-      - lint-and-format
     runs-on: general
     container:
       image: ${{ vars.GCP_DOCKER_IMAGE_REGISTRY }}/node-extended:f4f41461
@@ -44,7 +42,6 @@ jobs:
 
   test:
     name: Test suite
-    needs: build
     runs-on: general
     container:
       image: ${{ vars.GCP_DOCKER_IMAGE_REGISTRY }}/node-extended:f4f41461
@@ -92,8 +89,6 @@ jobs:
 
   coverage:
     name: Code Coverage
-    needs:
-      - build
     runs-on: general
     container:
       image: ${{ vars.GCP_DOCKER_IMAGE_REGISTRY }}/node-extended:f4f41461


### PR DESCRIPTION
I removed the needs dependencies between lint, build, test, and coverage in .github/workflows/pull-request.yml, so all four jobs kick off together instead of queueing in a long chain. Right now every quick bug fix turns into a 15‑minute wait because the test suite sits at the tail end of that chain; letting the jobs fan out in parallel means we start seeing results almost immediately and bring the overall CI turnaround down to roughly half, without touching any secrets or skipping steps.