### PR TITLE
VAULT007: guard max deposit/mint at zero rate

### DIFF
--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -271,6 +271,9 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      */
     function maxDeposit(address receiver) public view virtual override returns (uint256) {
         StrategyData storage S = _strategyStorage();
+        if (_currentRateRay() == 0) {
+            return 0;
+        }
         if (receiver == S.dragonRouter || _isVaultInsolvent()) {
             return 0;
         }
@@ -285,6 +288,9 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      */
     function maxMint(address receiver) public view virtual override returns (uint256) {
         StrategyData storage S = _strategyStorage();
+        if (_currentRateRay() == 0) {
+            return 0;
+        }
         if (receiver == S.dragonRouter || _isVaultInsolvent()) {
             return 0;
         }

--- a/test/unit/strategies/yieldSkimming/Accounting.t.sol
+++ b/test/unit/strategies/yieldSkimming/Accounting.t.sol
@@ -599,6 +599,22 @@ contract AccountingTest is Setup {
         assertEq(strategy.balanceOf(donationAddress), 0, "Donation address should have no shares");
     }
 
+    function test_maxDeposit_maxMint_return_zero_when_rate_zero() public {
+        address alice = makeAddr("alice");
+        MockStrategySkimming(address(strategy)).updateExchangeRate(0);
+
+        assertEq(strategy.maxDeposit(alice), 0, "maxDeposit should be zero at rate 0");
+        assertEq(strategy.maxMint(alice), 0, "maxMint should be zero at rate 0");
+
+        vm.prank(alice);
+        vm.expectRevert();
+        strategy.deposit(1e18, alice);
+
+        vm.prank(alice);
+        vm.expectRevert();
+        strategy.mint(1e18, alice);
+    }
+
     // ===== DEFICIT ADJUSTMENT TESTS =====
     /**
      * @notice Test invariant: Depositors during loss period cannot withdraw more underlying value than deposited


### PR DESCRIPTION
## Summary
- return 0 from maxDeposit/maxMint when the exchange rate is zero
- add a yield skimming accounting regression test for the zero-rate edge case

## Testing
- forge test --match-path test/unit/strategies/yieldSkimming/Accounting.t.sol -vv