### PR TITLE
refactor(vault): streamline role enforcement mask check (Cantina 212)

### DIFF
--- a/src/core/MultistrategyVault.sol
+++ b/src/core/MultistrategyVault.sol
@@ -397,7 +397,7 @@ contract MultistrategyVault is IMultistrategyVault {
      */
     function _enforceRole(address account_, Roles role_) internal view {
         uint256 mask = 1 << uint256(role_);
-        if ((roles[account_] & mask) != mask) revert NotAllowed();
+        require((roles[account_] & mask) == mask, NotAllowed());
     }
 
     /**


### PR DESCRIPTION
## Summary
- remove redundant nonzero comparison in _enforceRole
- compute role mask once for clearer logic and keep behavior identical

## Testing
- forge build
