### PR TITLE
fix(guards): initialize ownable state in anti loophole guard (Cantina 603)

### DIFF
--- a/src/zodiac-core/guards/antiLoopHoleGuard.sol
+++ b/src/zodiac-core/guards/antiLoopHoleGuard.sol
@@ -24,7 +24,7 @@ contract AntiLoopholeGuard is FactoryFriendly, BaseGuard {
     function setUp(bytes memory initializeParams) public override initializer {
         address _owner = abi.decode(initializeParams, (address));
         lockEndTime = block.timestamp + LOCK_DURATION;
-        transferOwnership(_owner);
+        __Ownable_init(_owner);
     }
 
     // solhint-disable

--- a/test/unit/zodiac-core/guards/AntiLoopholeGuard.t.sol
+++ b/test/unit/zodiac-core/guards/AntiLoopholeGuard.t.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.23;
+
+import "forge-std/Test.sol";
+import { Clones } from "@openzeppelin/contracts/proxy/Clones.sol";
+import { AntiLoopholeGuard } from "src/zodiac-core/guards/antiLoopHoleGuard.sol";
+
+contract AntiLoopholeGuardTest is Test {
+    function testConstructorInitializesOwnership() external {
+        address owner = address(0xBEEF);
+        uint256 start = block.timestamp;
+
+        AntiLoopholeGuard guard = new AntiLoopholeGuard(owner);
+
+        assertEq(guard.owner(), owner);
+        assertEq(guard.lockEndTime(), start + guard.LOCK_DURATION());
+        assertFalse(guard.isDisabled());
+    }
+
+    function testSetUpInitializesOwnership() external {
+        AntiLoopholeGuard implementation = new AntiLoopholeGuard(address(this));
+        address owner = address(0xCAFE);
+        uint256 start = block.timestamp;
+
+        address clone = Clones.clone(address(implementation));
+        AntiLoopholeGuard(clone).setUp(abi.encode(owner));
+
+        assertEq(AntiLoopholeGuard(clone).owner(), owner);
+        assertEq(AntiLoopholeGuard(clone).lockEndTime(), start + AntiLoopholeGuard(clone).LOCK_DURATION());
+        assertFalse(AntiLoopholeGuard(clone).isDisabled());
+    }
+}


### PR DESCRIPTION
## Summary
- call __Ownable_init during AntiLoopholeGuard setup so ownership transfers succeed
- add unit tests covering constructor and clone initialization flows

## Testing
- forge test --match-path test/unit/zodiac-core/guards/AntiLoopholeGuard.t.sol
