### PR TITLE
VAULT006: burn dragon buffer before user withdrawals

### DIFF
--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -165,6 +165,10 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         StrategyData storage S = _strategyStorage();
         YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
 
+        if (owner != S.dragonRouter) {
+            _applyLossProtectionIfNeeded(S, YS);
+        }
+
         // Dragon cannot withdraw during insolvency - must protect users
         _requireDragonSolvency(owner);
 
@@ -216,6 +220,10 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
     ) public override nonReentrant returns (uint256 shares) {
         StrategyData storage S = _strategyStorage();
         YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
+
+        if (owner != S.dragonRouter) {
+            _applyLossProtectionIfNeeded(S, YS);
+        }
 
         // Dragon cannot withdraw during insolvency - must protect users
         _requireDragonSolvency(owner);
@@ -654,6 +662,23 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             return exchangeRate * 10 ** (27 - exchangeRateDecimals);
         } else {
             return exchangeRate / 10 ** (exchangeRateDecimals - 27);
+        }
+    }
+
+    /**
+     * @dev Burns dragon shares to cover losses if the current value is below total debt.
+     */
+    function _applyLossProtectionIfNeeded(StrategyData storage S, YieldSkimmingStorage storage YS) internal {
+        if (!S.enableBurning) {
+            return;
+        }
+
+        uint256 currentRate = _currentRateRay();
+        uint256 currentVaultValue = S.totalAssets.mulDiv(currentRate, WadRayMath.RAY);
+        uint256 totalDebt = YS.totalDebtOwedToUserInAssetValue + YS.dragonRouterDebtInAssetValue;
+
+        if (currentVaultValue < totalDebt) {
+            _handleDragonLossProtection(S, YS, totalDebt - currentVaultValue, currentRate);
         }
     }
 

--- a/test/unit/strategies/yieldSkimming/Accounting.t.sol
+++ b/test/unit/strategies/yieldSkimming/Accounting.t.sol
@@ -1546,6 +1546,51 @@ contract AccountingTest is Setup {
         assertLt(dragonSharesAfterLoss, dragonShares, "Dragon shares should be burned to handle loss");
     }
 
+    function test_redeem_burns_dragon_buffer_before_report() public {
+        address alice = makeAddr("alice");
+        uint256 depositAmount = 100e18;
+
+        _primeDragonProfitThenLoss(alice, depositAmount);
+
+        uint256 aliceShares = strategy.balanceOf(alice);
+        vm.prank(alice);
+        uint256 assetsOut = strategy.redeem(aliceShares, alice, alice);
+
+        assertEq(assetsOut, depositAmount, "user should be made whole by dragon buffer");
+        assertEq(strategy.balanceOf(donationAddress), 0, "dragon shares should be burned on loss");
+    }
+
+    function test_withdraw_burns_dragon_buffer_before_report() public {
+        address alice = makeAddr("alice");
+        uint256 depositAmount = 100e18;
+
+        _primeDragonProfitThenLoss(alice, depositAmount);
+
+        vm.prank(alice);
+        uint256 sharesBurned = strategy.withdraw(depositAmount, alice, alice);
+
+        assertEq(sharesBurned, depositAmount, "shares burned should match requested assets");
+        assertEq(strategy.balanceOf(donationAddress), 0, "dragon shares should be burned on loss");
+        assertEq(strategy.balanceOf(alice), 0, "user shares should be fully redeemed");
+    }
+
+    function _primeDragonProfitThenLoss(address alice, uint256 depositAmount) internal returns (uint256 dragonShares) {
+        vm.startPrank(management);
+        strategy.setEnableBurning(true);
+        vm.stopPrank();
+
+        mintAndDepositIntoStrategy(strategy, alice, depositAmount);
+
+        MockStrategySkimming(address(strategy)).updateExchangeRate(15e17);
+        vm.prank(keeper);
+        strategy.report();
+
+        dragonShares = strategy.balanceOf(donationAddress);
+        assertGt(dragonShares, 0, "dragon should have shares");
+
+        MockStrategySkimming(address(strategy)).updateExchangeRate(1e18);
+    }
+
     struct DragonRouterChangeVars {
         address oldDragonRouter;
         address newDragonRouter;


### PR DESCRIPTION
## Summary
- burn dragon shares on user withdraw/redeem when the vault value is below total debt
- keep user withdrawals whole even if report() has not run yet
- add yield skimming accounting tests to cover pre-report loss protection

## Testing
- forge test --match-path test/unit/strategies/yieldSkimming/Accounting.t.sol -vv