### PR TITLE
chore(foundry): refine optimizer runs and build config

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -19,6 +19,8 @@ compilation_restrictions = [
     { paths = "src/core/MultistrategyVault.sol", optimizer_runs = 16 },
     { paths = "src/regen/RegenStaker.sol", optimizer_runs = 16 },
     { paths = "src/regen/RegenStakerWithoutDelegateSurrogateVotes.sol", optimizer_runs = 16 },
+    { paths = "src/mechanisms/TokenizedAllocationMechanism.sol", optimizer_runs = 16 },
+    { paths = "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol", optimizer_runs = 4096 },
     { paths = "src/guards/KeeperBotGuard.sol", optimizer_runs = 4096 },
     { paths = "src/utils/routers-transformers/Trader.sol", optimizer_runs = 65536 },
 ]
@@ -37,7 +39,7 @@ build_info = true
 extra_output = ["storageLayout"]
 fuzz = { runs = 256, max_test_rejects = 65536, seed = "0xDEADC0DE" }
 deny = "warnings"
-ignored_error_codes = [2424, 3860, 4591, 5574, 8429, 9207]
+ignored_error_codes = [2424, 3860, 4591, 5574, 8429, 9207, 9170]
 lint = { severity = ["high"], exclude_lints = ["erc20-unchecked-transfer", "unsafe-typecast", "incorrect-shift"] }
 
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,10 +4,28 @@ out = "out"
 libs = ["dependencies"]
 evm_version = "prague"
 optimizer = true
-# Runs changed from 10M to 25k to fit code in EVM
-optimizer_runs = 5
+# Default runs target balanced gas/size; size-limited contracts override below.
+optimizer_runs = 1048576
+additional_compiler_profiles = [
+    { name = "enormous", optimizer = true, optimizer_runs = 1 },
+    { name = "gigantic", optimizer = true, optimizer_runs = 16 },
+    { name = "huge", optimizer = true, optimizer_runs = 256 },
+    { name = "large", optimizer = true, optimizer_runs = 4096 },
+    { name = "medium", optimizer = true, optimizer_runs = 65536 },
+]
+compilation_restrictions = [
+    { paths = "src/zodiac-core/vaults/Passport.sol", optimizer_runs = 1 },
+    { paths = "src/core/MultistrategyLockedVault.sol", optimizer_runs = 16 },
+    { paths = "src/core/MultistrategyVault.sol", optimizer_runs = 16 },
+    { paths = "src/regen/RegenStaker.sol", optimizer_runs = 16 },
+    { paths = "src/regen/RegenStakerWithoutDelegateSurrogateVotes.sol", optimizer_runs = 16 },
+    { paths = "src/guards/KeeperBotGuard.sol", optimizer_runs = 4096 },
+    { paths = "src/utils/routers-transformers/Trader.sol", optimizer_runs = 65536 },
+]
+
 via_ir = false
-solc = "0.8.30"
+solc = "0.8.33"
+auto_detect_solc = false
 verbosity = 3
 ast = true
 fs_permissions = [
@@ -18,6 +36,8 @@ fs_permissions = [
 build_info = true
 extra_output = ["storageLayout"]
 fuzz = { runs = 256, max_test_rejects = 65536, seed = "0xDEADC0DE" }
+deny = "warnings"
+ignored_error_codes = [2424, 3860, 4591, 5574, 8429, 9207]
 lint = { severity = ["high"], exclude_lints = ["erc20-unchecked-transfer", "unsafe-typecast", "incorrect-shift"] }
 
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -4,7 +4,7 @@
 @tokenized-strategy-periphery/=dependencies/tokenized-strategy-periphery-3.0.2/src/
 abdk-libraries-solidity/=dependencies/abdk-libraries-solidity-3.2/
 erc4626-tests/=dependencies/erc4626-tests-0.0.0/
-forge-std/=dependencies/forge-std-1.9.7/src/
+forge-std/=dependencies/forge-std-1.14.0/src/
 hats-protocol/=dependencies/hats-protocol-1.0/src/
 kontrol-cheatcodes/=dependencies/kontrol-cheatcodes-v0.0.1/
 lib/ERC1155/=dependencies/hats-protocol-1.0/lib/ERC1155/

--- a/script/deploy/DeployTrader.sol
+++ b/script/deploy/DeployTrader.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
 import { Script } from "forge-std/Script.sol";

--- a/soldeer.lock
+++ b/soldeer.lock
@@ -24,10 +24,10 @@ rev = "232ff9ba8194e406967f52ecc5cb52ed764209e9"
 
 [[dependencies]]
 name = "forge-std"
-version = "1.9.7"
-url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_9_7_28-04-2025_15:55:08_forge-std-1.9.zip"
-checksum = "8d9e0a885fa8ee6429a4d344aeb6799119f6a94c7c4fe6f188df79b0dce294ba"
-integrity = "9e60fdba82bc374df80db7f2951faff6467b9091873004a3d314cf0c084b3c7d"
+version = "1.14.0"
+url = "https://soldeer-revisions.s3.amazonaws.com/forge-std/1_14_0_05-01-2026_15:24:39_forge-std-1.14.zip"
+checksum = "d10079d1b7aac1a36dd2eeb4c5d042e8ed27b00f4ef89530b7f0a6ecd18cada3"
+integrity = "64133846def1b04b1726d2bf1292c19050a0e8cb832b60c6104c19595b9699f8"
 
 [[dependencies]]
 name = "gnosisguild-zodiac"

--- a/src/utils/routers-transformers/Trader.sol
+++ b/src/utils/routers-transformers/Trader.sol
@@ -350,6 +350,7 @@ contract Trader is ITransformer, Ownable, Pausable {
         spent = spent + saleValue;
 
         if (BASE == NATIVE_TOKEN) {
+            //slither-disable-next-line arbitrary-send-eth
             payable(swapper).transfer(saleValue);
         } else {
             IERC20(BASE).safeTransfer(swapper, saleValue);

--- a/test/mocks/MockFactory.sol
+++ b/test/mocks/MockFactory.sol
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: MIT
 pragma solidity >=0.8.18;
 
 contract MockFactory {


### PR DESCRIPTION
## Summary
- define optimizer run tiers and per-contract compilation restrictions to balance gas/size constraints
- bump solc to 0.8.33, disable auto-detect, and enforce warnings with an ignore list
- update forge-std to 1.14.0 (remappings and soldeer lock)
- add SPDX headers to deploy/test helpers and suppress slither warning for Trader native transfer