### PR TITLE
Fix pause bypass on delegate and bump (Cantina 663/338)

### DIFF
--- a/src/regen/RegenStakerBase.sol
+++ b/src/regen/RegenStakerBase.sol
@@ -846,7 +846,7 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         Deposit storage deposit,
         DepositIdentifier _depositId,
         address _newDelegatee
-    ) internal virtual override nonReentrant {
+    ) internal virtual override whenNotPaused nonReentrant {
         super._alterDelegatee(deposit, _depositId, _newDelegatee);
     }
 
@@ -860,7 +860,7 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         Deposit storage deposit,
         DepositIdentifier _depositId,
         address _newClaimer
-    ) internal virtual override nonReentrant {
+    ) internal virtual override whenNotPaused nonReentrant {
         super._alterClaimer(deposit, _depositId, _newClaimer);
     }
 
@@ -952,7 +952,7 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         DepositIdentifier _depositId,
         address _tipReceiver,
         uint256 _requestedTip
-    ) public virtual override nonReentrant {
+    ) public virtual override whenNotPaused nonReentrant {
         if (_requestedTip > maxBumpTip) revert Staker__InvalidTip();
 
         Deposit storage deposit = deposits[_depositId];

--- a/test/proof-of-fixes/cantina-competition-september-2025/Finding338Fix.t.sol
+++ b/test/proof-of-fixes/cantina-competition-september-2025/Finding338Fix.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+import { OctantTestBase } from "test/proof-of-concepts/OctantTestBase.t.sol";
+import { Staker } from "staker/Staker.sol";
+import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
+
+/// @title Cantina Competition September 2025 – Finding 338 Fix
+/// @notice Ensures delegatee and claimer changes respect pause state.
+contract Finding338Fix is Test, OctantTestBase {
+    Staker.DepositIdentifier internal aliceDepositId;
+
+    uint256 internal constant ALICE_STAKE = 1_000 ether;
+
+    function testFix_AlterDelegateeHonorsPause() public {
+        setUp();
+        _seedDeposit();
+
+        vm.prank(admin);
+        regenStaker.pause();
+
+        vm.prank(alice);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        regenStaker.alterDelegatee(aliceDepositId, bob);
+    }
+
+    function testFix_AlterClaimerHonorsPause() public {
+        setUp();
+        _seedDeposit();
+
+        vm.prank(admin);
+        regenStaker.pause();
+
+        vm.prank(alice);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        regenStaker.alterClaimer(aliceDepositId, bob);
+    }
+
+    function _seedDeposit() internal {
+        stakeToken.mint(alice, ALICE_STAKE);
+
+        vm.startPrank(alice);
+        stakeToken.approve(address(regenStaker), ALICE_STAKE);
+        aliceDepositId = regenStaker.stake(ALICE_STAKE, alice, alice);
+        vm.stopPrank();
+    }
+}

--- a/test/proof-of-fixes/cantina-competition-september-2025/Finding663Fix.t.sol
+++ b/test/proof-of-fixes/cantina-competition-september-2025/Finding663Fix.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+import { OctantTestBase } from "test/proof-of-concepts/OctantTestBase.t.sol";
+import { Staker } from "staker/Staker.sol";
+import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
+
+/// @title Cantina Competition September 2025 – Finding 663 Fix
+/// @notice Ensures pausing the staker also halts earning power bumps.
+contract Finding663Fix is Test, OctantTestBase {
+    Staker.DepositIdentifier internal aliceDepositId;
+    Staker.DepositIdentifier internal bobDepositId;
+    Staker.DepositIdentifier internal charlieDepositId;
+
+    uint256 internal constant ALICE_STAKE = 1_000 ether;
+    uint256 internal constant BOB_STAKE = 100 ether;
+    uint256 internal constant CHARLIE_STAKE = 50 ether;
+    uint256 internal constant REWARD_AMOUNT = 100 ether;
+
+    function testFix_BumpEarningPowerHonorsPause() public {
+        setUp();
+
+        _seedBaseScenario();
+
+        vm.prank(admin);
+        regenStaker.pause();
+
+        vm.prank(charlie);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        regenStaker.bumpEarningPower(aliceDepositId, charlie, 0);
+    }
+
+    /// @dev Recreates the base setup, staking, reward notification and attack prep.
+    function _seedBaseScenario() internal {
+        // Fund actors
+        stakeToken.mint(alice, ALICE_STAKE);
+        stakeToken.mint(bob, BOB_STAKE);
+        stakeToken.mint(charlie, CHARLIE_STAKE);
+        rewardToken.mint(rewardNotifier, REWARD_AMOUNT);
+
+        // Whitelist bump keeper for staking/earning power
+        vm.prank(admin);
+        stakerWhitelist.addToWhitelist(charlie);
+        vm.prank(admin);
+        earningPowerWhitelist.addToWhitelist(charlie);
+
+        vm.startPrank(alice);
+        stakeToken.approve(address(regenStaker), ALICE_STAKE);
+        aliceDepositId = regenStaker.stake(ALICE_STAKE, alice, alice);
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+        stakeToken.approve(address(regenStaker), BOB_STAKE);
+        bobDepositId = regenStaker.stake(BOB_STAKE, bob, bob);
+        vm.stopPrank();
+
+        vm.startPrank(charlie);
+        stakeToken.approve(address(regenStaker), CHARLIE_STAKE);
+        charlieDepositId = regenStaker.stake(CHARLIE_STAKE, charlie, charlie);
+        vm.stopPrank();
+
+        vm.prank(rewardNotifier);
+        rewardToken.approve(address(regenStaker), REWARD_AMOUNT);
+        vm.prank(rewardNotifier);
+        rewardToken.transfer(address(regenStaker), REWARD_AMOUNT);
+        vm.prank(rewardNotifier);
+        regenStaker.notifyRewardAmount(REWARD_AMOUNT);
+
+        vm.warp(block.timestamp + REWARD_DURATION / 2);
+
+        vm.prank(alice);
+        regenStaker.claimReward(aliceDepositId);
+
+        vm.prank(admin);
+        earningPowerWhitelist.removeFromWhitelist(alice);
+    }
+}


### PR DESCRIPTION
## Summary
- add `whenNotPaused` guards to `bumpEarningPower`, `alterDelegatee`, and `alterClaimer`
- add Cantina regressions for findings #663 and #338 to ensure pause behaves consistently

## Testing
- forge test --match-path test/proof-of-fixes/cantina-competition-september-2025/Finding663Fix.t.sol
- forge test --match-path test/proof-of-fixes/cantina-competition-september-2025/Finding338Fix.t.sol
