### PR TITLE
fix: add og fallback staker recovery (Cantina 283 Option 4)

### DIFF
--- a/src/regen/REGEN_USER_GUIDE.md
+++ b/src/regen/REGEN_USER_GUIDE.md
@@ -14,9 +14,11 @@ withdraw(depositId, amount)
 claimReward(depositId) → amount
 compoundRewards(depositId) → amount  // reward token = stake token only
 contribute(depositId, mechanism, amount, deadline, v, r, s) → amount
+recoverOgRewards() → amount
 ```
 
 - `contribute` supports zero `amount` inputs to forward a signature-only registration when the allocation mechanism allows zero-deposit signup. No rewards are moved in that case.
+- `recoverOgRewards` permissionlessly sweeps idle emissions accrued by the OG fallback staker to the configured fee collector. The sweep reverts if no fee collector is set.
 
 ## Key Parameters
 

--- a/test/proof-of-fixes/cantina-competition-september-2025/Finding283Option4.t.sol
+++ b/test/proof-of-fixes/cantina-competition-september-2025/Finding283Option4.t.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { OctantTestBase } from "test/proof-of-concepts/OctantTestBase.t.sol";
+import { Staker } from "staker/Staker.sol";
+
+/// @title Cantina Competition September 2025 – Option 4 Fix
+/// @notice Validates OG fallback staker accrual and permissionless recovery.
+contract Finding283Option4 is OctantTestBase {
+    uint256 internal constant REWARD_AMOUNT = 5_000 ether;
+
+    function testFix_OgFallbackRecoverySendsToFeeCollector() public {
+        setUp();
+
+        address feeCollector = makeAddr("feeCollector");
+        vm.prank(admin);
+        regenStaker.setClaimFeeParameters(Staker.ClaimFeeParameters({ feeAmount: 0, feeCollector: feeCollector }));
+
+        rewardToken.mint(address(regenStaker), REWARD_AMOUNT);
+        vm.prank(rewardNotifier);
+        regenStaker.notifyRewardAmount(REWARD_AMOUNT);
+
+        vm.warp(block.timestamp + regenStaker.rewardDuration());
+
+        address caller = makeAddr("sweeper");
+        vm.prank(caller);
+        uint256 recovered = regenStaker.recoverOgRewards();
+
+        assertApproxEqAbs(recovered, REWARD_AMOUNT, 1, "recovered amount mismatch");
+        assertApproxEqAbs(
+            rewardToken.balanceOf(feeCollector),
+            REWARD_AMOUNT,
+            1,
+            "fee collector should receive recovery"
+        );
+    }
+}


### PR DESCRIPTION
4. **Seed OG fallback staker to absorb idle rewards**
   - *Idea*: keep a sentinel deposit with earning power `1` owned by the contract so reward streaming never idles; once a real staker shows up we disable the sentinel weight, and re-enable it again when the last deposit exits.
   - *Implementation excerpt*:
     ```solidity
     ogDepositId = DepositIdentifier.wrap(type(uint256).max);
     ...
     function _maybeDeactivateOgFallback() internal {
         if (ogDeposit.earningPower != 0 && totalEarningPower > OG_EARNING_POWER) {
             ogDeposit.rewardPerTokenCheckpoint = rewardPerTokenAccumulatedCheckpoint;
             ogDeposit.earningPower = 0;
             totalEarningPower -= OG_EARNING_POWER;
             depositorTotalEarningPower[ogStaker] -= OG_EARNING_POWER;
         }
     }

     function recoverOgRewards() external nonReentrant returns (uint256 recoveredAmount) {
         ClaimFeeParameters memory params = claimFeeParameters;
         require(params.feeCollector != address(0), "og: fee collector not set");
         ...
         SafeERC20.safeTransfer(REWARD_TOKEN, params.feeCollector, recoveredAmount);
         emit OgRewardsRecovered(msg.sender, recoveredAmount);
     }
     ```
   - *Trade-offs*: deterministic sentinel ID avoids shifting user deposit numbering, but bookkeeping now assumes the fee collector is configured to reclaim idle emissions.

## Testing
- forge test --match-path test/integration/regen/RegenIntegration.t.sol --match-test test_OgFallbackAccruesAndRecovers
- forge test --match-path test/unit/regen/CompoundEquivalence.t.sol --match-test test_CompoundEqualsClaimPlusStakeMore
- forge test --match-path test/regen/RegenStakerWithoutDelegateSurrogateVotes.SameTokenProtection.t.sol
- forge test --match-path test/proof-of-fixes/cantina-competition-september-2025/Finding283Option4.t.sol
