### PR TITLE
feat(factories): unify computeStrategyAddress ABI with vault/asset pa…

### DIFF
--- a/partners/shutter_dao_0x36/script/GenerateProposalCalldata.s.sol
+++ b/partners/shutter_dao_0x36/script/GenerateProposalCalldata.s.sol
@@ -7,7 +7,6 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
 import { IMorphoCompounderStrategyFactoryV1 } from "src/interfaces/IMorphoCompounderStrategyFactoryV1.sol";
 import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
-import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 
 import {
     USDC_MAINNET,
@@ -99,7 +98,7 @@ contract GenerateProposalCalldata is Script {
         bytes32 bytecodeHash = keccak256(strategyBytecode);
         console.log("Strategy Bytecode Hash:", vm.toString(bytecodeHash));
 
-        address predictedAddress = BaseStrategyFactory(MORPHO_STRATEGY_FACTORY).predictStrategyAddress(
+        address predictedAddress = IMorphoCompounderStrategyFactoryV1(MORPHO_STRATEGY_FACTORY).predictStrategyAddress(
             parameterHash,
             SHUTTER_TREASURY,
             strategyBytecode

--- a/partners/shutter_dao_0x36/script/VerifyProposalExecution.s.sol
+++ b/partners/shutter_dao_0x36/script/VerifyProposalExecution.s.sol
@@ -8,7 +8,6 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
 import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
 import { IMorphoCompounderStrategyFactoryV1 } from "src/interfaces/IMorphoCompounderStrategyFactoryV1.sol";
-import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 
 import {
     USDC_MAINNET,
@@ -130,7 +129,7 @@ contract VerifyProposalExecution is Script {
             )
         );
 
-        return BaseStrategyFactory(MORPHO_STRATEGY_FACTORY).predictStrategyAddress(
+        return IMorphoCompounderStrategyFactoryV1(MORPHO_STRATEGY_FACTORY).predictStrategyAddress(
             parameterHash, SHUTTER_TREASURY, strategyBytecode
         );
     }

--- a/partners/shutter_dao_0x36/test/ShutterDAOCalldataVerification.t.sol
+++ b/partners/shutter_dao_0x36/test/ShutterDAOCalldataVerification.t.sol
@@ -99,8 +99,10 @@ contract ShutterDAOCalldataVerificationTest is Test {
             )
         );
 
-        // Predict address using local bytecode
-        address predictedAddress = factory.predictStrategyAddress(parameterHash, SHUTTER_TREASURY, strategyBytecode);
+        // Predict address using local bytecode (V1 interface)
+        address predictedAddress = IMorphoCompounderStrategyFactoryV1(address(factory)).predictStrategyAddress(
+            parameterHash, SHUTTER_TREASURY, strategyBytecode
+        );
         console2.log("Predicted (local bytecode):", predictedAddress);
 
         // Deploy via factory to get actual address

--- a/src/factories/AaveV3StrategyFactory.sol
+++ b/src/factories/AaveV3StrategyFactory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.25;
 
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 import { AaveV3Strategy } from "src/strategies/yieldDonating/AaveV3Strategy.sol";
 import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 
@@ -93,5 +94,57 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
 
         emit StrategyDeploy(msg.sender, _donationAddress, strategyAddress, _name);
         return strategyAddress;
+    }
+
+    /// @inheritdoc BaseStrategyFactory
+    function computeStrategyAddress(
+        address _vault,
+        address _asset,
+        string memory _name,
+        string memory _symbol,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress,
+        address _deployer
+    ) public view override returns (address) {
+        if (_vault != AAVE_ADDRESSES_PROVIDER) revert InvalidVault(_vault, AAVE_ADDRESSES_PROVIDER);
+        if (_asset != USDC) revert InvalidAsset(_asset, USDC);
+
+        bytes32 parameterHash = keccak256(
+            abi.encode(
+                AAVE_ADDRESSES_PROVIDER,
+                _asset,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes memory bytecode = abi.encodePacked(
+            type(AaveV3Strategy).creationCode,
+            abi.encode(
+                AAVE_ADDRESSES_PROVIDER,
+                _asset,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
+        return Create2.computeAddress(finalSalt, keccak256(bytecode));
     }
 }

--- a/src/factories/AaveV3StrategyFactory.sol
+++ b/src/factories/AaveV3StrategyFactory.sol
@@ -116,7 +116,7 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
         bytes32 parameterHash = keccak256(
             abi.encode(
                 AAVE_ADDRESSES_PROVIDER,
-                _asset,
+                USDC,
                 _name,
                 _symbol,
                 _management,
@@ -132,7 +132,7 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
             type(AaveV3Strategy).creationCode,
             abi.encode(
                 AAVE_ADDRESSES_PROVIDER,
-                _asset,
+                USDC,
                 _name,
                 _symbol,
                 _management,

--- a/src/factories/AaveV3StrategyFactory.sol
+++ b/src/factories/AaveV3StrategyFactory.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.25;
 
-import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 import { AaveV3Strategy } from "src/strategies/yieldDonating/AaveV3Strategy.sol";
 import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 
@@ -144,7 +143,6 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
             )
         );
 
-        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
-        return Create2.computeAddress(finalSalt, keccak256(bytecode));
+        return _predictStrategyAddress(parameterHash, _deployer, bytecode);
     }
 }

--- a/src/factories/BaseERC4626StrategyFactory.sol
+++ b/src/factories/BaseERC4626StrategyFactory.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.25;
 
-import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 
 /**
@@ -122,8 +121,7 @@ abstract contract BaseERC4626StrategyFactory is BaseStrategyFactory {
         bytes32 parameterHash = keccak256(constructorArgs);
         bytes memory bytecode = abi.encodePacked(_getCreationCode(), constructorArgs);
 
-        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
-        return Create2.computeAddress(finalSalt, keccak256(bytecode));
+        return _predictStrategyAddress(parameterHash, _deployer, bytecode);
     }
 
     /**

--- a/src/factories/BaseERC4626StrategyFactory.sol
+++ b/src/factories/BaseERC4626StrategyFactory.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.25;
 
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 
 /**
@@ -90,6 +91,40 @@ abstract contract BaseERC4626StrategyFactory is BaseStrategyFactory {
      * @return The bytecode of the strategy contract (without constructor args)
      */
     function _getCreationCode() internal pure virtual returns (bytes memory);
+
+    /// @inheritdoc BaseStrategyFactory
+    function computeStrategyAddress(
+        address _vault,
+        address _asset,
+        string memory _name,
+        string memory _symbol,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress,
+        address _deployer
+    ) public view override returns (address) {
+        bytes memory constructorArgs = abi.encode(
+            _vault,
+            _asset,
+            _name,
+            _symbol,
+            _management,
+            _keeper,
+            _emergencyAdmin,
+            _donationAddress,
+            _enableBurning,
+            _tokenizedStrategyAddress
+        );
+
+        bytes32 parameterHash = keccak256(constructorArgs);
+        bytes memory bytecode = abi.encodePacked(_getCreationCode(), constructorArgs);
+
+        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
+        return Create2.computeAddress(finalSalt, keccak256(bytecode));
+    }
 
     /**
      * @dev Internal function to deploy strategy with given parameters

--- a/src/factories/BaseStrategyFactory.sol
+++ b/src/factories/BaseStrategyFactory.sol
@@ -37,12 +37,42 @@ abstract contract BaseStrategyFactory {
 
     // Custom errors
     error StrategyAlreadyExists(address existingStrategy);
+    error InvalidVault(address provided, address expected);
+    error InvalidAsset(address provided, address expected);
 
     // Note: Child factories should declare and emit their own `StrategyDeploy` event for compatibility.
 
     /**
-     * @notice Predict deployment address using strategy parameter hash
-     * @dev Combines parameter hash with deployer address for deterministic deployment
+     * @notice Compute the deterministic address where a strategy will be deployed
+     * @dev Must be implemented by child factories using their own bytecode
+     * @param _vault Vault address (e.g., Yearn vault, or factory constant for hardcoded vaults)
+     * @param _asset Underlying asset address (or factory constant for hardcoded assets)
+     * @param _name Strategy share token name
+     * @param _symbol Strategy share token symbol
+     * @param _management Management address
+     * @param _keeper Keeper address
+     * @param _emergencyAdmin Emergency admin address
+     * @param _donationAddress Donation address
+     * @param _enableBurning Enable burning flag
+     * @param _tokenizedStrategyAddress TokenizedStrategy implementation
+     * @param _deployer Address that will deploy the strategy
+     * @return Predicted strategy address
+     */
+    function computeStrategyAddress(
+        address _vault,
+        address _asset,
+        string memory _name,
+        string memory _symbol,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress,
+        address _deployer
+    ) public view virtual returns (address);
+
+    /**
      * @param _parameterHash Hash of all strategy parameters
      * @param deployer Deployer address
      * @param bytecode Deployment bytecode (including constructor args)

--- a/src/factories/BaseStrategyFactory.sol
+++ b/src/factories/BaseStrategyFactory.sol
@@ -73,37 +73,42 @@ abstract contract BaseStrategyFactory {
     ) public view virtual returns (address);
 
     /**
+     * @dev Internal helper to predict deterministic deployment address
+     * @dev Single source of truth for salt computation - used by child factories' computeStrategyAddress
      * @param _parameterHash Hash of all strategy parameters
-     * @param deployer Deployer address
-     * @param bytecode Deployment bytecode (including constructor args)
+     * @param _deployer Deployer address
+     * @param _bytecode Deployment bytecode (including constructor args)
      * @return Predicted contract address
      */
-    function predictStrategyAddress(
+    function _predictStrategyAddress(
         bytes32 _parameterHash,
-        address deployer,
-        bytes memory bytecode
-    ) external view returns (address) {
-        bytes32 finalSalt = keccak256(abi.encodePacked(_parameterHash, deployer));
-        return Create2.computeAddress(finalSalt, keccak256(bytecode));
+        address _deployer,
+        bytes memory _bytecode
+    ) internal view returns (address) {
+        bytes32 finalSalt = keccak256(abi.encodePacked(_parameterHash, _deployer));
+        return Create2.computeAddress(finalSalt, keccak256(_bytecode));
     }
 
     /**
      * @dev Internal function to deploy strategy using CREATE2
-     * @param bytecode Deployment bytecode including constructor args
+     * @param _bytecode Deployment bytecode including constructor args
      * @param _parameterHash Hash of all strategy parameters for deterministic deployment
      * @return strategyAddress Deployed strategy address
      */
-    function _deployStrategy(bytes memory bytecode, bytes32 _parameterHash) internal returns (address strategyAddress) {
+    function _deployStrategy(
+        bytes memory _bytecode,
+        bytes32 _parameterHash
+    ) internal returns (address strategyAddress) {
         bytes32 finalSalt = keccak256(abi.encodePacked(_parameterHash, msg.sender));
 
         // Check if strategy would be deployed to an existing address
-        address predictedAddress = Create2.computeAddress(finalSalt, keccak256(bytecode));
+        address predictedAddress = _predictStrategyAddress(_parameterHash, msg.sender, _bytecode);
 
         if (predictedAddress.code.length > 0) {
             revert StrategyAlreadyExists(predictedAddress);
         }
 
-        strategyAddress = Create2.deploy(0, finalSalt, bytecode);
+        strategyAddress = Create2.deploy(0, finalSalt, _bytecode);
     }
 
     /**

--- a/src/factories/LidoStrategyFactory.sol
+++ b/src/factories/LidoStrategyFactory.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.25;
 
 import { BaseStrategyFactory } from "./BaseStrategyFactory.sol";
 import { LidoStrategy } from "src/strategies/yieldSkimming/LidoStrategy.sol";
-import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /**
  * @title LidoStrategyFactory
@@ -149,7 +148,6 @@ contract LidoStrategyFactory is BaseStrategyFactory {
             )
         );
 
-        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
-        return Create2.computeAddress(finalSalt, keccak256(bytecode));
+        return _predictStrategyAddress(parameterHash, _deployer, bytecode);
     }
 }

--- a/src/factories/LidoStrategyFactory.sol
+++ b/src/factories/LidoStrategyFactory.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.25;
 
 import { BaseStrategyFactory } from "./BaseStrategyFactory.sol";
 import { LidoStrategy } from "src/strategies/yieldSkimming/LidoStrategy.sol";
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /**
  * @title LidoStrategyFactory
@@ -100,5 +101,55 @@ contract LidoStrategyFactory is BaseStrategyFactory {
 
         // Record the deployment
         _recordStrategy(_name, _donationAddress, strategyAddress);
+    }
+
+    /// @inheritdoc BaseStrategyFactory
+    function computeStrategyAddress(
+        address _vault,
+        address _asset,
+        string memory _name,
+        string memory _symbol,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress,
+        address _deployer
+    ) public view override returns (address) {
+        if (_vault != WSTETH) revert InvalidVault(_vault, WSTETH);
+        if (_asset != WSTETH) revert InvalidAsset(_asset, WSTETH);
+
+        bytes32 parameterHash = keccak256(
+            abi.encode(
+                WSTETH,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes memory bytecode = abi.encodePacked(
+            type(LidoStrategy).creationCode,
+            abi.encode(
+                WSTETH,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
+        return Create2.computeAddress(finalSalt, keccak256(bytecode));
     }
 }

--- a/src/factories/MorphoCompounderStrategyFactory.sol
+++ b/src/factories/MorphoCompounderStrategyFactory.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 pragma solidity >=0.8.25;
 
-import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
 import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 
@@ -145,7 +144,6 @@ contract MorphoCompounderStrategyFactory is BaseStrategyFactory {
             )
         );
 
-        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
-        return Create2.computeAddress(finalSalt, keccak256(bytecode));
+        return _predictStrategyAddress(parameterHash, _deployer, bytecode);
     }
 }

--- a/src/factories/MorphoCompounderStrategyFactory.sol
+++ b/src/factories/MorphoCompounderStrategyFactory.sol
@@ -96,4 +96,56 @@ contract MorphoCompounderStrategyFactory is BaseStrategyFactory {
         emit StrategyDeploy(msg.sender, _donationAddress, strategyAddress, _name);
         return strategyAddress;
     }
+
+    /// @inheritdoc BaseStrategyFactory
+    function computeStrategyAddress(
+        address _vault,
+        address _asset,
+        string memory _name,
+        string memory _symbol,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress,
+        address _deployer
+    ) public view override returns (address) {
+        if (_vault != YS_USDC) revert InvalidVault(_vault, YS_USDC);
+        if (_asset != USDC) revert InvalidAsset(_asset, USDC);
+
+        bytes32 parameterHash = keccak256(
+            abi.encode(
+                YS_USDC,
+                _asset,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes memory bytecode = abi.encodePacked(
+            type(MorphoCompounderStrategy).creationCode,
+            abi.encode(
+                YS_USDC,
+                _asset,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
+        return Create2.computeAddress(finalSalt, keccak256(bytecode));
+    }
 }

--- a/src/factories/MorphoCompounderStrategyFactory.sol
+++ b/src/factories/MorphoCompounderStrategyFactory.sol
@@ -117,7 +117,7 @@ contract MorphoCompounderStrategyFactory is BaseStrategyFactory {
         bytes32 parameterHash = keccak256(
             abi.encode(
                 YS_USDC,
-                _asset,
+                USDC,
                 _name,
                 _symbol,
                 _management,
@@ -133,7 +133,7 @@ contract MorphoCompounderStrategyFactory is BaseStrategyFactory {
             type(MorphoCompounderStrategy).creationCode,
             abi.encode(
                 YS_USDC,
-                _asset,
+                USDC,
                 _name,
                 _symbol,
                 _management,

--- a/src/factories/SkyCompounderStrategyFactory.sol
+++ b/src/factories/SkyCompounderStrategyFactory.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.25;
 
 import { BaseStrategyFactory } from "./BaseStrategyFactory.sol";
 import { SkyCompounderStrategy } from "src/strategies/yieldDonating/SkyCompounderStrategy.sol";
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /**
  * @title SkyCompounderStrategyFactory
@@ -12,8 +13,11 @@ import { SkyCompounderStrategy } from "src/strategies/yieldDonating/SkyCompounde
  * @dev Inherits deterministic deployment from BaseStrategyFactory
  */
 contract SkyCompounderStrategyFactory is BaseStrategyFactory {
-    /// @notice USDS reward address on mainnet
-    address constant USDS_REWARD_ADDRESS = 0x0650CAF159C5A49f711e8169D4336ECB9b950275;
+    /// @notice USDS staking/reward contract address on mainnet
+    address public constant USDS_REWARD_ADDRESS = 0x0650CAF159C5A49f711e8169D4336ECB9b950275;
+
+    /// @notice USDS token address on mainnet (staking token)
+    address public constant USDS = 0xdC035D45d973E3EC169d2276DDab16f1e407384F;
 
     /// @notice Emitted when a new SkyCompounderStrategy is deployed
     /// @param deployer Address that deployed the strategy
@@ -87,5 +91,55 @@ contract SkyCompounderStrategyFactory is BaseStrategyFactory {
 
         // Record the deployment
         _recordStrategy(_name, _donationAddress, strategyAddress);
+    }
+
+    /// @inheritdoc BaseStrategyFactory
+    function computeStrategyAddress(
+        address _vault,
+        address _asset,
+        string memory _name,
+        string memory _symbol,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress,
+        address _deployer
+    ) public view override returns (address) {
+        if (_vault != USDS_REWARD_ADDRESS) revert InvalidVault(_vault, USDS_REWARD_ADDRESS);
+        if (_asset != USDS) revert InvalidAsset(_asset, USDS);
+
+        bytes32 parameterHash = keccak256(
+            abi.encode(
+                USDS_REWARD_ADDRESS,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes memory bytecode = abi.encodePacked(
+            type(SkyCompounderStrategy).creationCode,
+            abi.encode(
+                USDS_REWARD_ADDRESS,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
+        return Create2.computeAddress(finalSalt, keccak256(bytecode));
     }
 }

--- a/src/factories/SkyCompounderStrategyFactory.sol
+++ b/src/factories/SkyCompounderStrategyFactory.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.25;
 
 import { BaseStrategyFactory } from "./BaseStrategyFactory.sol";
 import { SkyCompounderStrategy } from "src/strategies/yieldDonating/SkyCompounderStrategy.sol";
-import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /**
  * @title SkyCompounderStrategyFactory
@@ -139,7 +138,6 @@ contract SkyCompounderStrategyFactory is BaseStrategyFactory {
             )
         );
 
-        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
-        return Create2.computeAddress(finalSalt, keccak256(bytecode));
+        return _predictStrategyAddress(parameterHash, _deployer, bytecode);
     }
 }

--- a/src/factories/yieldDonating/YearnV3StrategyFactory.sol
+++ b/src/factories/yieldDonating/YearnV3StrategyFactory.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.25;
 
 import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 import { YearnV3Strategy } from "src/strategies/yieldDonating/YearnV3Strategy.sol";
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /**
  * @title YearnV3StrategyFactory
@@ -107,5 +108,54 @@ contract YearnV3StrategyFactory is BaseStrategyFactory {
 
         emit StrategyDeploy(_management, _donationAddress, strategyAddress, _name);
         return strategyAddress;
+    }
+
+    /// @inheritdoc BaseStrategyFactory
+    function computeStrategyAddress(
+        address _vault,
+        address _asset,
+        string memory _name,
+        string memory _symbol,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress,
+        address _deployer
+    ) public view override returns (address) {
+        bytes32 parameterHash = keccak256(
+            abi.encode(
+                _vault,
+                _asset,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes memory bytecode = abi.encodePacked(
+            type(YearnV3Strategy).creationCode,
+            abi.encode(
+                _vault,
+                _asset,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
+        return Create2.computeAddress(finalSalt, keccak256(bytecode));
     }
 }

--- a/src/factories/yieldDonating/YearnV3StrategyFactory.sol
+++ b/src/factories/yieldDonating/YearnV3StrategyFactory.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.25;
 
 import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 import { YearnV3Strategy } from "src/strategies/yieldDonating/YearnV3Strategy.sol";
-import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /**
  * @title YearnV3StrategyFactory
@@ -155,7 +154,6 @@ contract YearnV3StrategyFactory is BaseStrategyFactory {
             )
         );
 
-        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
-        return Create2.computeAddress(finalSalt, keccak256(bytecode));
+        return _predictStrategyAddress(parameterHash, _deployer, bytecode);
     }
 }

--- a/src/factories/yieldSkimming/RocketPoolStrategyFactory.sol
+++ b/src/factories/yieldSkimming/RocketPoolStrategyFactory.sol
@@ -3,6 +3,7 @@ pragma solidity >=0.8.25;
 
 import { BaseStrategyFactory } from "../BaseStrategyFactory.sol";
 import { RocketPoolStrategy } from "src/strategies/yieldSkimming/RocketPoolStrategy.sol";
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /**
  * @title RocketPoolStrategyFactory
@@ -87,5 +88,55 @@ contract RocketPoolStrategyFactory is BaseStrategyFactory {
 
         // Record the deployment
         _recordStrategy(_name, _donationAddress, strategyAddress);
+    }
+
+    /// @inheritdoc BaseStrategyFactory
+    function computeStrategyAddress(
+        address _vault,
+        address _asset,
+        string memory _name,
+        string memory _symbol,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress,
+        address _deployer
+    ) public view override returns (address) {
+        if (_vault != R_ETH) revert InvalidVault(_vault, R_ETH);
+        if (_asset != R_ETH) revert InvalidAsset(_asset, R_ETH);
+
+        bytes32 parameterHash = keccak256(
+            abi.encode(
+                R_ETH,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes memory bytecode = abi.encodePacked(
+            type(RocketPoolStrategy).creationCode,
+            abi.encode(
+                R_ETH,
+                _name,
+                _symbol,
+                _management,
+                _keeper,
+                _emergencyAdmin,
+                _donationAddress,
+                _enableBurning,
+                _tokenizedStrategyAddress
+            )
+        );
+
+        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
+        return Create2.computeAddress(finalSalt, keccak256(bytecode));
     }
 }

--- a/src/factories/yieldSkimming/RocketPoolStrategyFactory.sol
+++ b/src/factories/yieldSkimming/RocketPoolStrategyFactory.sol
@@ -3,7 +3,6 @@ pragma solidity >=0.8.25;
 
 import { BaseStrategyFactory } from "../BaseStrategyFactory.sol";
 import { RocketPoolStrategy } from "src/strategies/yieldSkimming/RocketPoolStrategy.sol";
-import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /**
  * @title RocketPoolStrategyFactory
@@ -136,7 +135,6 @@ contract RocketPoolStrategyFactory is BaseStrategyFactory {
             )
         );
 
-        bytes32 finalSalt = keccak256(abi.encodePacked(parameterHash, _deployer));
-        return Create2.computeAddress(finalSalt, keccak256(bytecode));
+        return _predictStrategyAddress(parameterHash, _deployer, bytecode);
     }
 }

--- a/test/integration/factories/AaveV3StrategyFactory.t.sol
+++ b/test/integration/factories/AaveV3StrategyFactory.t.sol
@@ -78,6 +78,60 @@ contract AaveV3StrategyFactoryTest is BaseFactoryIntegrationTest {
         vm.label(TOKENIZED_STRATEGY_ADDRESS, "TokenizedStrategy");
     }
 
+    function _vault() internal pure override returns (address) {
+        return 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e; // AAVE_ADDRESSES_PROVIDER
+    }
+
+    function _factoryValidatesVaultAsset() internal pure override returns (bool) {
+        return true;
+    }
+
+    function _computeStrategyAddress(
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e, // AAVE_ADDRESSES_PROVIDER
+                USDC,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
+    }
+
+    function _computeStrategyAddressWithVault(
+        address vault,
+        address asset,
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                vault,
+                asset,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
+    }
+
     // ========== CONCRETE TESTS ==========
 
     /// @notice Test creating a strategy through the factory
@@ -98,5 +152,30 @@ contract AaveV3StrategyFactoryTest is BaseFactoryIntegrationTest {
     /// @notice Test for deterministic addressing and duplicate prevention
     function testDeterministicAddressingAave() public {
         _testDeterministicAddressing();
+    }
+
+    /// @notice Test computeStrategyAddress matches actual deployment
+    function testComputeStrategyAddressMatchesDeploymentAave() public {
+        _testComputeStrategyAddressMatchesDeployment("Aave Compute Test", "osAAVE_CT");
+    }
+
+    /// @notice Test computeStrategyAddress with different deployers
+    function testComputeStrategyAddressDifferentDeployersAave() public {
+        _testComputeStrategyAddressDifferentDeployers();
+    }
+
+    /// @notice Test computeStrategyAddress with different parameters
+    function testComputeStrategyAddressDifferentParamsAave() public {
+        _testComputeStrategyAddressDifferentParams();
+    }
+
+    /// @notice Test computeStrategyAddress reverts on invalid vault
+    function testComputeStrategyAddressInvalidVaultAave() public {
+        _testComputeStrategyAddressInvalidVault();
+    }
+
+    /// @notice Test computeStrategyAddress reverts on invalid asset
+    function testComputeStrategyAddressInvalidAssetAave() public {
+        _testComputeStrategyAddressInvalidAsset();
     }
 }

--- a/test/integration/factories/ERC4626StrategyFactory.t.sol
+++ b/test/integration/factories/ERC4626StrategyFactory.t.sol
@@ -440,4 +440,156 @@ contract ERC4626StrategyFactoryTest is Test {
         assertEq(deployerAddress, management, "Deployer should be tracked");
         assertEq(name, strategyName, "Name should match");
     }
+
+    // ========== COMPUTE STRATEGY ADDRESS TESTS ==========
+
+    /// @notice Test computeStrategyAddress matches actual deployment
+    function testComputeStrategyAddressMatchesDeployment() public {
+        string memory strategyName = "Compute Test Strategy";
+        string memory symbol = "osCT";
+
+        // Compute expected address before deployment
+        address expectedAddress = factory.computeStrategyAddress(
+            USDC_SPARK_VAULT,
+            USDC,
+            strategyName,
+            symbol,
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation),
+            management
+        );
+
+        // Deploy the strategy
+        vm.startPrank(management);
+        address actualAddress = factory.createStrategy(
+            USDC_SPARK_VAULT,
+            USDC,
+            strategyName,
+            symbol,
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
+        );
+        vm.stopPrank();
+
+        // Verify computed address matches actual deployment
+        assertEq(expectedAddress, actualAddress, "Computed address should match deployed address");
+    }
+
+    /// @notice Test computeStrategyAddress with different deployers produces different addresses
+    function testComputeStrategyAddressDifferentDeployers() public view {
+        string memory strategyName = "Deployer Test Strategy";
+        string memory symbol = "osDEP";
+
+        address deployer1 = address(0x1111);
+        address deployer2 = address(0x2222);
+
+        address addr1 = factory.computeStrategyAddress(
+            USDC_SPARK_VAULT,
+            USDC,
+            strategyName,
+            symbol,
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation),
+            deployer1
+        );
+
+        address addr2 = factory.computeStrategyAddress(
+            USDC_SPARK_VAULT,
+            USDC,
+            strategyName,
+            symbol,
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation),
+            deployer2
+        );
+
+        assertTrue(addr1 != addr2, "Different deployers should produce different addresses");
+    }
+
+    /// @notice Test computeStrategyAddress with different vaults produces different addresses
+    function testComputeStrategyAddressDifferentVaults() public view {
+        string memory strategyName = "Vault Test Strategy";
+
+        address addr1 = factory.computeStrategyAddress(
+            USDC_SPARK_VAULT,
+            USDC,
+            strategyName,
+            "osVT1",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation),
+            management
+        );
+
+        address addr2 = factory.computeStrategyAddress(
+            WETH_SPARK_VAULT,
+            WETH,
+            strategyName,
+            "osVT1",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation),
+            management
+        );
+
+        assertTrue(addr1 != addr2, "Different vaults should produce different addresses");
+    }
+
+    /// @notice Test computeStrategyAddress with same params produces same address
+    function testComputeStrategyAddressSameParams() public view {
+        string memory strategyName = "Same Params Strategy";
+        string memory symbol = "osSP";
+
+        address addr1 = factory.computeStrategyAddress(
+            USDC_SPARK_VAULT,
+            USDC,
+            strategyName,
+            symbol,
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation),
+            management
+        );
+
+        address addr2 = factory.computeStrategyAddress(
+            USDC_SPARK_VAULT,
+            USDC,
+            strategyName,
+            symbol,
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation),
+            management
+        );
+
+        assertEq(addr1, addr2, "Same params should produce same address");
+    }
 }

--- a/test/integration/factories/ERC4626StrategyFactory.t.sol
+++ b/test/integration/factories/ERC4626StrategyFactory.t.sol
@@ -1,129 +1,160 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.25;
 
-import { Test } from "forge-std/Test.sol";
+import { BaseFactoryIntegrationTest } from "test/integration/factories/base/BaseFactoryIntegrationTest.sol";
 import { ERC4626Strategy } from "src/strategies/yieldDonating/ERC4626Strategy.sol";
 import { ERC4626StrategyFactory } from "src/factories/ERC4626StrategyFactory.sol";
-import { BaseStrategyFactory } from "src/factories/BaseStrategyFactory.sol";
 import { BaseERC4626StrategyFactory } from "src/factories/BaseERC4626StrategyFactory.sol";
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 
 /// @title ERC4626StrategyFactory Test
 /// @author Octant
 /// @notice Integration tests for the ERC4626StrategyFactory using a mainnet fork
-contract ERC4626StrategyFactoryTest is Test {
-    using SafeERC20 for ERC20;
-
-    // Factory for creating strategies
-    YieldDonatingTokenizedStrategy public tokenizedStrategy;
+contract ERC4626StrategyFactoryTest is BaseFactoryIntegrationTest {
+    // Factory and implementation
     ERC4626StrategyFactory public factory;
+    YieldDonatingTokenizedStrategy public implementation;
 
-    // Strategy parameters
-    address public management;
-    address public keeper;
-    address public emergencyAdmin;
-    address public donationAddress;
-
-    // Mainnet addresses - Spark vaults
+    // Mainnet addresses - Spark vaults (using USDC as default for shared tests)
     address public constant USDC_SPARK_VAULT = 0x28B3a8fb53B741A8Fd78c0fb9A6B2393d896a43d;
     address public constant WETH_SPARK_VAULT = 0xfE6eb3b609a7C8352A241f7F3A21CEA4e9209B8f;
     address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     address public constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address public constant TOKENIZED_STRATEGY_ADDRESS = 0x8cf7246a74704bBE59c9dF614ccB5e3d9717d8Ac;
 
-    // Test constants
-    uint256 public mainnetFork;
-    YieldDonatingTokenizedStrategy public implementation;
-
     function setUp() public {
-        // Create a mainnet fork
-        mainnetFork = vm.createFork("mainnet");
-        vm.selectFork(mainnetFork);
+        _baseSetUp();
+    }
 
-        // Etch YieldDonatingTokenizedStrategy
-        implementation = new YieldDonatingTokenizedStrategy{ salt: keccak256("OCT_YIELD_DONATING_STRATEGY_V1") }();
-        bytes memory tokenizedStrategyBytecode = address(implementation).code;
-        vm.etch(TOKENIZED_STRATEGY_ADDRESS, tokenizedStrategyBytecode);
+    // ========== ABSTRACT IMPLEMENTATIONS ==========
 
-        // Now use that address as our tokenizedStrategy
-        tokenizedStrategy = YieldDonatingTokenizedStrategy(TOKENIZED_STRATEGY_ADDRESS);
+    function _factory() internal view override returns (address) {
+        return address(factory);
+    }
 
-        // Set up addresses
-        management = address(0x1);
-        keeper = address(0x2);
-        emergencyAdmin = address(0x3);
-        donationAddress = address(0x4);
+    function _implementation() internal view override returns (address) {
+        return address(implementation);
+    }
 
-        // Deploy factory
+    function _asset() internal pure override returns (address) {
+        return USDC;
+    }
+
+    function _vault() internal pure override returns (address) {
+        return USDC_SPARK_VAULT;
+    }
+
+    function _strategySymbolPrefix() internal pure override returns (string memory) {
+        return "osERC4626";
+    }
+
+    function _deployFactory() internal override {
         factory = new ERC4626StrategyFactory();
+    }
 
-        // Label addresses for better trace outputs
+    function _deployImplementation() internal override returns (address) {
+        implementation = new YieldDonatingTokenizedStrategy{ salt: keccak256("OCT_YIELD_DONATING_STRATEGY_V1") }();
+        vm.etch(TOKENIZED_STRATEGY_ADDRESS, address(implementation).code);
+        return address(implementation);
+    }
+
+    function _createStrategy(
+        string memory name,
+        string memory symbol,
+        address mgmt
+    ) internal override returns (address) {
+        return
+            factory.createStrategy(
+                USDC_SPARK_VAULT,
+                USDC,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation)
+            );
+    }
+
+    function _labelFactoryAddresses() internal override {
         vm.label(address(factory), "ERC4626StrategyFactory");
         vm.label(USDC_SPARK_VAULT, "USDC Spark Vault");
         vm.label(WETH_SPARK_VAULT, "WETH Spark Vault");
         vm.label(USDC, "USDC");
         vm.label(WETH, "WETH");
         vm.label(TOKENIZED_STRATEGY_ADDRESS, "TokenizedStrategy");
-        vm.label(management, "Management");
-        vm.label(keeper, "Keeper");
-        vm.label(emergencyAdmin, "Emergency Admin");
-        vm.label(donationAddress, "Donation Address");
     }
 
-    /// @notice Test creating a strategy through the factory for USDC Spark vault
-    function testCreateStrategyUSDC() public {
-        string memory strategyName = "Spark USDC Donating Strategy";
-
-        // Create a strategy and check events
-        vm.startPrank(management);
-        vm.expectEmit(true, true, true, false); // Check deployer, targetVault, and donationAddress; ignore strategy address
-        emit BaseERC4626StrategyFactory.StrategyDeploy(
-            management,
-            USDC_SPARK_VAULT,
-            donationAddress,
-            address(0),
-            strategyName
-        );
-
-        address strategyAddress = factory.createStrategy(
-            USDC_SPARK_VAULT,
-            USDC,
-            strategyName,
-            "osSparkUSDC",
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false, // enableBurning
-            address(implementation)
-        );
-        vm.stopPrank();
-
-        // Verify strategy is tracked in factory
-        (address deployerAddress, uint256 timestamp, string memory name, address stratDonationAddress) = factory
-            .strategies(management, 0);
-
-        assertEq(deployerAddress, management, "Deployer address incorrect in factory");
-        assertEq(name, strategyName, "Strategy name incorrect in factory");
-        assertEq(stratDonationAddress, donationAddress, "Donation address incorrect in factory");
-        assertTrue(timestamp > 0, "Timestamp should be set");
-
-        // Verify strategy was initialized correctly
-        ERC4626Strategy strategy = ERC4626Strategy(strategyAddress);
-        assertEq(IERC4626(address(strategy)).asset(), USDC, "Asset should be USDC");
-        assertEq(strategy.targetVault(), USDC_SPARK_VAULT, "Target vault should be USDC Spark vault");
+    function _computeStrategyAddress(
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                USDC_SPARK_VAULT,
+                USDC,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
     }
 
-    /// @notice Test creating a strategy through the factory for WETH Spark vault
+    // ========== SHARED TESTS ==========
+
+    /// @notice Test creating a strategy through the factory
+    function testCreateStrategyERC4626() public {
+        _testCreateStrategy("ERC4626 Vault Shares", "osERC4626");
+    }
+
+    /// @notice Test creating multiple strategies for the same user
+    function testMultipleStrategiesPerUserERC4626() public {
+        _testMultipleStrategiesPerUser("First ERC4626 Vault", "Second ERC4626 Vault");
+    }
+
+    /// @notice Test creating strategies for different users
+    function testMultipleUsersERC4626() public {
+        _testMultipleUsers();
+    }
+
+    /// @notice Test for deterministic addressing and duplicate prevention
+    function testDeterministicAddressingERC4626() public {
+        _testDeterministicAddressing();
+    }
+
+    /// @notice Test computeStrategyAddress matches actual deployment
+    function testComputeStrategyAddressMatchesDeploymentERC4626() public {
+        _testComputeStrategyAddressMatchesDeployment("ERC4626 Compute Test", "osERC4626_CT");
+    }
+
+    /// @notice Test computeStrategyAddress with different deployers
+    function testComputeStrategyAddressDifferentDeployersERC4626() public {
+        _testComputeStrategyAddressDifferentDeployers();
+    }
+
+    /// @notice Test computeStrategyAddress with different parameters
+    function testComputeStrategyAddressDifferentParamsERC4626() public {
+        _testComputeStrategyAddressDifferentParams();
+    }
+
+    // ========== ERC4626-SPECIFIC TESTS (multi-vault support) ==========
+
+    /// @notice Test creating a strategy for WETH Spark vault
     function testCreateStrategyWETH() public {
         string memory strategyName = "Spark WETH Donating Strategy";
 
-        // Create a strategy and check events
         vm.startPrank(management);
-        vm.expectEmit(true, true, true, false); // Check deployer, targetVault, and donationAddress; ignore strategy address
+        vm.expectEmit(true, true, true, false);
         emit BaseERC4626StrategyFactory.StrategyDeploy(
             management,
             WETH_SPARK_VAULT,
@@ -141,19 +172,10 @@ contract ERC4626StrategyFactoryTest is Test {
             keeper,
             emergencyAdmin,
             donationAddress,
-            false, // enableBurning
+            false,
             address(implementation)
         );
         vm.stopPrank();
-
-        // Verify strategy is tracked in factory
-        (address deployerAddress, uint256 timestamp, string memory name, address stratDonationAddress) = factory
-            .strategies(management, 0);
-
-        assertEq(deployerAddress, management, "Deployer address incorrect in factory");
-        assertEq(name, strategyName, "Strategy name incorrect in factory");
-        assertEq(stratDonationAddress, donationAddress, "Donation address incorrect in factory");
-        assertTrue(timestamp > 0, "Timestamp should be set");
 
         // Verify strategy was initialized correctly
         ERC4626Strategy strategy = ERC4626Strategy(strategyAddress);
@@ -161,178 +183,11 @@ contract ERC4626StrategyFactoryTest is Test {
         assertEq(strategy.targetVault(), WETH_SPARK_VAULT, "Target vault should be WETH Spark vault");
     }
 
-    /// @notice Test creating multiple strategies for the same user
-    function testMultipleStrategiesPerUser() public {
-        // Create first strategy (USDC)
-        string memory firstStrategyName = "First Spark USDC Strategy";
-
-        vm.startPrank(management);
-        address firstStrategyAddress = factory.createStrategy(
-            USDC_SPARK_VAULT,
-            USDC,
-            firstStrategyName,
-            "osSparkUSDC1",
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false, // enableBurning
-            address(implementation)
-        );
-
-        // Create second strategy (WETH) for same user
-        string memory secondStrategyName = "First Spark WETH Strategy";
-
-        address secondStrategyAddress = factory.createStrategy(
-            WETH_SPARK_VAULT,
-            WETH,
-            secondStrategyName,
-            "osSparkWETH1",
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false, // enableBurning
-            address(implementation)
-        );
-        vm.stopPrank();
-
-        // Verify both strategies exist
-        (address deployerAddress, , string memory name, ) = factory.strategies(management, 0);
-        assertEq(deployerAddress, management, "First deployer address incorrect");
-        assertEq(name, firstStrategyName, "First strategy name incorrect");
-
-        (deployerAddress, , name, ) = factory.strategies(management, 1);
-        assertEq(deployerAddress, management, "Second deployer address incorrect");
-        assertEq(name, secondStrategyName, "Second strategy name incorrect");
-
-        // Verify strategies are different
-        assertTrue(firstStrategyAddress != secondStrategyAddress, "Strategies should have different addresses");
-
-        // Verify they target different vaults
-        ERC4626Strategy firstStrategy = ERC4626Strategy(firstStrategyAddress);
-        ERC4626Strategy secondStrategy = ERC4626Strategy(secondStrategyAddress);
-        assertEq(firstStrategy.targetVault(), USDC_SPARK_VAULT, "First strategy should target USDC vault");
-        assertEq(secondStrategy.targetVault(), WETH_SPARK_VAULT, "Second strategy should target WETH vault");
-    }
-
-    /// @notice Test creating strategies for different users
-    function testMultipleUsers() public {
-        string memory firstStrategyName = "First User's USDC Strategy";
-        string memory secondStrategyName = "Second User's WETH Strategy";
-
-        address firstUser = address(0x5678);
-        address secondUser = address(0x9876);
-
-        // Create strategy for first user (USDC)
-        vm.startPrank(firstUser);
-        address firstStrategyAddress = factory.createStrategy(
-            USDC_SPARK_VAULT,
-            USDC,
-            firstStrategyName,
-            "osUser1USDC",
-            firstUser,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false, // enableBurning
-            address(implementation)
-        );
-        vm.stopPrank();
-
-        // Create strategy for second user (WETH)
-        vm.startPrank(secondUser);
-        address secondStrategyAddress = factory.createStrategy(
-            WETH_SPARK_VAULT,
-            WETH,
-            secondStrategyName,
-            "osUser2WETH",
-            secondUser,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false, // enableBurning
-            address(implementation)
-        );
-        vm.stopPrank();
-
-        // Verify strategies are properly tracked for each user
-        (address deployerAddress, , string memory name, ) = factory.strategies(firstUser, 0);
-        assertEq(deployerAddress, firstUser, "First user's deployer address incorrect");
-        assertEq(name, firstStrategyName, "First user's strategy name incorrect");
-
-        (deployerAddress, , name, ) = factory.strategies(secondUser, 0);
-        assertEq(deployerAddress, secondUser, "Second user's deployer address incorrect");
-        assertEq(name, secondStrategyName, "Second user's strategy name incorrect");
-
-        // Verify strategies are different
-        assertTrue(firstStrategyAddress != secondStrategyAddress, "Strategies should have different addresses");
-    }
-
-    /// @notice Test for deterministic addressing and duplicate prevention
-    function testDeterministicAddressing() public {
-        string memory strategyName = "Deterministic USDC Strategy";
-
-        // Create a strategy
-        vm.startPrank(management);
-        address firstAddress = factory.createStrategy(
-            USDC_SPARK_VAULT,
-            USDC,
-            strategyName,
-            "osDET",
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false, // enableBurning
-            address(implementation)
-        );
-        vm.stopPrank();
-
-        // Try to deploy the exact same strategy again - should revert
-        vm.startPrank(management);
-        vm.expectRevert(abi.encodeWithSelector(BaseStrategyFactory.StrategyAlreadyExists.selector, firstAddress));
-        factory.createStrategy(
-            USDC_SPARK_VAULT,
-            USDC,
-            strategyName,
-            "osDET",
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false, // enableBurning
-            address(implementation)
-        );
-        vm.stopPrank();
-
-        // Create a strategy with different parameters - should succeed
-        string memory differentName = "Different USDC Strategy";
-        vm.startPrank(management);
-        address secondAddress = factory.createStrategy(
-            USDC_SPARK_VAULT,
-            USDC,
-            differentName,
-            "osDIFF",
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false, // enableBurning
-            address(implementation)
-        );
-        vm.stopPrank();
-
-        // Different parameters should result in different address
-        assertTrue(firstAddress != secondAddress, "Different params should create different address");
-    }
-
     /// @notice Test creating strategy with different vault (same user, different target vault)
     function testDifferentVaultSameParams() public {
         string memory strategyName = "Same Name Different Vault";
 
         vm.startPrank(management);
-        // Create USDC strategy
         address usdcStrategyAddress = factory.createStrategy(
             USDC_SPARK_VAULT,
             USDC,
@@ -342,72 +197,66 @@ contract ERC4626StrategyFactoryTest is Test {
             keeper,
             emergencyAdmin,
             donationAddress,
-            false, // enableBurning
+            false,
             address(implementation)
         );
 
-        // Create WETH strategy with same name and params but different vault
         address wethStrategyAddress = factory.createStrategy(
             WETH_SPARK_VAULT,
             WETH,
-            strategyName, // Same name
-            "osSame1", // Same symbol
-            management, // Same management
-            keeper, // Same keeper
-            emergencyAdmin, // Same emergency admin
-            donationAddress, // Same donation address
-            false, // Same enableBurning
-            address(implementation) // Same implementation
+            strategyName,
+            "osSame1",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
         );
         vm.stopPrank();
 
-        // Should create different strategies since target vault is different
         assertTrue(
             usdcStrategyAddress != wethStrategyAddress,
             "Different target vaults should create different strategies"
         );
 
         // Verify both are tracked
-        (address deployerAddress, , , ) = factory.strategies(management, 0);
-        assertEq(deployerAddress, management, "First strategy should be tracked");
-        (deployerAddress, , , ) = factory.strategies(management, 1);
-        assertEq(deployerAddress, management, "Second strategy should be tracked");
+        ERC4626Strategy usdcStrategy = ERC4626Strategy(usdcStrategyAddress);
+        ERC4626Strategy wethStrategy = ERC4626Strategy(wethStrategyAddress);
+        assertEq(usdcStrategy.targetVault(), USDC_SPARK_VAULT, "First strategy should target USDC vault");
+        assertEq(wethStrategy.targetVault(), WETH_SPARK_VAULT, "Second strategy should target WETH vault");
     }
 
     /// @notice Test asset validation during strategy creation
     function testAssetValidation() public {
-        string memory strategyName = "Invalid Asset Strategy";
-
-        // Try to create strategy with wrong asset for USDC vault
         vm.startPrank(management);
         vm.expectRevert("Asset mismatch with target vault");
         factory.createStrategy(
             USDC_SPARK_VAULT,
             WETH, // Wrong asset - should be USDC
-            strategyName,
+            "Invalid Strategy",
             "osInvalid",
             management,
             keeper,
             emergencyAdmin,
             donationAddress,
-            false, // enableBurning
+            false,
             address(implementation)
         );
         vm.stopPrank();
 
-        // Try to create strategy with wrong asset for WETH vault
         vm.startPrank(management);
         vm.expectRevert("Asset mismatch with target vault");
         factory.createStrategy(
             WETH_SPARK_VAULT,
             USDC, // Wrong asset - should be WETH
-            strategyName,
+            "Invalid Strategy",
             "osInvalid",
             management,
             keeper,
             emergencyAdmin,
             donationAddress,
-            false, // enableBurning
+            false,
             address(implementation)
         );
         vm.stopPrank();
@@ -432,94 +281,7 @@ contract ERC4626StrategyFactoryTest is Test {
         );
         vm.stopPrank();
 
-        // Verify strategy was created successfully
         assertTrue(strategyAddress != address(0), "Strategy should be deployed");
-
-        // Verify it's tracked in factory
-        (address deployerAddress, , string memory name, ) = factory.strategies(management, 0);
-        assertEq(deployerAddress, management, "Deployer should be tracked");
-        assertEq(name, strategyName, "Name should match");
-    }
-
-    // ========== COMPUTE STRATEGY ADDRESS TESTS ==========
-
-    /// @notice Test computeStrategyAddress matches actual deployment
-    function testComputeStrategyAddressMatchesDeployment() public {
-        string memory strategyName = "Compute Test Strategy";
-        string memory symbol = "osCT";
-
-        // Compute expected address before deployment
-        address expectedAddress = factory.computeStrategyAddress(
-            USDC_SPARK_VAULT,
-            USDC,
-            strategyName,
-            symbol,
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false,
-            address(implementation),
-            management
-        );
-
-        // Deploy the strategy
-        vm.startPrank(management);
-        address actualAddress = factory.createStrategy(
-            USDC_SPARK_VAULT,
-            USDC,
-            strategyName,
-            symbol,
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false,
-            address(implementation)
-        );
-        vm.stopPrank();
-
-        // Verify computed address matches actual deployment
-        assertEq(expectedAddress, actualAddress, "Computed address should match deployed address");
-    }
-
-    /// @notice Test computeStrategyAddress with different deployers produces different addresses
-    function testComputeStrategyAddressDifferentDeployers() public view {
-        string memory strategyName = "Deployer Test Strategy";
-        string memory symbol = "osDEP";
-
-        address deployer1 = address(0x1111);
-        address deployer2 = address(0x2222);
-
-        address addr1 = factory.computeStrategyAddress(
-            USDC_SPARK_VAULT,
-            USDC,
-            strategyName,
-            symbol,
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false,
-            address(implementation),
-            deployer1
-        );
-
-        address addr2 = factory.computeStrategyAddress(
-            USDC_SPARK_VAULT,
-            USDC,
-            strategyName,
-            symbol,
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false,
-            address(implementation),
-            deployer2
-        );
-
-        assertTrue(addr1 != addr2, "Different deployers should produce different addresses");
     }
 
     /// @notice Test computeStrategyAddress with different vaults produces different addresses
@@ -555,41 +317,5 @@ contract ERC4626StrategyFactoryTest is Test {
         );
 
         assertTrue(addr1 != addr2, "Different vaults should produce different addresses");
-    }
-
-    /// @notice Test computeStrategyAddress with same params produces same address
-    function testComputeStrategyAddressSameParams() public view {
-        string memory strategyName = "Same Params Strategy";
-        string memory symbol = "osSP";
-
-        address addr1 = factory.computeStrategyAddress(
-            USDC_SPARK_VAULT,
-            USDC,
-            strategyName,
-            symbol,
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false,
-            address(implementation),
-            management
-        );
-
-        address addr2 = factory.computeStrategyAddress(
-            USDC_SPARK_VAULT,
-            USDC,
-            strategyName,
-            symbol,
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            false,
-            address(implementation),
-            management
-        );
-
-        assertEq(addr1, addr2, "Same params should produce same address");
     }
 }

--- a/test/integration/factories/LidoStrategyFactory.t.sol
+++ b/test/integration/factories/LidoStrategyFactory.t.sol
@@ -74,6 +74,60 @@ contract LidoStrategyFactoryTest is BaseFactoryIntegrationTest {
         vm.label(TOKENIZED_STRATEGY_ADDRESS, "TokenizedStrategy");
     }
 
+    function _vault() internal pure override returns (address) {
+        return WSTETH;
+    }
+
+    function _factoryValidatesVaultAsset() internal pure override returns (bool) {
+        return true;
+    }
+
+    function _computeStrategyAddress(
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                WSTETH,
+                WSTETH,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
+    }
+
+    function _computeStrategyAddressWithVault(
+        address vault,
+        address asset,
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                vault,
+                asset,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
+    }
+
     // ========== CONCRETE TESTS ==========
 
     /// @notice Test creating a strategy through the factory
@@ -94,5 +148,30 @@ contract LidoStrategyFactoryTest is BaseFactoryIntegrationTest {
     /// @notice Test for deterministic addressing and duplicate prevention
     function testDeterministicAddressingLido() public {
         _testDeterministicAddressing();
+    }
+
+    /// @notice Test computeStrategyAddress matches actual deployment
+    function testComputeStrategyAddressMatchesDeploymentLido() public {
+        _testComputeStrategyAddressMatchesDeployment("Lido Compute Test", "osLIDO_CT");
+    }
+
+    /// @notice Test computeStrategyAddress with different deployers
+    function testComputeStrategyAddressDifferentDeployersLido() public {
+        _testComputeStrategyAddressDifferentDeployers();
+    }
+
+    /// @notice Test computeStrategyAddress with different parameters
+    function testComputeStrategyAddressDifferentParamsLido() public {
+        _testComputeStrategyAddressDifferentParams();
+    }
+
+    /// @notice Test computeStrategyAddress reverts on invalid vault
+    function testComputeStrategyAddressInvalidVaultLido() public {
+        _testComputeStrategyAddressInvalidVault();
+    }
+
+    /// @notice Test computeStrategyAddress reverts on invalid asset
+    function testComputeStrategyAddressInvalidAssetLido() public {
+        _testComputeStrategyAddressInvalidAsset();
     }
 }

--- a/test/integration/factories/MorphoCompounderStrategyFactory.t.sol
+++ b/test/integration/factories/MorphoCompounderStrategyFactory.t.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.25;
 
 import { BaseFactoryIntegrationTest } from "test/integration/factories/base/BaseFactoryIntegrationTest.sol";
-import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
 import { MorphoCompounderStrategyFactory } from "src/factories/MorphoCompounderStrategyFactory.sol";
 import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
 
@@ -76,6 +75,60 @@ contract MorphoCompounderStrategyFactoryTest is BaseFactoryIntegrationTest {
         vm.label(TOKENIZED_STRATEGY_ADDRESS, "TokenizedStrategy");
     }
 
+    function _vault() internal pure override returns (address) {
+        return YIELD_VAULT;
+    }
+
+    function _factoryValidatesVaultAsset() internal pure override returns (bool) {
+        return true;
+    }
+
+    function _computeStrategyAddress(
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                YIELD_VAULT,
+                USDC,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
+    }
+
+    function _computeStrategyAddressWithVault(
+        address vault,
+        address asset,
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                vault,
+                asset,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
+    }
+
     // ========== CONCRETE TESTS ==========
 
     /// @notice Test creating a strategy through the factory
@@ -96,5 +149,30 @@ contract MorphoCompounderStrategyFactoryTest is BaseFactoryIntegrationTest {
     /// @notice Test for deterministic addressing and duplicate prevention
     function testDeterministicAddressingMorpho() public {
         _testDeterministicAddressing();
+    }
+
+    /// @notice Test computeStrategyAddress matches actual deployment
+    function testComputeStrategyAddressMatchesDeploymentMorpho() public {
+        _testComputeStrategyAddressMatchesDeployment("Morpho Compute Test", "osMORPHO_CT");
+    }
+
+    /// @notice Test computeStrategyAddress with different deployers
+    function testComputeStrategyAddressDifferentDeployersMorpho() public {
+        _testComputeStrategyAddressDifferentDeployers();
+    }
+
+    /// @notice Test computeStrategyAddress with different parameters
+    function testComputeStrategyAddressDifferentParamsMorpho() public {
+        _testComputeStrategyAddressDifferentParams();
+    }
+
+    /// @notice Test computeStrategyAddress reverts on invalid vault
+    function testComputeStrategyAddressInvalidVaultMorpho() public {
+        _testComputeStrategyAddressInvalidVault();
+    }
+
+    /// @notice Test computeStrategyAddress reverts on invalid asset
+    function testComputeStrategyAddressInvalidAssetMorpho() public {
+        _testComputeStrategyAddressInvalidAsset();
     }
 }

--- a/test/integration/factories/RocketPoolStrategyFactory.t.sol
+++ b/test/integration/factories/RocketPoolStrategyFactory.t.sol
@@ -74,6 +74,60 @@ contract RocketPoolStrategyFactoryTest is BaseFactoryIntegrationTest {
         vm.label(TOKENIZED_STRATEGY_ADDRESS, "TokenizedStrategy");
     }
 
+    function _vault() internal pure override returns (address) {
+        return R_ETH;
+    }
+
+    function _factoryValidatesVaultAsset() internal pure override returns (bool) {
+        return true;
+    }
+
+    function _computeStrategyAddress(
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                R_ETH,
+                R_ETH,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
+    }
+
+    function _computeStrategyAddressWithVault(
+        address vault,
+        address asset,
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                vault,
+                asset,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
+    }
+
     // ========== CONCRETE TESTS ==========
 
     /// @notice Test creating a strategy through the factory
@@ -94,5 +148,30 @@ contract RocketPoolStrategyFactoryTest is BaseFactoryIntegrationTest {
     /// @notice Test for deterministic addressing and duplicate prevention
     function testDeterministicAddressingRocketPool() public {
         _testDeterministicAddressing();
+    }
+
+    /// @notice Test computeStrategyAddress matches actual deployment
+    function testComputeStrategyAddressMatchesDeploymentRocketPool() public {
+        _testComputeStrategyAddressMatchesDeployment("RocketPool Compute Test", "osRPL_CT");
+    }
+
+    /// @notice Test computeStrategyAddress with different deployers
+    function testComputeStrategyAddressDifferentDeployersRocketPool() public {
+        _testComputeStrategyAddressDifferentDeployers();
+    }
+
+    /// @notice Test computeStrategyAddress with different parameters
+    function testComputeStrategyAddressDifferentParamsRocketPool() public {
+        _testComputeStrategyAddressDifferentParams();
+    }
+
+    /// @notice Test computeStrategyAddress reverts on invalid vault
+    function testComputeStrategyAddressInvalidVaultRocketPool() public {
+        _testComputeStrategyAddressInvalidVault();
+    }
+
+    /// @notice Test computeStrategyAddress reverts on invalid asset
+    function testComputeStrategyAddressInvalidAssetRocketPool() public {
+        _testComputeStrategyAddressInvalidAsset();
     }
 }

--- a/test/integration/factories/SkyCompounderStrategyFactory.t.sol
+++ b/test/integration/factories/SkyCompounderStrategyFactory.t.sol
@@ -79,6 +79,60 @@ contract SkyCompounderStrategyFactoryTest is BaseFactoryIntegrationTest {
         vm.label(TOKENIZED_STRATEGY_ADDRESS, "TokenizedStrategy");
     }
 
+    function _vault() internal pure override returns (address) {
+        return STAKING;
+    }
+
+    function _factoryValidatesVaultAsset() internal pure override returns (bool) {
+        return true;
+    }
+
+    function _computeStrategyAddress(
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                STAKING,
+                USDS,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                true, // enableBurning
+                address(tokenizedStrategy),
+                deployer
+            );
+    }
+
+    function _computeStrategyAddressWithVault(
+        address vault,
+        address asset,
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                vault,
+                asset,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                true, // enableBurning
+                address(tokenizedStrategy),
+                deployer
+            );
+    }
+
     // ========== CONCRETE TESTS ==========
 
     /// @notice Test creating a strategy through the factory
@@ -99,5 +153,30 @@ contract SkyCompounderStrategyFactoryTest is BaseFactoryIntegrationTest {
     /// @notice Test for deterministic addressing and duplicate prevention
     function testDeterministicAddressingSky() public {
         _testDeterministicAddressing();
+    }
+
+    /// @notice Test computeStrategyAddress matches actual deployment
+    function testComputeStrategyAddressMatchesDeploymentSky() public {
+        _testComputeStrategyAddressMatchesDeployment("Sky Compute Test", "osSKY_CT");
+    }
+
+    /// @notice Test computeStrategyAddress with different deployers
+    function testComputeStrategyAddressDifferentDeployersSky() public {
+        _testComputeStrategyAddressDifferentDeployers();
+    }
+
+    /// @notice Test computeStrategyAddress with different parameters
+    function testComputeStrategyAddressDifferentParamsSky() public {
+        _testComputeStrategyAddressDifferentParams();
+    }
+
+    /// @notice Test computeStrategyAddress reverts on invalid vault
+    function testComputeStrategyAddressInvalidVaultSky() public {
+        _testComputeStrategyAddressInvalidVault();
+    }
+
+    /// @notice Test computeStrategyAddress reverts on invalid asset
+    function testComputeStrategyAddressInvalidAssetSky() public {
+        _testComputeStrategyAddressInvalidAsset();
     }
 }

--- a/test/integration/factories/SparkStrategyFactory.t.sol
+++ b/test/integration/factories/SparkStrategyFactory.t.sol
@@ -75,6 +75,32 @@ contract SparkStrategyFactoryTest is BaseFactoryIntegrationTest {
         vm.label(SparkTestConfig.TOKENIZED_STRATEGY_ADDRESS, "TokenizedStrategy");
     }
 
+    function _vault() internal pure override returns (address) {
+        return SparkTestConfig.USDC_SPARK_VAULT;
+    }
+
+    function _computeStrategyAddress(
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                SparkTestConfig.USDC_SPARK_VAULT,
+                SparkTestConfig.USDC,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
+    }
+
     // ========== CONCRETE TESTS ==========
 
     /// @notice Test creating a strategy through the factory
@@ -137,5 +163,20 @@ contract SparkStrategyFactoryTest is BaseFactoryIntegrationTest {
         SparkStrategy strategy = SparkStrategy(strategyAddress);
         assertEq(strategy.targetVault(), SparkTestConfig.WETH_SPARK_VAULT, "Target vault incorrect");
         assertEq(IERC4626(strategyAddress).asset(), SparkTestConfig.WETH, "Asset incorrect");
+    }
+
+    /// @notice Test computeStrategyAddress matches actual deployment
+    function testComputeStrategyAddressMatchesDeploymentSpark() public {
+        _testComputeStrategyAddressMatchesDeployment("Spark Compute Test", "osSpark_CT");
+    }
+
+    /// @notice Test computeStrategyAddress with different deployers
+    function testComputeStrategyAddressDifferentDeployersSpark() public {
+        _testComputeStrategyAddressDifferentDeployers();
+    }
+
+    /// @notice Test computeStrategyAddress with different parameters
+    function testComputeStrategyAddressDifferentParamsSpark() public {
+        _testComputeStrategyAddressDifferentParams();
     }
 }

--- a/test/integration/factories/YearnV3StrategyFactory.t.sol
+++ b/test/integration/factories/YearnV3StrategyFactory.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { BaseFactoryIntegrationTest } from "test/integration/factories/base/BaseFactoryIntegrationTest.sol";
+import { YearnV3StrategyFactory } from "src/factories/yieldDonating/YearnV3StrategyFactory.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { YearnV3TestConfig } from "test/integration/strategies/config/YearnV3TestConfig.sol";
+
+/// @title YearnV3StrategyFactory Test
+/// @author Octant
+/// @notice Integration tests for the YearnV3StrategyFactory using a mainnet fork
+contract YearnV3StrategyFactoryTest is BaseFactoryIntegrationTest {
+    // Factory and implementation
+    YearnV3StrategyFactory public factory;
+    YieldDonatingTokenizedStrategy public implementation;
+
+    function setUp() public {
+        _baseSetUp();
+    }
+
+    // ========== ABSTRACT IMPLEMENTATIONS ==========
+
+    function _factory() internal view override returns (address) {
+        return address(factory);
+    }
+
+    function _implementation() internal view override returns (address) {
+        return address(implementation);
+    }
+
+    function _asset() internal pure override returns (address) {
+        return YearnV3TestConfig.USDC;
+    }
+
+    function _vault() internal pure override returns (address) {
+        return YearnV3TestConfig.YEARN_V3_USDC_VAULT;
+    }
+
+    function _strategySymbolPrefix() internal pure override returns (string memory) {
+        return "osYEARN";
+    }
+
+    function _deployFactory() internal override {
+        factory = new YearnV3StrategyFactory();
+    }
+
+    function _deployImplementation() internal override returns (address) {
+        implementation = new YieldDonatingTokenizedStrategy{ salt: keccak256("OCT_YIELD_DONATING_STRATEGY_V1") }();
+        vm.etch(YearnV3TestConfig.TOKENIZED_STRATEGY_ADDRESS, address(implementation).code);
+        return address(implementation);
+    }
+
+    function _createStrategy(
+        string memory name,
+        string memory symbol,
+        address mgmt
+    ) internal override returns (address) {
+        return
+            factory.createStrategy(
+                YearnV3TestConfig.YEARN_V3_USDC_VAULT,
+                YearnV3TestConfig.USDC,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation)
+            );
+    }
+
+    function _labelFactoryAddresses() internal override {
+        vm.label(address(factory), "YearnV3StrategyFactory");
+        vm.label(YearnV3TestConfig.USDC, "USDC");
+        vm.label(YearnV3TestConfig.YEARN_V3_USDC_VAULT, "YearnV3USDCVault");
+        vm.label(YearnV3TestConfig.TOKENIZED_STRATEGY_ADDRESS, "TokenizedStrategy");
+    }
+
+    function _computeStrategyAddress(
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view override returns (address) {
+        return
+            factory.computeStrategyAddress(
+                YearnV3TestConfig.YEARN_V3_USDC_VAULT,
+                YearnV3TestConfig.USDC,
+                name,
+                symbol,
+                mgmt,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false, // enableBurning
+                address(implementation),
+                deployer
+            );
+    }
+
+    // ========== CONCRETE TESTS ==========
+
+    /// @notice Test creating a strategy through the factory
+    function testCreateStrategyYearnV3() public {
+        _testCreateStrategy("YearnV3 Vault Shares", "osYEARN");
+    }
+
+    /// @notice Test creating multiple strategies for the same user
+    function testMultipleStrategiesPerUserYearnV3() public {
+        _testMultipleStrategiesPerUser("First YearnV3 Vault", "Second YearnV3 Vault");
+    }
+
+    /// @notice Test creating strategies for different users
+    function testMultipleUsersYearnV3() public {
+        _testMultipleUsers();
+    }
+
+    /// @notice Test for deterministic addressing and duplicate prevention
+    function testDeterministicAddressingYearnV3() public {
+        _testDeterministicAddressing();
+    }
+
+    /// @notice Test computeStrategyAddress matches actual deployment
+    function testComputeStrategyAddressMatchesDeploymentYearnV3() public {
+        _testComputeStrategyAddressMatchesDeployment("YearnV3 Compute Test", "osYEARN_CT");
+    }
+
+    /// @notice Test computeStrategyAddress with different deployers
+    function testComputeStrategyAddressDifferentDeployersYearnV3() public {
+        _testComputeStrategyAddressDifferentDeployers();
+    }
+
+    /// @notice Test computeStrategyAddress with different parameters
+    function testComputeStrategyAddressDifferentParamsYearnV3() public {
+        _testComputeStrategyAddressDifferentParams();
+    }
+
+    /// @notice Test that YearnV3-specific info is stored correctly
+    function testYearnV3SpecificInfoStored() public {
+        vm.startPrank(management);
+        address strategyAddress = _createStrategy("YearnV3 Info Test", "osYEARN_IT", management);
+        vm.stopPrank();
+
+        address storedManagement = factory.yearnV3StrategyInfo(strategyAddress);
+        assertEq(storedManagement, management, "Management address should be stored in YearnV3-specific info");
+    }
+}

--- a/test/integration/factories/base/BaseFactoryIntegrationTest.sol
+++ b/test/integration/factories/base/BaseFactoryIntegrationTest.sol
@@ -41,6 +41,15 @@ abstract contract BaseFactoryIntegrationTest is Test {
     /// @notice Returns the expected asset address for strategies
     function _asset() internal pure virtual returns (address);
 
+    /// @notice Returns the expected vault address for strategies (used by computeStrategyAddress)
+    function _vault() internal view virtual returns (address);
+
+    /// @notice Returns true if the factory validates vault/asset parameters
+    /// @dev Override to return true for factories with hardcoded vault/asset that validate inputs
+    function _factoryValidatesVaultAsset() internal pure virtual returns (bool) {
+        return false;
+    }
+
     /// @notice Returns the strategy symbol prefix
     function _strategySymbolPrefix() internal pure virtual returns (string memory);
 
@@ -59,6 +68,19 @@ abstract contract BaseFactoryIntegrationTest is Test {
 
     /// @notice Labels factory-specific addresses
     function _labelFactoryAddresses() internal virtual;
+
+    /// @notice Computes the strategy address using the factory's computeStrategyAddress function
+    /// @param name The strategy name
+    /// @param symbol The strategy symbol
+    /// @param mgmt The management address
+    /// @param deployer The deployer address
+    /// @return The computed strategy address
+    function _computeStrategyAddress(
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view virtual returns (address);
 
     // ========== SHARED SETUP ==========
 
@@ -185,5 +207,108 @@ abstract contract BaseFactoryIntegrationTest is Test {
         vm.stopPrank();
 
         assertTrue(firstAddr != secondAddr, "Different params should create different address");
+    }
+
+    /// @notice Shared test: computeStrategyAddress matches actual deployment
+    /// @param vaultName The vault name to use
+    /// @param symbol The symbol to use
+    function _testComputeStrategyAddressMatchesDeployment(
+        string memory vaultName,
+        string memory symbol
+    ) internal virtual {
+        // Compute expected address before deployment
+        address expectedAddress = _computeStrategyAddress(vaultName, symbol, management, management);
+
+        // Deploy the strategy
+        vm.startPrank(management);
+        address actualAddress = _createStrategy(vaultName, symbol, management);
+        vm.stopPrank();
+
+        // Verify computed address matches actual deployment
+        assertEq(expectedAddress, actualAddress, "Computed address should match deployed address");
+    }
+
+    /// @notice Shared test: computeStrategyAddress with different deployers
+    function _testComputeStrategyAddressDifferentDeployers() internal virtual {
+        string memory vaultName = "Deployer Test Vault";
+        string memory symbol = string.concat(_strategySymbolPrefix(), "DEP");
+
+        address deployer1 = address(0x1111);
+        address deployer2 = address(0x2222);
+
+        // Compute addresses for different deployers
+        address addr1 = _computeStrategyAddress(vaultName, symbol, management, deployer1);
+        address addr2 = _computeStrategyAddress(vaultName, symbol, management, deployer2);
+
+        // Different deployers should result in different addresses
+        assertTrue(addr1 != addr2, "Different deployers should produce different addresses");
+    }
+
+    /// @notice Shared test: computeStrategyAddress with different parameters
+    function _testComputeStrategyAddressDifferentParams() internal virtual {
+        string memory symbol = string.concat(_strategySymbolPrefix(), "PARAM");
+
+        // Same params should give same address
+        address addr1 = _computeStrategyAddress("Same Vault", symbol, management, management);
+        address addr2 = _computeStrategyAddress("Same Vault", symbol, management, management);
+        assertEq(addr1, addr2, "Same params should produce same address");
+
+        // Different name should give different address
+        address addr3 = _computeStrategyAddress("Different Vault", symbol, management, management);
+        assertTrue(addr1 != addr3, "Different name should produce different address");
+
+        // Different symbol should give different address
+        address addr4 = _computeStrategyAddress("Same Vault", "DIFF", management, management);
+        assertTrue(addr1 != addr4, "Different symbol should produce different address");
+    }
+
+    /// @notice Shared test: computeStrategyAddress reverts on invalid vault (for factories with validation)
+    /// @dev Only call this for factories where _factoryValidatesVaultAsset() returns true
+    function _testComputeStrategyAddressInvalidVault() internal virtual {
+        require(_factoryValidatesVaultAsset(), "Factory does not validate vault/asset");
+
+        address invalidVault = address(0xDEAD);
+        string memory name = "Invalid Vault Test";
+        string memory symbol = string.concat(_strategySymbolPrefix(), "INV");
+
+        vm.expectRevert(abi.encodeWithSelector(BaseStrategyFactory.InvalidVault.selector, invalidVault, _vault()));
+
+        // Call computeStrategyAddress with invalid vault - this will need to be implemented
+        // by calling the factory's computeStrategyAddress directly with the invalid vault
+        _computeStrategyAddressWithVault(invalidVault, _asset(), name, symbol, management, management);
+    }
+
+    /// @notice Shared test: computeStrategyAddress reverts on invalid asset (for factories with validation)
+    /// @dev Only call this for factories where _factoryValidatesVaultAsset() returns true
+    function _testComputeStrategyAddressInvalidAsset() internal virtual {
+        require(_factoryValidatesVaultAsset(), "Factory does not validate vault/asset");
+
+        address invalidAsset = address(0xBEEF);
+        string memory name = "Invalid Asset Test";
+        string memory symbol = string.concat(_strategySymbolPrefix(), "INV");
+
+        vm.expectRevert(abi.encodeWithSelector(BaseStrategyFactory.InvalidAsset.selector, invalidAsset, _asset()));
+
+        _computeStrategyAddressWithVault(_vault(), invalidAsset, name, symbol, management, management);
+    }
+
+    /// @notice Helper to call computeStrategyAddress with custom vault/asset (for validation tests)
+    /// @dev Override in factories that need to test invalid vault/asset validation
+    function _computeStrategyAddressWithVault(
+        address vault,
+        address asset,
+        string memory name,
+        string memory symbol,
+        address mgmt,
+        address deployer
+    ) internal view virtual returns (address) {
+        // Default implementation - override in factory tests that validate vault/asset
+        vault;
+        asset;
+        name;
+        symbol;
+        mgmt;
+        deployer;
+        revert("Override _computeStrategyAddressWithVault for vault/asset validation tests");
     }
 }

--- a/test/integration/strategies/YieldDonating/factories/MorphoCompounderVaultFactory.t.sol
+++ b/test/integration/strategies/YieldDonating/factories/MorphoCompounderVaultFactory.t.sol
@@ -78,40 +78,20 @@ contract MorphoCompounderDonatingVaultFactoryTest is Test {
 
         string memory vaultSymbol = "osMORPHO";
 
-        // Generate parameter hash for prediction
-        bytes32 parameterHash = keccak256(
-            abi.encode(
-                0x074134A2784F4F66b6ceD6f68849382990Ff3215, // YS_USDC
-                0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, // USDC
-                vaultSharesName,
-                vaultSymbol,
-                management,
-                keeper,
-                emergencyAdmin,
-                donationAddress,
-                false, // enableBurning
-                address(implementation)
-            )
+        // Predict address using computeStrategyAddress
+        address expectedStrategyAddress = factory.computeStrategyAddress(
+            0x074134A2784F4F66b6ceD6f68849382990Ff3215, // YS_USDC (vault)
+            0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, // USDC (asset)
+            vaultSharesName,
+            vaultSymbol,
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false, // enableBurning
+            address(implementation),
+            management // deployer
         );
-
-        // Build the bytecode for address prediction
-        bytes memory bytecode = abi.encodePacked(
-            type(MorphoCompounderStrategy).creationCode,
-            abi.encode(
-                0x074134A2784F4F66b6ceD6f68849382990Ff3215, // YS_USDC
-                0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, // USDC
-                vaultSharesName,
-                vaultSymbol,
-                management,
-                keeper,
-                emergencyAdmin,
-                donationAddress,
-                false, // enableBurning
-                address(implementation)
-            )
-        );
-
-        address expectedStrategyAddress = factory.predictStrategyAddress(parameterHash, management, bytecode);
 
         // Create a strategy and check events
         vm.startPrank(management);


### PR DESCRIPTION
# PR: Add `computeStrategyAddress` to Strategy Factories

## Summary

This PR introduces a unified `computeStrategyAddress()` function across all strategy factories, enabling deterministic address prediction before deployment using CREATE2.

## Changes

### New Feature: `computeStrategyAddress()`

- **Added abstract function to `BaseStrategyFactory`** with unified ABI accepting vault, asset, and all strategy parameters
- **Implemented in all 8 strategy factories:**
  - `AaveV3StrategyFactory`
  - `BaseERC4626StrategyFactory`
  - `LidoStrategyFactory`
  - `MorphoCompounderStrategyFactory`
  - `SkyCompounderStrategyFactory`
  - `YearnV3StrategyFactory`
  - `RocketPoolStrategyFactory`


### Test Infrastructure

- **Extended `BaseFactoryIntegrationTest`** with:
  - `_vault()` - returns expected vault address
  - `_computeStrategyAddress()` - calls factory's compute function
  - `_factoryValidatesVaultAsset()` - indicates if factory validates inputs
  - `_computeStrategyAddressWithVault()` - helper for validation tests

- **New shared tests:**
  - `_testComputeStrategyAddressMatchesDeployment()` - verifies predicted address equals deployed
  - `_testComputeStrategyAddressDifferentDeployers()` - different deployers produce different addresses
  - `_testComputeStrategyAddressDifferentParams()` - different params produce different addresses
  - `_testComputeStrategyAddressInvalidVault()` - reverts on wrong vault
  - `_testComputeStrategyAddressInvalidAsset()` - reverts on wrong asset

- **Refactored `ERC4626StrategyFactory.t.sol`** to use `BaseFactoryIntegrationTest` 