### PR TITLE
fix(regen): allow zero-deposit signup contributions (Cantina 578)

### DIFF
--- a/src/regen/REGEN_USER_GUIDE.md
+++ b/src/regen/REGEN_USER_GUIDE.md
@@ -16,6 +16,8 @@ compoundRewards(depositId) → amount  // reward token = stake token only
 contribute(depositId, mechanism, amount, deadline, v, r, s) → amount
 ```
 
+- `contribute` supports zero `amount` inputs to forward a signature-only registration when the allocation mechanism allows zero-deposit signup. No rewards are moved in that case.
+
 ## Key Parameters
 
 - **Reward Duration**: 7-3000 days (≥30 days recommended for precision)

--- a/src/regen/RegenStakerBase.sol
+++ b/src/regen/RegenStakerBase.sol
@@ -560,7 +560,6 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         bytes32 _s
     ) public virtual whenNotPaused nonReentrant returns (uint256 amountContributedToAllocationMechanism) {
         _checkWhitelisted(sharedState.contributionWhitelist, msg.sender);
-        require(_amount > 0, ZeroOperation());
         _revertIfAddressZero(_allocationMechanismAddress);
         require(
             sharedState.allocationMechanismWhitelist.isWhitelisted(_allocationMechanismAddress),
@@ -585,6 +584,19 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
 
         uint256 unclaimedAmount = deposit.scaledUnclaimedRewardCheckpoint / SCALE_FACTOR;
         require(_amount <= unclaimedAmount, CantAfford(_amount, unclaimedAmount));
+
+        if (_amount == 0) {
+            emit RewardContributed(_depositId, msg.sender, _allocationMechanismAddress, 0);
+            TokenizedAllocationMechanism(_allocationMechanismAddress).signupOnBehalfWithSignature(
+                msg.sender,
+                0,
+                _deadline,
+                _v,
+                _r,
+                _s
+            );
+            return 0;
+        }
 
         uint256 fee = claimFeeParameters.feeAmount;
 


### PR DESCRIPTION
## Summary
- allow RegenStaker `contribute` to forward zero-deposit registrations without moving rewards
- document zero-amount support in the user guide and add integration coverage for the zero path

## Testing
- forge test --match-path test/integration/regen/RegenIntegration.t.sol --match-test test_Contribute_WithZeroAmount_AllowsSignup
- forge test --match-path test/integration/regen/RegenIntegration.t.sol --match-test test_Contribute_WithSignature_Success