### PR TITLE
Feature/osu 1404 pass symbol and name to initialization to strategies

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -22,6 +22,7 @@ seed = "0xDEADC0DE"
 fuzz = { runs = 256, max_test_rejects = 65536 }
 deny_warnings = true
 lint = { severity = ["high"], exclude_lints = ["erc20-unchecked-transfer", "unsafe-typecast", "incorrect-shift"] }
+ignored_warnings_from = ["dependencies"]
 
 
 [profile.local]

--- a/partners/shutter_dao_0x36/test/ShutterDAOIntegration.t.sol
+++ b/partners/shutter_dao_0x36/test/ShutterDAOIntegration.t.sol
@@ -137,12 +137,14 @@ contract ShutterDAOIntegrationTest is Test {
     function _predictStrategyAddress(address _paymentSplitter, address _keeper) internal view returns (address) {
         address ysUsdc = MorphoCompounderStrategyFactory(MORPHO_STRATEGY_FACTORY).YS_USDC();
         address usdc = MorphoCompounderStrategyFactory(MORPHO_STRATEGY_FACTORY).USDC();
+        string memory strategySymbol = "osSHU";
 
         bytes32 parameterHash = keccak256(
             abi.encode(
                 ysUsdc,
                 usdc,
                 STRATEGY_NAME,
+                strategySymbol,
                 SHUTTER_TREASURY,
                 _keeper,
                 SHUTTER_TREASURY,
@@ -158,6 +160,7 @@ contract ShutterDAOIntegrationTest is Test {
                 ysUsdc,
                 usdc,
                 STRATEGY_NAME,
+                strategySymbol,
                 SHUTTER_TREASURY,
                 _keeper,
                 SHUTTER_TREASURY,
@@ -211,6 +214,7 @@ contract ShutterDAOIntegrationTest is Test {
                     MorphoCompounderStrategyFactory.createStrategy,
                     (
                         STRATEGY_NAME,
+                        "osSHU",
                         SHUTTER_TREASURY,
                         keeperBot,
                         SHUTTER_TREASURY,
@@ -426,12 +430,14 @@ contract ShutterDAOGasProfilingTest is Test {
     ) internal view returns (bytes32 parameterHash, bytes memory strategyBytecode) {
         address ysUsdc = MorphoCompounderStrategyFactory(MORPHO_STRATEGY_FACTORY).YS_USDC();
         address usdc = MorphoCompounderStrategyFactory(MORPHO_STRATEGY_FACTORY).USDC();
+        string memory strategySymbol = "osSHU";
 
         parameterHash = keccak256(
             abi.encode(
                 ysUsdc,
                 usdc,
                 STRATEGY_NAME,
+                strategySymbol,
                 SHUTTER_TREASURY,
                 keeper,
                 SHUTTER_TREASURY,
@@ -447,6 +453,7 @@ contract ShutterDAOGasProfilingTest is Test {
                 ysUsdc,
                 usdc,
                 STRATEGY_NAME,
+                strategySymbol,
                 SHUTTER_TREASURY,
                 keeper,
                 SHUTTER_TREASURY,
@@ -507,6 +514,7 @@ contract ShutterDAOGasProfilingTest is Test {
                     MorphoCompounderStrategyFactory.createStrategy,
                     (
                         STRATEGY_NAME,
+                        "osSHU",
                         SHUTTER_TREASURY,
                         keeperBot,
                         SHUTTER_TREASURY,

--- a/src/core/BaseStrategy.sol
+++ b/src/core/BaseStrategy.sol
@@ -140,6 +140,7 @@ abstract contract BaseStrategy {
      *
      * @param _asset Address of the underlying asset.
      * @param _name Name the strategy will use.
+     * @param _symbol Symbol the strategy will use.
      * @param _management Address with management permissions
      * @param _keeper Address with keeper permissions
      * @param _emergencyAdmin Address with emergency admin permissions
@@ -150,6 +151,7 @@ abstract contract BaseStrategy {
     constructor(
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -167,7 +169,7 @@ abstract contract BaseStrategy {
         _delegateCall(
             abi.encodeCall(
                 ITokenizedStrategy.initialize,
-                (_asset, _name, _management, _keeper, _emergencyAdmin, _donationAddress, _enableBurning)
+                (_asset, _name, _symbol, _management, _keeper, _emergencyAdmin, _donationAddress, _enableBurning)
             )
         );
 

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -225,6 +225,10 @@ abstract contract TokenizedStrategy {
         /// @notice Human-readable name of the strategy share token
         /// @dev ERC20 metadata. Set during initialize() and never changes
         string name;
+
+        /// @notice Symbol of the strategy share token
+        /// @dev ERC20 metadata. Set during initialize() and never changes
+        string symbol;
         
         /// @notice Total supply of strategy shares currently minted
         /// @dev In share base units. Increases on deposits, decreases on withdrawals
@@ -551,6 +555,7 @@ abstract contract TokenizedStrategy {
      *
      * @param _asset Address of the underlying ERC20 asset (cannot be zero)
      * @param _name Human-readable name for strategy shares (e.g., \"Octant Lido ETH Strategy\")
+     * @param _symbol Symbol for strategy shares (e.g., \"osWSTETH\")
      * @param _management Address for primary admin (cannot be zero)
      * @param _keeper Address authorized to call report/tend (cannot be zero)
      * @param _emergencyAdmin Address authorized for emergency actions (cannot be zero)
@@ -562,6 +567,7 @@ abstract contract TokenizedStrategy {
     function initialize(
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -578,6 +584,8 @@ abstract contract TokenizedStrategy {
         S.asset = ERC20(_asset);
         // Set the Strategy Tokens name.
         S.name = _name;
+        // Set the Strategy Tokens symbol.
+        S.symbol = _symbol;
         // Set decimals based off the `asset`.
         S.decimals = ERC20(_asset).decimals();
 
@@ -1458,11 +1466,10 @@ abstract contract TokenizedStrategy {
 
     /**
      * @notice Returns the symbol of the strategy token.
-     * @dev Will be 'os' + asset symbol.
      * @return symbol_ Token symbol
      */
     function symbol() external view returns (string memory) {
-        return string(abi.encodePacked("os", _strategyStorage().asset.symbol()));
+        return _strategyStorage().symbol;
     }
 
     /**

--- a/src/core/interfaces/ITokenizedStrategy.sol
+++ b/src/core/interfaces/ITokenizedStrategy.sol
@@ -72,6 +72,7 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
      * @notice Used to initialize storage for a newly deployed strategy
      * @param _asset Underlying asset address
      * @param _name Strategy name
+     * @param _symbol Strategy symbol
      * @param _management Management address
      * @param _keeper Keeper address
      * @param _emergencyAdmin Emergency admin address
@@ -81,6 +82,7 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
     function initialize(
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,

--- a/src/factories/LidoStrategyFactory.sol
+++ b/src/factories/LidoStrategyFactory.sol
@@ -44,6 +44,7 @@ contract LidoStrategyFactory is BaseStrategyFactory {
      *      5. Record deployment for tracking
      *
      * @param _name Strategy share token name
+     * @param _symbol Strategy share token symbol
      * @param _management Management address (can update params)
      * @param _keeper Keeper address (calls report)
      * @param _emergencyAdmin Emergency admin address
@@ -54,6 +55,7 @@ contract LidoStrategyFactory is BaseStrategyFactory {
      */
     function createStrategy(
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -66,6 +68,7 @@ contract LidoStrategyFactory is BaseStrategyFactory {
             abi.encode(
                 WSTETH,
                 _name,
+                _symbol,
                 _management,
                 _keeper,
                 _emergencyAdmin,
@@ -80,6 +83,7 @@ contract LidoStrategyFactory is BaseStrategyFactory {
             abi.encode(
                 WSTETH,
                 _name,
+                _symbol,
                 _management,
                 _keeper,
                 _emergencyAdmin,

--- a/src/factories/MorphoCompounderStrategyFactory.sol
+++ b/src/factories/MorphoCompounderStrategyFactory.sol
@@ -40,6 +40,7 @@ contract MorphoCompounderStrategyFactory is BaseStrategyFactory {
      * @notice Deploy a new MorphoCompounder strategy
      * @dev Deterministic salt derived from all parameters to avoid duplicates
      * @param _name Strategy share token name
+     * @param _symbol Strategy share token symbol
      * @param _management Management address (can update params)
      * @param _keeper Keeper address (calls report)
      * @param _emergencyAdmin Emergency admin address
@@ -50,6 +51,7 @@ contract MorphoCompounderStrategyFactory is BaseStrategyFactory {
      */
     function createStrategy(
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -62,6 +64,7 @@ contract MorphoCompounderStrategyFactory is BaseStrategyFactory {
                 YS_USDC,
                 USDC,
                 _name,
+                _symbol,
                 _management,
                 _keeper,
                 _emergencyAdmin,
@@ -77,6 +80,7 @@ contract MorphoCompounderStrategyFactory is BaseStrategyFactory {
                 YS_USDC,
                 USDC,
                 _name,
+                _symbol,
                 _management,
                 _keeper,
                 _emergencyAdmin,

--- a/src/factories/SkyCompounderStrategyFactory.sol
+++ b/src/factories/SkyCompounderStrategyFactory.sol
@@ -31,6 +31,7 @@ contract SkyCompounderStrategyFactory is BaseStrategyFactory {
      * @notice Deploys a new SkyCompounder strategy for the Yield Donating Vault
      * @dev Uses deterministic deployment based on strategy parameters to prevent duplicates
      * @param _name Strategy share token name
+     * @param _symbol Strategy share token symbol
      * @param _management Management address (can update params)
      * @param _keeper Keeper address (calls report)
      * @param _emergencyAdmin Emergency admin address
@@ -41,6 +42,7 @@ contract SkyCompounderStrategyFactory is BaseStrategyFactory {
      */
     function createStrategy(
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -53,6 +55,7 @@ contract SkyCompounderStrategyFactory is BaseStrategyFactory {
             abi.encode(
                 USDS_REWARD_ADDRESS,
                 _name,
+                _symbol,
                 _management,
                 _keeper,
                 _emergencyAdmin,
@@ -67,6 +70,7 @@ contract SkyCompounderStrategyFactory is BaseStrategyFactory {
             abi.encode(
                 USDS_REWARD_ADDRESS,
                 _name,
+                _symbol,
                 _management,
                 _keeper,
                 _emergencyAdmin,

--- a/src/factories/yieldDonating/YearnV3StrategyFactory.sol
+++ b/src/factories/yieldDonating/YearnV3StrategyFactory.sol
@@ -42,6 +42,7 @@ contract YearnV3StrategyFactory is BaseStrategyFactory {
      * @param _yearnVault Yearn v3 vault address to compound into
      * @param _asset Underlying asset address
      * @param _name Strategy share token name
+     * @param _symbol Strategy share token symbol
      * @param _management Management address (can update params)
      * @param _keeper Keeper address (calls report)
      * @param _emergencyAdmin Emergency admin address
@@ -54,6 +55,7 @@ contract YearnV3StrategyFactory is BaseStrategyFactory {
         address _yearnVault,
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -67,6 +69,7 @@ contract YearnV3StrategyFactory is BaseStrategyFactory {
                 _yearnVault,
                 _asset,
                 _name,
+                _symbol,
                 _management,
                 _keeper,
                 _emergencyAdmin,
@@ -83,6 +86,7 @@ contract YearnV3StrategyFactory is BaseStrategyFactory {
                 _yearnVault,
                 _asset,
                 _name,
+                _symbol,
                 _management,
                 _keeper,
                 _emergencyAdmin,

--- a/src/factories/yieldSkimming/RocketPoolStrategyFactory.sol
+++ b/src/factories/yieldSkimming/RocketPoolStrategyFactory.sol
@@ -31,6 +31,7 @@ contract RocketPoolStrategyFactory is BaseStrategyFactory {
      * @notice Deploys a new RocketPool strategy for the Yield Skimming Vault
      * @dev Uses deterministic deployment based on strategy parameters to prevent duplicates
      * @param _name Strategy share token name
+     * @param _symbol Strategy share token symbol
      * @param _management Management address (can update params)
      * @param _keeper Keeper address (calls report)
      * @param _emergencyAdmin Emergency admin address
@@ -41,6 +42,7 @@ contract RocketPoolStrategyFactory is BaseStrategyFactory {
      */
     function createStrategy(
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -53,6 +55,7 @@ contract RocketPoolStrategyFactory is BaseStrategyFactory {
             abi.encode(
                 R_ETH,
                 _name,
+                _symbol,
                 _management,
                 _keeper,
                 _emergencyAdmin,
@@ -67,6 +70,7 @@ contract RocketPoolStrategyFactory is BaseStrategyFactory {
             abi.encode(
                 R_ETH,
                 _name,
+                _symbol,
                 _management,
                 _keeper,
                 _emergencyAdmin,

--- a/src/strategies/periphery/BaseHealthCheck.sol
+++ b/src/strategies/periphery/BaseHealthCheck.sol
@@ -50,6 +50,7 @@ abstract contract BaseHealthCheck is BaseStrategy, IBaseHealthCheck {
     constructor(
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -60,6 +61,7 @@ abstract contract BaseHealthCheck is BaseStrategy, IBaseHealthCheck {
         BaseStrategy(
             _asset,
             _name,
+            _symbol,
             _management,
             _keeper,
             _emergencyAdmin,

--- a/src/strategies/periphery/BaseYieldSkimmingHealthCheck.sol
+++ b/src/strategies/periphery/BaseYieldSkimmingHealthCheck.sol
@@ -42,6 +42,7 @@ abstract contract BaseYieldSkimmingHealthCheck is BaseStrategy, IBaseHealthCheck
     constructor(
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -52,6 +53,7 @@ abstract contract BaseYieldSkimmingHealthCheck is BaseStrategy, IBaseHealthCheck
         BaseStrategy(
             _asset,
             _name,
+            _symbol,
             _management,
             _keeper,
             _emergencyAdmin,

--- a/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
+++ b/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
@@ -44,6 +44,7 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
      * @param _compounderVault Address of the Morpho compounder vault to deposit into
      * @param _asset Address of the underlying asset (must match compounder vault's asset)
      * @param _name Strategy display name (e.g., "Octant Morpho USDC Strategy")
+     * @param _symbol Strategy symbol (e.g., "osMorphoUSDC")
      * @param _management Address with management permissions
      * @param _keeper Address authorized to call report() and tend()
      * @param _emergencyAdmin Address authorized for emergency shutdown
@@ -55,6 +56,7 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
         address _compounderVault,
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -65,6 +67,7 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
         BaseHealthCheck(
             _asset,
             _name,
+            _symbol,
             _management,
             _keeper,
             _emergencyAdmin,

--- a/src/strategies/yieldDonating/SkyCompounderStrategy.sol
+++ b/src/strategies/yieldDonating/SkyCompounderStrategy.sol
@@ -53,6 +53,7 @@ contract SkyCompounderStrategy is BaseHealthCheck, UniswapV3Swapper, ISkyCompoun
      * @notice Constructs the Sky Compounder Strategy
      * @param _staking Sky Protocol staking contract address
      * @param _name Strategy share token name
+     * @param _symbol Strategy share token symbol
      * @param _management Management address (can update params)
      * @param _keeper Keeper address (calls report)
      * @param _emergencyAdmin Emergency admin address
@@ -64,6 +65,7 @@ contract SkyCompounderStrategy is BaseHealthCheck, UniswapV3Swapper, ISkyCompoun
     constructor(
         address _staking,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -74,6 +76,7 @@ contract SkyCompounderStrategy is BaseHealthCheck, UniswapV3Swapper, ISkyCompoun
         BaseHealthCheck(
             USDS,
             _name,
+            _symbol,
             _management,
             _keeper,
             _emergencyAdmin,

--- a/src/strategies/yieldDonating/YearnV3Strategy.sol
+++ b/src/strategies/yieldDonating/YearnV3Strategy.sol
@@ -43,6 +43,7 @@ contract YearnV3Strategy is BaseHealthCheck {
      * @param _yearnVault Address of the Yearn v3 vault this strategy deposits into
      * @param _asset Address of the underlying asset (must match Yearn vault's asset)
      * @param _name Strategy display name (e.g., "Octant Yearn USDC Strategy")
+     * @param _symbol Strategy symbol (e.g., "osYearnUSDC")
      * @param _management Address with management permissions
      * @param _keeper Address authorized to call report() and tend()
      * @param _emergencyAdmin Address authorized for emergency shutdown
@@ -54,6 +55,7 @@ contract YearnV3Strategy is BaseHealthCheck {
         address _yearnVault,
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -64,6 +66,7 @@ contract YearnV3Strategy is BaseHealthCheck {
         BaseHealthCheck(
             _asset,
             _name,
+            _symbol,
             _management,
             _keeper,
             _emergencyAdmin,

--- a/src/strategies/yieldSkimming/BaseYieldSkimmingStrategy.sol
+++ b/src/strategies/yieldSkimming/BaseYieldSkimmingStrategy.sol
@@ -43,6 +43,7 @@ abstract contract BaseYieldSkimmingStrategy is BaseYieldSkimmingHealthCheck {
     constructor(
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -53,6 +54,7 @@ abstract contract BaseYieldSkimmingStrategy is BaseYieldSkimmingHealthCheck {
         BaseYieldSkimmingHealthCheck(
             _asset,
             _name,
+            _symbol,
             _management,
             _keeper,
             _emergencyAdmin,

--- a/src/strategies/yieldSkimming/LidoStrategy.sol
+++ b/src/strategies/yieldSkimming/LidoStrategy.sol
@@ -40,6 +40,7 @@ contract LidoStrategy is BaseYieldSkimmingStrategy {
     /**
      * @param _asset Address of the underlying asset (wstETH)
      * @param _name Strategy name
+     * @param _symbol Strategy symbol
      * @param _management Address with management role
      * @param _keeper Address with keeper role
      * @param _emergencyAdmin Address with emergency admin role
@@ -50,6 +51,7 @@ contract LidoStrategy is BaseYieldSkimmingStrategy {
     constructor(
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -60,6 +62,7 @@ contract LidoStrategy is BaseYieldSkimmingStrategy {
         BaseYieldSkimmingStrategy(
             _asset, // shares address
             _name,
+            _symbol,
             _management,
             _keeper,
             _emergencyAdmin,

--- a/src/strategies/yieldSkimming/RocketPoolStrategy.sol
+++ b/src/strategies/yieldSkimming/RocketPoolStrategy.sol
@@ -40,6 +40,7 @@ contract RocketPoolStrategy is BaseYieldSkimmingStrategy {
     /**
      * @param _asset Address of the underlying asset
      * @param _name Strategy name
+     * @param _symbol Strategy symbol
      * @param _management Address with management role
      * @param _keeper Address with keeper role
      * @param _emergencyAdmin Address with emergency admin role
@@ -50,6 +51,7 @@ contract RocketPoolStrategy is BaseYieldSkimmingStrategy {
     constructor(
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
@@ -60,6 +62,7 @@ contract RocketPoolStrategy is BaseYieldSkimmingStrategy {
         BaseYieldSkimmingStrategy(
             _asset, // shares address
             _name,
+            _symbol,
             _management,
             _keeper,
             _emergencyAdmin,

--- a/test/integration/factories/LidoStrategyFactory.t.sol
+++ b/test/integration/factories/LidoStrategyFactory.t.sol
@@ -81,6 +81,7 @@ contract LidoStrategyFactoryTest is Test {
 
         address strategyAddress = factory.createStrategy(
             vaultSharesName,
+            "osLIDO",
             management,
             keeper,
             emergencyAdmin,
@@ -112,6 +113,7 @@ contract LidoStrategyFactoryTest is Test {
         vm.startPrank(management);
         address firstStrategyAddress = factory.createStrategy(
             firstVaultName,
+            "osLIDO1",
             management,
             keeper,
             emergencyAdmin,
@@ -125,6 +127,7 @@ contract LidoStrategyFactoryTest is Test {
 
         address secondStrategyAddress = factory.createStrategy(
             secondVaultName,
+            "osLIDO2",
             management,
             keeper,
             emergencyAdmin,
@@ -158,6 +161,7 @@ contract LidoStrategyFactoryTest is Test {
         vm.startPrank(firstUser);
         address firstStrategyAddress = factory.createStrategy(
             firstVaultName,
+            "osLIDO1",
             firstUser,
             keeper,
             emergencyAdmin,
@@ -173,6 +177,7 @@ contract LidoStrategyFactoryTest is Test {
         vm.startPrank(secondUser);
         address secondStrategyAddress = factory.createStrategy(
             secondVaultName,
+            "osLIDO2",
             secondUser,
             keeper,
             emergencyAdmin,
@@ -203,6 +208,7 @@ contract LidoStrategyFactoryTest is Test {
         vm.startPrank(management);
         address firstAddress = factory.createStrategy(
             vaultSharesName,
+            "osDET",
             management,
             keeper,
             emergencyAdmin,
@@ -217,6 +223,7 @@ contract LidoStrategyFactoryTest is Test {
         vm.expectRevert(abi.encodeWithSelector(BaseStrategyFactory.StrategyAlreadyExists.selector, firstAddress));
         factory.createStrategy(
             vaultSharesName,
+            "osDET",
             management,
             keeper,
             emergencyAdmin,
@@ -231,6 +238,7 @@ contract LidoStrategyFactoryTest is Test {
         vm.startPrank(management);
         address secondAddress = factory.createStrategy(
             differentName,
+            "osDIF",
             management,
             keeper,
             emergencyAdmin,

--- a/test/integration/factories/LidoStrategyFactory.t.sol
+++ b/test/integration/factories/LidoStrategyFactory.t.sol
@@ -11,6 +11,7 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { CREATE3 } from "solady/utils/CREATE3.sol";
 
 /// @title LidoStrategyFactory Test
@@ -103,6 +104,11 @@ contract LidoStrategyFactoryTest is Test {
         // Verify strategy was initialized correctly
         LidoStrategy strategy = LidoStrategy(strategyAddress);
         assertEq(IERC4626(address(strategy)).asset(), WSTETH, "Yield vault address incorrect");
+        assertEq(
+            ITokenizedStrategy(address(strategy)).symbol(),
+            "osLIDO",
+            "Symbol should match the value passed during creation"
+        );
     }
 
     /// @notice Test creating multiple strategies for the same user

--- a/test/integration/factories/MorphoCompounderStrategyFactory.t.sol
+++ b/test/integration/factories/MorphoCompounderStrategyFactory.t.sol
@@ -81,6 +81,7 @@ contract MorphoCompounderStrategyFactoryTest is Test {
 
         address strategyAddress = factory.createStrategy(
             vaultSharesName,
+            "osMORPHO",
             management,
             keeper,
             emergencyAdmin,
@@ -116,6 +117,7 @@ contract MorphoCompounderStrategyFactoryTest is Test {
         vm.startPrank(management);
         address firstStrategyAddress = factory.createStrategy(
             firstVaultName,
+            "osMORPHO1",
             management,
             keeper,
             emergencyAdmin,
@@ -129,6 +131,7 @@ contract MorphoCompounderStrategyFactoryTest is Test {
 
         address secondStrategyAddress = factory.createStrategy(
             secondVaultName,
+            "osMORPHO2",
             management,
             keeper,
             emergencyAdmin,
@@ -162,6 +165,7 @@ contract MorphoCompounderStrategyFactoryTest is Test {
         vm.startPrank(firstUser);
         address firstStrategyAddress = factory.createStrategy(
             firstVaultName,
+            "osMORPHO1",
             firstUser,
             keeper,
             emergencyAdmin,
@@ -177,6 +181,7 @@ contract MorphoCompounderStrategyFactoryTest is Test {
         vm.startPrank(secondUser);
         address secondStrategyAddress = factory.createStrategy(
             secondVaultName,
+            "osMORPHO2",
             secondUser,
             keeper,
             emergencyAdmin,
@@ -207,6 +212,7 @@ contract MorphoCompounderStrategyFactoryTest is Test {
         vm.startPrank(management);
         address firstAddress = factory.createStrategy(
             vaultSharesName,
+            "osDET",
             management,
             keeper,
             emergencyAdmin,
@@ -221,6 +227,7 @@ contract MorphoCompounderStrategyFactoryTest is Test {
         vm.expectRevert(abi.encodeWithSelector(BaseStrategyFactory.StrategyAlreadyExists.selector, firstAddress));
         factory.createStrategy(
             vaultSharesName,
+            "osDET",
             management,
             keeper,
             emergencyAdmin,
@@ -235,6 +242,7 @@ contract MorphoCompounderStrategyFactoryTest is Test {
         vm.startPrank(management);
         address secondAddress = factory.createStrategy(
             differentName,
+            "osDIF",
             management,
             keeper,
             emergencyAdmin,

--- a/test/integration/factories/MorphoCompounderStrategyFactory.t.sol
+++ b/test/integration/factories/MorphoCompounderStrategyFactory.t.sol
@@ -11,6 +11,7 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { CREATE3 } from "solady/utils/CREATE3.sol";
 
 /// @title MorphoCompounderStrategyFactory Test
@@ -106,6 +107,11 @@ contract MorphoCompounderStrategyFactoryTest is Test {
             IERC4626(address(strategy)).asset(),
             0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48,
             "USDC asset address incorrect"
+        );
+        assertEq(
+            ITokenizedStrategy(address(strategy)).symbol(),
+            "osMORPHO",
+            "Symbol should match the value passed during creation"
         );
     }
 

--- a/test/integration/factories/RocketPoolStrategyFactory.t.sol
+++ b/test/integration/factories/RocketPoolStrategyFactory.t.sol
@@ -84,6 +84,7 @@ contract RocketPoolStrategyFactoryTest is Test {
 
         address strategyAddress = factory.createStrategy(
             vaultSharesName,
+            "osRPL",
             management,
             keeper,
             emergencyAdmin,
@@ -116,6 +117,7 @@ contract RocketPoolStrategyFactoryTest is Test {
         vm.startPrank(management);
         address firstStrategyAddress = factory.createStrategy(
             firstVaultName,
+            "osRPL1",
             management,
             keeper,
             emergencyAdmin,
@@ -127,6 +129,7 @@ contract RocketPoolStrategyFactoryTest is Test {
         // Create second strategy for same user
         address secondStrategyAddress = factory.createStrategy(
             secondVaultName,
+            "osRPL2",
             management,
             keeper,
             emergencyAdmin,
@@ -165,6 +168,7 @@ contract RocketPoolStrategyFactoryTest is Test {
             vm.startPrank(users[i]);
             strategyAddresses[i] = factory.createStrategy(
                 vaultNames[i],
+                string(abi.encodePacked("osRPL", i)),
                 users[i],
                 keeper,
                 emergencyAdmin,
@@ -194,6 +198,7 @@ contract RocketPoolStrategyFactoryTest is Test {
         vm.startPrank(management);
         address firstAddress = factory.createStrategy(
             vaultSharesName,
+            "osTEST",
             management,
             keeper,
             emergencyAdmin,
@@ -206,6 +211,7 @@ contract RocketPoolStrategyFactoryTest is Test {
         vm.expectRevert(abi.encodeWithSelector(BaseStrategyFactory.StrategyAlreadyExists.selector, firstAddress));
         factory.createStrategy(
             vaultSharesName,
+            "osTEST",
             management,
             keeper,
             emergencyAdmin,
@@ -218,6 +224,7 @@ contract RocketPoolStrategyFactoryTest is Test {
         string memory differentName = "Different Vault";
         address secondAddress = factory.createStrategy(
             differentName,
+            "osDIF",
             management,
             keeper,
             emergencyAdmin,
@@ -255,6 +262,7 @@ contract RocketPoolStrategyFactoryTest is Test {
         vm.startPrank(fuzzManagement);
         factory.createStrategy(
             vaultName,
+            "osFUZZ",
             fuzzManagement,
             fuzzKeeper,
             fuzzEmergencyAdmin,
@@ -284,10 +292,12 @@ contract RocketPoolStrategyFactoryTest is Test {
         // Create multiple strategies
         for (uint256 i = 0; i < numStrategies; i++) {
             string memory vaultName = string(abi.encodePacked("Vault_", i));
+            string memory vaultSymbol = string(abi.encodePacked("osV", i));
 
             vm.startPrank(testUser);
             factory.createStrategy(
                 vaultName,
+                vaultSymbol,
                 testUser,
                 keeper,
                 emergencyAdmin,

--- a/test/integration/factories/RocketPoolStrategyFactory.t.sol
+++ b/test/integration/factories/RocketPoolStrategyFactory.t.sol
@@ -11,6 +11,7 @@ import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /// @title RocketPoolFactory Test
@@ -106,6 +107,11 @@ contract RocketPoolStrategyFactoryTest is Test {
         // Verify strategy was initialized correctly
         RocketPoolStrategy strategy = RocketPoolStrategy(strategyAddress);
         assertEq(IERC4626(address(strategy)).asset(), R_ETH, "Yield vault address incorrect");
+        assertEq(
+            ITokenizedStrategy(address(strategy)).symbol(),
+            "osRPL",
+            "Symbol should match the value passed during creation"
+        );
     }
 
     /// @notice Fuzz test for creating multiple strategies for the same user

--- a/test/integration/factories/SkyCompounderStrategyFactory.t.sol
+++ b/test/integration/factories/SkyCompounderStrategyFactory.t.sol
@@ -78,11 +78,14 @@ contract SkyCompounderStrategyFactoryTest is Test {
     function testCreateStrategy() public {
         string memory vaultSharesName = "SkyCompounder Vault Shares";
 
+        string memory vaultSymbol = "osSKY";
+
         // Calculate expected address based on parameters
         bytes32 parameterHash = keccak256(
             abi.encode(
                 0x0650CAF159C5A49f711e8169D4336ECB9b950275, // USDS_REWARD_ADDRESS
                 vaultSharesName,
+                vaultSymbol,
                 management,
                 keeper,
                 emergencyAdmin,
@@ -98,6 +101,7 @@ contract SkyCompounderStrategyFactoryTest is Test {
             abi.encode(
                 0x0650CAF159C5A49f711e8169D4336ECB9b950275, // USDS_REWARD_ADDRESS
                 vaultSharesName,
+                vaultSymbol,
                 management,
                 keeper,
                 emergencyAdmin,
@@ -119,6 +123,7 @@ contract SkyCompounderStrategyFactoryTest is Test {
 
         address strategyAddress = factory.createStrategy(
             vaultSharesName,
+            vaultSymbol,
             management,
             keeper,
             emergencyAdmin,
@@ -151,6 +156,7 @@ contract SkyCompounderStrategyFactoryTest is Test {
         vm.startPrank(management);
         address firstStrategyAddress = factory.createStrategy(
             firstVaultName,
+            "osSKY1",
             management,
             keeper,
             emergencyAdmin,
@@ -164,6 +170,7 @@ contract SkyCompounderStrategyFactoryTest is Test {
 
         address secondStrategyAddress = factory.createStrategy(
             secondVaultName,
+            "osSKY2",
             management,
             keeper,
             emergencyAdmin,
@@ -197,6 +204,7 @@ contract SkyCompounderStrategyFactoryTest is Test {
         vm.startPrank(firstUser);
         address firstStrategyAddress = factory.createStrategy(
             firstVaultName,
+            "osSKY1",
             firstUser,
             keeper,
             emergencyAdmin,
@@ -212,6 +220,7 @@ contract SkyCompounderStrategyFactoryTest is Test {
         vm.startPrank(secondUser);
         address secondStrategyAddress = factory.createStrategy(
             secondVaultName,
+            "osSKY2",
             secondUser,
             keeper,
             emergencyAdmin,
@@ -242,6 +251,7 @@ contract SkyCompounderStrategyFactoryTest is Test {
         vm.startPrank(management);
         address firstAddress = factory.createStrategy(
             vaultSharesName,
+            "osDET",
             management,
             keeper,
             emergencyAdmin,
@@ -254,6 +264,7 @@ contract SkyCompounderStrategyFactoryTest is Test {
         vm.expectRevert(abi.encodeWithSelector(BaseStrategyFactory.StrategyAlreadyExists.selector, firstAddress));
         factory.createStrategy(
             vaultSharesName,
+            "osDET",
             management,
             keeper,
             emergencyAdmin,
@@ -266,6 +277,7 @@ contract SkyCompounderStrategyFactoryTest is Test {
         string memory differentName = "Different Vault";
         address secondAddress = factory.createStrategy(
             differentName,
+            "osDIF",
             management,
             keeper,
             emergencyAdmin,

--- a/test/integration/factories/SkyCompounderStrategyFactory.t.sol
+++ b/test/integration/factories/SkyCompounderStrategyFactory.t.sol
@@ -11,6 +11,7 @@ import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 
 /// @title SkyCompounderStrategyFactory Test
 /// @author mil0x
@@ -145,7 +146,11 @@ contract SkyCompounderStrategyFactoryTest is Test {
         // Verify strategy was initialized correctly
         SkyCompounderStrategy strategy = SkyCompounderStrategy(strategyAddress);
         assertEq(strategy.staking(), STAKING, "Staking address incorrect");
-        // assertEq(strategy.donationAddress(), donationAddress, "Donation address incorrect");
+        assertEq(
+            ITokenizedStrategy(address(strategy)).symbol(),
+            vaultSymbol,
+            "Symbol should match the value passed during creation"
+        );
     }
 
     /// @notice Test creating multiple strategies for the same user

--- a/test/integration/factories/YieldDonatingTokenizedStrategy.t.sol
+++ b/test/integration/factories/YieldDonatingTokenizedStrategy.t.sol
@@ -72,6 +72,7 @@ contract YieldDonatingTokenizedStrategyTest is Test {
         strategy.initialize(
             mockAsset,
             "Test Strategy",
+            "tsTEST",
             mockManagement,
             mockKeeper,
             mockEmergencyAdmin,

--- a/test/integration/guards/KeeperBotGuard.t.sol
+++ b/test/integration/guards/KeeperBotGuard.t.sol
@@ -141,6 +141,7 @@ contract KeeperBotGuardTest is Test {
         strategy = MorphoCompounderStrategy(
             strategyFactory.createStrategy(
                 "MorphoCompounder KeeperBot Test Strategy",
+                "osKBT",
                 address(safeMultisig), // Use Safe as management directly
                 address(safeMultisig), // Use Safe as keeper too
                 emergencyAdmin,

--- a/test/integration/strategies/YieldDonating/MorphoCompounderStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/MorphoCompounderStrategy.t.sol
@@ -101,6 +101,7 @@ contract MorphoCompounderDonatingStrategyTest is Test {
         strategy = MorphoCompounderStrategy(
             factory.createStrategy(
                 params.strategyName,
+                "osMORPHO",
                 params.management,
                 params.keeper,
                 params.emergencyAdmin,
@@ -525,6 +526,7 @@ contract MorphoCompounderDonatingStrategyTest is Test {
             MORPHO_VAULT,
             address(0x123), // Wrong asset
             strategyName,
+            "osMORPHO",
             management,
             keeper,
             emergencyAdmin,

--- a/test/integration/strategies/YieldDonating/SkyCompounder.t.sol
+++ b/test/integration/strategies/YieldDonating/SkyCompounder.t.sol
@@ -113,6 +113,7 @@ contract SkyCompounderTest is Test {
         vm.startPrank(params.management);
         address strategyAddress = factory.createStrategy(
             params.vaultSharesName,
+            "osSKY",
             params.management,
             params.keeper,
             params.emergencyAdmin,

--- a/test/integration/strategies/YieldDonating/SkyCompounterHealthCheck.t.sol
+++ b/test/integration/strategies/YieldDonating/SkyCompounterHealthCheck.t.sol
@@ -115,6 +115,7 @@ contract SkyCompounterHealthCheckTest is Test {
         vm.startPrank(params.management);
         address strategyAddress = factory.createStrategy(
             params.vaultSharesName,
+            "osSKY",
             params.management,
             params.keeper,
             params.emergencyAdmin,

--- a/test/integration/strategies/YieldDonating/YearnV3Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/YearnV3Strategy.t.sol
@@ -102,6 +102,7 @@ contract YearnV3DonatingStrategyTest is Test {
                 YEARN_V3_USDC_VAULT,
                 USDC,
                 params.strategyName,
+                "osYEARN",
                 params.management,
                 params.keeper,
                 params.emergencyAdmin,
@@ -515,6 +516,7 @@ contract YearnV3DonatingStrategyTest is Test {
             YEARN_V3_USDC_VAULT,
             address(0x123), // Wrong asset
             strategyName,
+            "osYEARN",
             management,
             keeper,
             emergencyAdmin,

--- a/test/integration/strategies/YieldDonating/factories/MorphoCompounderVaultFactory.t.sol
+++ b/test/integration/strategies/YieldDonating/factories/MorphoCompounderVaultFactory.t.sol
@@ -76,12 +76,15 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
     function testCreateStrategy() public {
         string memory vaultSharesName = "MorphoCompounder Donating Vault Shares";
 
+        string memory vaultSymbol = "osMORPHO";
+
         // Generate parameter hash for prediction
         bytes32 parameterHash = keccak256(
             abi.encode(
                 0x074134A2784F4F66b6ceD6f68849382990Ff3215, // YS_USDC
                 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, // USDC
                 vaultSharesName,
+                vaultSymbol,
                 management,
                 keeper,
                 emergencyAdmin,
@@ -98,6 +101,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
                 0x074134A2784F4F66b6ceD6f68849382990Ff3215, // YS_USDC
                 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, // USDC
                 vaultSharesName,
+                vaultSymbol,
                 management,
                 keeper,
                 emergencyAdmin,
@@ -121,6 +125,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
 
         address strategyAddress = factory.createStrategy(
             vaultSharesName,
+            vaultSymbol,
             management,
             keeper,
             emergencyAdmin,
@@ -152,6 +157,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
         vm.startPrank(management);
         address firstStrategyAddress = factory.createStrategy(
             firstVaultName,
+            "osMORPHO1",
             management,
             keeper,
             emergencyAdmin,
@@ -165,6 +171,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
 
         address secondStrategyAddress = factory.createStrategy(
             secondVaultName,
+            "osMORPHO2",
             management,
             keeper,
             emergencyAdmin,
@@ -198,6 +205,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
         vm.startPrank(firstUser);
         address firstStrategyAddress = factory.createStrategy(
             firstVaultName,
+            "osMORPHO1",
             firstUser,
             keeper,
             emergencyAdmin,
@@ -213,6 +221,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
         vm.startPrank(secondUser);
         address secondStrategyAddress = factory.createStrategy(
             secondVaultName,
+            "osMORPHO2",
             secondUser,
             keeper,
             emergencyAdmin,
@@ -243,6 +252,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
         vm.startPrank(management);
         address firstAddress = factory.createStrategy(
             vaultSharesName,
+            "osDET",
             management,
             keeper,
             emergencyAdmin,
@@ -257,6 +267,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
         vm.expectRevert(abi.encodeWithSelector(BaseStrategyFactory.StrategyAlreadyExists.selector, firstAddress));
         factory.createStrategy(
             vaultSharesName,
+            "osDET",
             management,
             keeper,
             emergencyAdmin,
@@ -271,6 +282,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
         vm.startPrank(management);
         address secondAddress = factory.createStrategy(
             differentName,
+            "osDIF",
             management,
             keeper,
             emergencyAdmin,
@@ -292,6 +304,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
         vm.startPrank(management);
         address firstStrategyAddress = factory.createStrategy(
             firstVaultName,
+            "osM1",
             management,
             keeper,
             emergencyAdmin,
@@ -302,6 +315,7 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
 
         address secondStrategyAddress = factory.createStrategy(
             secondVaultName,
+            "osM2",
             management,
             keeper,
             emergencyAdmin,

--- a/test/integration/strategies/YieldSkimming/LidoStrategy.t.sol
+++ b/test/integration/strategies/YieldSkimming/LidoStrategy.t.sol
@@ -153,6 +153,7 @@ contract LidoStrategyTest is Test {
         vm.startPrank(params.management);
         address strategyAddress = factory.createStrategy(
             params.vaultSharesName,
+            "osLIDO",
             params.management,
             params.keeper,
             params.emergencyAdmin,

--- a/test/integration/strategies/YieldSkimming/RocketPoolStrategy.t.sol
+++ b/test/integration/strategies/YieldSkimming/RocketPoolStrategy.t.sol
@@ -156,6 +156,7 @@ contract RocketPoolStrategyTest is Test {
         vm.startPrank(params.management);
         address strategyAddress = factory.createStrategy(
             params.vaultSharesName,
+            "osRPL",
             params.management,
             params.keeper,
             params.emergencyAdmin,

--- a/test/mocks/core/MockBaseStrategy.sol
+++ b/test/mocks/core/MockBaseStrategy.sol
@@ -19,6 +19,7 @@ contract MockStrategy is BaseStrategy {
         BaseStrategy(
             _asset,
             "Test Strategy",
+            "tsSYMBOL",
             msg.sender,
             msg.sender,
             msg.sender,

--- a/test/mocks/core/MockTokenizedStrategyWithLoss.sol
+++ b/test/mocks/core/MockTokenizedStrategyWithLoss.sol
@@ -30,13 +30,14 @@ contract MockTokenizedStrategyWithLoss is TokenizedStrategy, IBaseStrategy {
     function initialize(
         address _asset,
         string memory _name,
+        string memory _symbol,
         address _management,
         address _keeper,
         address _emergencyAdmin,
         address _dragonRouter,
         bool _enableBurning
     ) public override {
-        super.initialize(_asset, _name, _management, _keeper, _emergencyAdmin, _dragonRouter, _enableBurning);
+        super.initialize(_asset, _name, _symbol, _management, _keeper, _emergencyAdmin, _dragonRouter, _enableBurning);
         mockTotalAssets = 0;
         mockAvailableDepositLimit = type(uint256).max;
         mockAvailableWithdrawLimit = type(uint256).max;

--- a/test/mocks/core/tokenized-strategies/MockFaultyStrategy.sol
+++ b/test/mocks/core/tokenized-strategies/MockFaultyStrategy.sol
@@ -27,6 +27,7 @@ contract MockFaultyStrategy is BaseStrategy {
         BaseStrategy(
             _asset,
             "Test Strategy",
+            "tsSYMBOL",
             _management,
             _keeper,
             _emergencyAdmin,

--- a/test/mocks/core/tokenized-strategies/MockIlliquidStrategy.sol
+++ b/test/mocks/core/tokenized-strategies/MockIlliquidStrategy.sol
@@ -21,6 +21,7 @@ contract MockIlliquidStrategy is BaseStrategy {
         BaseStrategy(
             _asset,
             "Test Strategy",
+            "tsSYMBOL",
             _management,
             _keeper,
             _emergencyAdmin,

--- a/test/mocks/core/tokenized-strategies/MockStrategy.sol
+++ b/test/mocks/core/tokenized-strategies/MockStrategy.sol
@@ -23,6 +23,7 @@ contract MockStrategy is BaseStrategy {
         BaseStrategy(
             _asset,
             "Test Strategy",
+            "tsSYMBOL",
             _management,
             _keeper,
             _emergencyAdmin,

--- a/test/mocks/core/tokenized-strategies/MockStrategySkimming.sol
+++ b/test/mocks/core/tokenized-strategies/MockStrategySkimming.sol
@@ -35,6 +35,7 @@ contract MockStrategySkimming is BaseStrategy {
         BaseStrategy(
             _yieldSource,
             "Test Strategy",
+            "tsSYMBOL",
             _management,
             _keeper,
             _emergencyAdmin,

--- a/test/proof-of-fixes/cantina-competition-september-2025/Finding658Fix.t.sol
+++ b/test/proof-of-fixes/cantina-competition-september-2025/Finding658Fix.t.sol
@@ -142,7 +142,16 @@ contract Finding658Fix is Test {
 
         YieldDonatingTokenizedStrategy implementation = new YieldDonatingTokenizedStrategy();
         strategy = YieldDonatingTokenizedStrategy(address(new ERC1967Proxy(address(implementation), "")));
-        strategy.initialize(address(asset), "Strategy", address(0x1), address(0x2), address(0x3), address(0x4), true);
+        strategy.initialize(
+            address(asset),
+            "Strategy",
+            "osTEST",
+            address(0x1),
+            address(0x2),
+            address(0x3),
+            address(0x4),
+            true
+        );
     }
 
     function _signPermit(

--- a/test/unit/core/tokenizedStrategy/BurningMechanism.t.sol
+++ b/test/unit/core/tokenizedStrategy/BurningMechanism.t.sol
@@ -45,6 +45,7 @@ contract BurningMechanismTest is Test {
         yieldDonatingStrategy.initialize(
             address(asset),
             "Yield Donating Strategy",
+            "osYD",
             management,
             keeper,
             emergencyAdmin,
@@ -55,6 +56,7 @@ contract BurningMechanismTest is Test {
         yieldSkimmingStrategy.initialize(
             address(asset),
             "Yield Skimming Strategy",
+            "osYS",
             management,
             keeper,
             emergencyAdmin,

--- a/test/unit/periphery/BaseYieldSkimmingHealthCheck.t.sol
+++ b/test/unit/periphery/BaseYieldSkimmingHealthCheck.t.sol
@@ -23,6 +23,7 @@ contract YieldSkimmingHealthCheckLogic is BaseYieldSkimmingHealthCheck {
         BaseYieldSkimmingHealthCheck(
             _asset,
             "Test Health Check",
+            "tsTHC",
             _management,
             address(0x2), // keeper
             address(0x3), // emergencyAdmin

--- a/test/unit/strategies/yieldDonating/AccessControl.t.sol
+++ b/test/unit/strategies/yieldDonating/AccessControl.t.sol
@@ -126,7 +126,7 @@ contract AccessControlTest is Setup {
         vm.assume(_address != address(0));
 
         vm.expectRevert("initialized");
-        tokenizedStrategy.initialize(address(asset), name_, _address, _address, _address, _address, true);
+        tokenizedStrategy.initialize(address(asset), name_, "tsSYMBOL", _address, _address, _address, _address, true);
     }
 
     function test_accessControl_deployFunds(address _address, uint256 _amount) public {

--- a/test/unit/strategies/yieldDonating/utils/Setup.sol
+++ b/test/unit/strategies/yieldDonating/utils/Setup.sol
@@ -61,6 +61,7 @@ contract Setup is Test {
         tokenizedStrategy.initialize(
             address(asset),
             "Test Strategy",
+            "tsSYMBOL",
             management,
             keeper,
             emergencyAdmin,

--- a/test/unit/strategies/yieldSkimming/AccessControl.t.sol
+++ b/test/unit/strategies/yieldSkimming/AccessControl.t.sol
@@ -126,7 +126,7 @@ contract AccessControlTest is Setup {
         vm.assume(_address != address(0));
 
         vm.expectRevert("initialized");
-        tokenizedStrategy.initialize(address(asset), name_, _address, _address, _address, _address, false);
+        tokenizedStrategy.initialize(address(asset), name_, "tsSYMBOL", _address, _address, _address, _address, false);
     }
 
     function test_accessControl_harvestAndReport(address _address, uint256 _amount) public {

--- a/test/unit/strategies/yieldSkimming/utils/Setup.sol
+++ b/test/unit/strategies/yieldSkimming/utils/Setup.sol
@@ -67,6 +67,7 @@ contract Setup is Test {
         tokenizedStrategy.initialize(
             address(yieldSource),
             "Test Strategy",
+            "tsSYMBOL",
             management,
             keeper,
             emergencyAdmin,


### PR DESCRIPTION
# PR Summary: Pass Symbol to Strategy Initialization

## What This PR Introduces

- **Custom strategy token symbol support**: Adds a `_symbol` parameter to the `initialize()` function across all strategies, allowing custom ERC20 symbols to be set during deployment instead of auto-generating them

- **Updated symbol storage**: The `TokenizedStrategy` contract now stores the symbol in its storage struct rather than dynamically computing it as `"os" + asset.symbol()`

- **Factory updates**: All strategy factories (`LidoStrategyFactory`, `MorphoCompounderStrategyFactory`, `SkyCompounderStrategyFactory`, `YearnV3StrategyFactory`, `RocketPoolStrategyFactory`) now accept and pass the symbol parameter when creating strategies

- **Propagated through inheritance chain**: The symbol parameter flows through `BaseStrategy` → `BaseHealthCheck` → `BaseYieldSkimmingHealthCheck` → individual strategy implementations

- **Build configuration**: Added `ignored_warnings_from = ["dependencies"]` to `foundry.toml` to suppress compiler warnings from external dependencies

## Breaking Change

This is a breaking change to the strategy initialization interface. All strategy deployments must now include a symbol parameter (e.g., `"osLIDO"`, `"osMORPHO"`, `"osSKY"`).
