### PR TITLE
Fix YieldDonating donation events (Cantina 262)

### DIFF
--- a/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.25;
+
 import { TokenizedStrategy, Math } from "src/core/TokenizedStrategy.sol";
 import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
 
@@ -20,6 +21,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
  *      - Losses first attempt dragon share burning when enabled; residual losses decrease PPS
  *      - Dragon router change follows TokenizedStrategy cooldown and two-step finalization
  */
+
 contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
     using Math for uint256;
 
@@ -34,6 +36,7 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
      * @dev Mints profit-derived shares to dragon router when newTotalAssets > oldTotalAssets; on loss, attempts
      *      dragon share burning if enabled. Residual loss reduces PPS (no tracked-loss bucket).
      */
+
     function report()
         public
         virtual
@@ -57,7 +60,7 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
 
             // mint the shares to the dragon router
             _mint(S, _dragonRouter, sharesToMint);
-            emit DonationMinted(_dragonRouter, profit);
+            emit DonationMinted(_dragonRouter, sharesToMint);
         } else {
             unchecked {
                 loss = oldTotalAssets - newTotalAssets;
@@ -93,12 +96,9 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
             uint256 sharesBurned = Math.min(sharesToBurn, S.balances[S.dragonRouter]);
 
             if (sharesBurned > 0) {
-                // Convert shares to assets BEFORE burning to get correct value
-                uint256 assetValueBurned = _convertToAssets(S, sharesBurned, Math.Rounding.Floor);
-
                 // Burn shares from dragon router
                 _burn(S, S.dragonRouter, sharesBurned);
-                emit DonationBurned(S.dragonRouter, assetValueBurned);
+                emit DonationBurned(S.dragonRouter, sharesBurned);
             }
         }
     }

--- a/test/proof-of-fixes/cantina-competition-september-2025/Finding262Fix.t.sol
+++ b/test/proof-of-fixes/cantina-competition-september-2025/Finding262Fix.t.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { Setup } from "test/unit/strategies/yieldDonating/utils/Setup.sol";
+
+/// @title Cantina Competition September 2025 – Finding 262 Fix
+/// @notice Ensures donation events report share amounts instead of asset amounts.
+contract Finding262Fix is Setup {
+    function testFix_DonationMintedEmitsShareAmount() public {
+        uint256 initialDeposit = 100 ether;
+        mintAndDepositIntoStrategy(strategy, user, initialDeposit);
+
+        // Realize initial state so the strategy has assets deployed.
+        vm.prank(keeper);
+        strategy.report();
+
+        // Simulate a loss to skew share price below 1.
+        uint256 simulatedLoss = 40 ether;
+        yieldSource.simulateLoss(simulatedLoss);
+        vm.prank(keeper);
+        strategy.report();
+
+        // Add a small profit after the loss.
+        uint256 profitAssets = 10 ether;
+        asset.mint(address(yieldSource), profitAssets);
+
+        uint256 before = strategy.balanceOf(donationAddress);
+        uint256 expectedShares = Math.mulDiv(
+            profitAssets,
+            strategy.totalSupply(),
+            strategy.totalAssets(),
+            Math.Rounding.Floor
+        );
+
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit YieldDonatingTokenizedStrategy.DonationMinted(donationAddress, expectedShares);
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 afterBalance = strategy.balanceOf(donationAddress);
+        assertEq(afterBalance - before, expectedShares, "shares minted mismatch");
+    }
+
+    function testFix_DonationBurnedEmitsShareAmount() public {
+        vm.prank(management);
+        strategy.setEnableBurning(true);
+
+        uint256 initialDeposit = 100 ether;
+        mintAndDepositIntoStrategy(strategy, user, initialDeposit);
+
+        // Realize initial profit so the dragon router holds shares.
+        uint256 initialProfit = 30 ether;
+        asset.mint(address(yieldSource), initialProfit);
+        vm.prank(keeper);
+        strategy.report();
+
+        // Record dragon share balance before loss.
+        uint256 before = strategy.balanceOf(donationAddress);
+
+        // Simulate loss that will trigger dragon share burning.
+        uint256 lossAssets = 20 ether;
+        yieldSource.simulateLoss(lossAssets);
+
+        uint256 totalSupply = strategy.totalSupply();
+        uint256 totalAssets = strategy.totalAssets();
+        uint256 expectedShares = Math.min(
+            Math.mulDiv(lossAssets, totalSupply, totalAssets, Math.Rounding.Ceil),
+            before
+        );
+
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit YieldDonatingTokenizedStrategy.DonationBurned(donationAddress, expectedShares);
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 afterBalance = strategy.balanceOf(donationAddress);
+        assertEq(before - afterBalance, expectedShares, "shares burned mismatch");
+    }
+}


### PR DESCRIPTION
## Summary
- switch YieldDonating donation events to emit share amounts so logs match share accounting
- add regression coverage that exercises profit and loss flows and checks the event payload

## Testing
- forge test --match-path test/proof-of-fixes/cantina-competition-september-2025/Finding262Fix.t.sol
