### PR TITLE
fix: _buildDomainSeparator in TokenizedStrategy

### DIFF
--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -5,7 +5,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import { TokenizedStrategy__InvalidSigner, TokenizedStrategy__NameImmutable } from "src/errors.sol";
+import { TokenizedStrategy__InvalidSigner } from "src/errors.sol";
 
 import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
 
@@ -170,6 +170,12 @@ abstract contract TokenizedStrategy {
      */
     event UpdateBurningMechanism(bool enableBurning);
 
+    /**
+     * @notice Emitted when the strategy name is updated.
+     * @param newName The new name of the strategy
+     */
+    event UpdateName(string newName);
+
     /*//////////////////////////////////////////////////////////////
                         STORAGE STRUCT
     //////////////////////////////////////////////////////////////*/
@@ -230,10 +236,14 @@ abstract contract TokenizedStrategy {
         /// @dev ERC20 metadata. Set during initialize() and never changes
         string symbol;
 
-        /// @notice Cached name hash used in the EIP-712 domain separator
-        /// @dev Set during initialize() and never changes
-        bytes32 permitNameHash;
-        
+        /// @notice Cached EIP-712 domain separator
+        /// @dev Computed in initialize and updated when name changes
+        bytes32 cachedDomainSeparator;
+
+        /// @notice Chain ID at initialization time
+        /// @dev Used to detect chain forks and trigger domain separator rebuild
+        uint256 cachedChainId;
+
         /// @notice Total supply of strategy shares currently minted
         /// @dev In share base units. Increases on deposits, decreases on withdrawals
         ///      Includes shares held by all users AND dragon router
@@ -586,8 +596,6 @@ abstract contract TokenizedStrategy {
         S.name = _name;
         // Set the Strategy Tokens symbol.
         S.symbol = _symbol;
-        // Cache EIP-712 name hash for stable permit domain.
-        S.permitNameHash = keccak256(bytes(_name));
         // Set decimals based off the `asset`.
         S.decimals = ERC20(_asset).decimals();
 
@@ -612,6 +620,10 @@ abstract contract TokenizedStrategy {
 
         // Set the burning mechanism flag
         S.enableBurning = _enableBurning;
+
+        // Cache domain separator for EIP-712 permit
+        S.cachedChainId = block.chainid;
+        S.cachedDomainSeparator = _buildDomainSeparator(S);
 
         // Emit event to signal a new strategy has been initialized.
         emit NewTokenizedStrategy(address(this), _asset, API_VERSION);
@@ -1438,10 +1450,15 @@ abstract contract TokenizedStrategy {
 
     /**
      * @notice Updates the name for the strategy.
-     * @dev Disabled to keep the EIP-712 domain stable after initialization.
+     * @dev Also updates the EIP-712 domain separator via permitNameHash,
+     *      which invalidates any previously signed but unused permits.
+     * @param _name New name for the strategy
      */
-    function setName(string calldata) external view onlyManagement {
-        revert TokenizedStrategy__NameImmutable();
+    function setName(string calldata _name) external onlyManagement {
+        StrategyData storage S = _strategyStorage();
+        S.name = _name;
+        S.cachedDomainSeparator = _buildDomainSeparator(S);
+        emit UpdateName(_name);
     }
 
     /**
@@ -1778,15 +1795,28 @@ abstract contract TokenizedStrategy {
     }
 
     /**
+     * @notice Builds the EIP-712 domain separator using current state.
+     * @dev Uses strategy name, API version, chain ID, and contract address.
+     * @param S Storage pointer to strategy data
+     * @return The computed domain separator.
+     */
+    function _buildDomainSeparator(StrategyData storage S) private view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(EIP712DOMAIN_TYPEHASH, keccak256(bytes(S.name)), VERSION_HASH, block.chainid, address(this))
+            );
+    }
+
+    /**
      * @notice Returns the EIP-712 domain separator used by {permit}.
+     * @dev Returns cached separator if chain ID unchanged, otherwise rebuilds.
      * @return domainSeparator Domain separator for permit calls
      */
     function DOMAIN_SEPARATOR() public view returns (bytes32) {
         StrategyData storage S = _strategyStorage();
-        bytes32 nameHash = S.permitNameHash;
-        if (nameHash == bytes32(0)) {
-            nameHash = keccak256(bytes(S.name));
+        if (block.chainid == S.cachedChainId) {
+            return S.cachedDomainSeparator;
         }
-        return keccak256(abi.encode(EIP712DOMAIN_TYPEHASH, nameHash, VERSION_HASH, block.chainid, address(this)));
+        return _buildDomainSeparator(S);
     }
 }

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -1450,7 +1450,7 @@ abstract contract TokenizedStrategy {
 
     /**
      * @notice Updates the name for the strategy.
-     * @dev Also updates the EIP-712 domain separator via permitNameHash,
+     * @dev Also updates the EIP-712 domain separator via cachedDomainSeparator,
      *      which invalidates any previously signed but unused permits.
      * @param _name New name for the strategy
      */

--- a/src/errors.sol
+++ b/src/errors.sol
@@ -36,7 +36,6 @@ error TokenizedStrategy__PermitDeadlineExpired();
 error TokenizedStrategy__InvalidSigner();
 error TokenizedStrategy__TransferFailed();
 error TokenizedStrategy__NotSelf();
-error TokenizedStrategy__NameImmutable();
 error TokenizedStrategy__WithdrawMoreThanMax();
 error TokenizedStrategy__RedeemMoreThanMax();
 error TokenizedStrategy__NotPendingManagement();

--- a/test/unit/strategies/yieldDonating/AccessControl.t.sol
+++ b/test/unit/strategies/yieldDonating/AccessControl.t.sol
@@ -4,7 +4,6 @@ pragma solidity >=0.8.18;
 import { Setup } from "./utils/Setup.sol";
 import { TokenizedStrategy } from "src/core/TokenizedStrategy.sol";
 import { BaseStrategy } from "src/core/BaseStrategy.sol";
-import { TokenizedStrategy__NameImmutable } from "src/errors.sol";
 
 contract AccessControlTest is Setup {
     function setUp() public override {
@@ -243,7 +242,6 @@ contract AccessControlTest is Setup {
     function test_setName(address _address) public {
         vm.assume(_address != address(strategy) && _address != management);
 
-        string memory initialName = strategy.name();
         string memory newName = "New Strategy Name";
 
         vm.prank(_address);
@@ -251,10 +249,9 @@ contract AccessControlTest is Setup {
         strategy.setName(newName);
 
         vm.prank(management);
-        vm.expectRevert(TokenizedStrategy__NameImmutable.selector);
         strategy.setName(newName);
 
-        assertEq(strategy.name(), initialName);
+        assertEq(strategy.name(), newName);
     }
 
     // ================== Dragon Router Cooldown Tests ==================

--- a/test/unit/strategies/yieldDonating/Permit.t.sol
+++ b/test/unit/strategies/yieldDonating/Permit.t.sol
@@ -141,6 +141,52 @@ contract PermitTest is Setup {
         strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
     }
 
+    function testDomainSeparatorRebuildsOnChainFork() public {
+        bytes32 originalSeparator = strategy.DOMAIN_SEPARATOR();
+        uint256 originalChainId = block.chainid;
+
+        // Simulate a chain fork by changing the chain ID
+        uint256 forkedChainId = originalChainId + 1;
+        vm.chainId(forkedChainId);
+
+        // Domain separator must differ from cached value
+        bytes32 forkedSeparator = strategy.DOMAIN_SEPARATOR();
+        assertTrue(forkedSeparator != originalSeparator, "Domain separator should change on chain fork");
+
+        // Verify it matches the expected recomputed value
+        bytes32 expectedSeparator = keccak256(
+            abi.encode(
+                EIP712DOMAIN_TYPEHASH,
+                keccak256(bytes(strategy.name())),
+                keccak256(bytes(strategy.apiVersion())),
+                forkedChainId,
+                address(strategy)
+            )
+        );
+        assertEq(forkedSeparator, expectedSeparator, "Forked separator should match recomputed value");
+
+        // Restore original chain ID -- cached value should be returned again
+        vm.chainId(originalChainId);
+        assertEq(strategy.DOMAIN_SEPARATOR(), originalSeparator, "Should return cached separator on original chain");
+    }
+
+    function testPermitInvalidatedAfterChainFork() public {
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp + 3600;
+
+        // Sign permit on the original chain
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        // Simulate a chain fork
+        vm.chainId(block.chainid + 1);
+
+        // Permit signed on the original chain must revert
+        vm.expectRevert();
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+    }
+
     // Helper function to generate permit digest according to EIP-712
     function _getPermitDigest(
         address token,

--- a/test/unit/strategies/yieldDonating/Permit.t.sol
+++ b/test/unit/strategies/yieldDonating/Permit.t.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.18;
+
+import { Setup } from "./utils/Setup.sol";
+import { TokenizedStrategy } from "src/core/TokenizedStrategy.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+contract PermitTest is Setup {
+    uint256 constant AMOUNT = 10 ** 18;
+    uint256 constant PRIVATE_KEY = 0xabcd; // Known private key for tests
+    bytes32 constant EIP712DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+    address public spender;
+
+    function setUp() public override {
+        super.setUp();
+        spender = address(0x1234);
+        vm.label(spender, "spender");
+    }
+
+    function testPermit() public {
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp + 3600;
+
+        assertEq(strategy.allowance(owner, spender), 0);
+
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+
+        assertEq(strategy.allowance(owner, spender), AMOUNT);
+    }
+
+    function testDomainSeparatorUsesStrategyName() public view {
+        bytes32 nameHash = keccak256(bytes(strategy.name()));
+        bytes32 versionHash = keccak256(bytes(strategy.apiVersion()));
+        bytes32 expectedDomainSeparator = keccak256(
+            abi.encode(EIP712DOMAIN_TYPEHASH, nameHash, versionHash, block.chainid, address(strategy))
+        );
+
+        assertEq(strategy.DOMAIN_SEPARATOR(), expectedDomainSeparator);
+    }
+
+    function testDomainSeparatorUpdatesOnNameChange() public {
+        bytes32 originalDomainSeparator = strategy.DOMAIN_SEPARATOR();
+
+        // Change name
+        string memory newName = "New Strategy Name";
+        vm.prank(management);
+        strategy.setName(newName);
+
+        // Verify domain separator changed
+        bytes32 newDomainSeparator = strategy.DOMAIN_SEPARATOR();
+        assertTrue(newDomainSeparator != originalDomainSeparator, "Domain separator should change with name");
+
+        // Verify new domain separator matches expected value
+        bytes32 expectedDomainSeparator = keccak256(
+            abi.encode(
+                EIP712DOMAIN_TYPEHASH,
+                keccak256(bytes(newName)),
+                keccak256(bytes(strategy.apiVersion())),
+                block.chainid,
+                address(strategy)
+            )
+        );
+        assertEq(newDomainSeparator, expectedDomainSeparator, "Domain separator should use new name");
+    }
+
+    function testPermitInvalidatedAfterNameChange() public {
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp + 3600;
+
+        // Sign permit with original name
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        // Change name before using permit
+        vm.prank(management);
+        strategy.setName("New Name");
+
+        // Old permit should fail (wrong domain separator)
+        vm.expectRevert();
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+    }
+
+    function testPermitWorksAfterNameChange() public {
+        // Change name first
+        vm.prank(management);
+        strategy.setName("New Name");
+
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp + 3600;
+
+        // Sign permit with new domain separator
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        // Permit should work
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+
+        assertEq(strategy.allowance(owner, spender), AMOUNT);
+    }
+
+    function testPermitWithUsedPermit() public {
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp + 3600;
+
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+
+        vm.expectRevert();
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+    }
+
+    function testPermitWithExpiredDeadline() public {
+        // Set block timestamp to 1000
+        vm.warp(1000);
+
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp - 600; // Expired deadline
+
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        vm.expectRevert("ERC20: PERMIT_DEADLINE_EXPIRED");
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+    }
+
+    // Helper function to generate permit digest according to EIP-712
+    function _getPermitDigest(
+        address token,
+        address owner,
+        address _spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    ) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, _spender, value, nonce, deadline));
+
+        return keccak256(abi.encodePacked("\x19\x01", TokenizedStrategy(token).DOMAIN_SEPARATOR(), structHash));
+    }
+}

--- a/test/unit/strategies/yieldSkimming/AccessControl.t.sol
+++ b/test/unit/strategies/yieldSkimming/AccessControl.t.sol
@@ -6,7 +6,6 @@ import { TokenizedStrategy } from "src/core/TokenizedStrategy.sol";
 import { BaseStrategy } from "src/core/BaseStrategy.sol";
 import { IYieldSkimmingStrategy } from "src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol";
 import { MockStrategySkimming } from "test/mocks/core/tokenized-strategies/MockStrategySkimming.sol";
-import { TokenizedStrategy__NameImmutable } from "src/errors.sol";
 
 contract AccessControlTest is Setup {
     function setUp() public override {
@@ -181,7 +180,6 @@ contract AccessControlTest is Setup {
     function test_setName(address _address) public {
         vm.assume(_address != address(strategy) && _address != management);
 
-        string memory initialName = strategy.name();
         string memory newName = "New Strategy Name";
 
         vm.prank(_address);
@@ -189,10 +187,9 @@ contract AccessControlTest is Setup {
         strategy.setName(newName);
 
         vm.prank(management);
-        vm.expectRevert(TokenizedStrategy__NameImmutable.selector);
         strategy.setName(newName);
 
-        assertEq(strategy.name(), initialName);
+        assertEq(strategy.name(), newName);
     }
 
     // ================== Dragon Router Cooldown Tests ==================

--- a/test/unit/strategies/yieldSkimming/Permit.t.sol
+++ b/test/unit/strategies/yieldSkimming/Permit.t.sol
@@ -141,6 +141,52 @@ contract PermitTest is Setup {
         strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
     }
 
+    function testDomainSeparatorRebuildsOnChainFork() public {
+        bytes32 originalSeparator = strategy.DOMAIN_SEPARATOR();
+        uint256 originalChainId = block.chainid;
+
+        // Simulate a chain fork by changing the chain ID
+        uint256 forkedChainId = originalChainId + 1;
+        vm.chainId(forkedChainId);
+
+        // Domain separator must differ from cached value
+        bytes32 forkedSeparator = strategy.DOMAIN_SEPARATOR();
+        assertTrue(forkedSeparator != originalSeparator, "Domain separator should change on chain fork");
+
+        // Verify it matches the expected recomputed value
+        bytes32 expectedSeparator = keccak256(
+            abi.encode(
+                EIP712DOMAIN_TYPEHASH,
+                keccak256(bytes(strategy.name())),
+                keccak256(bytes(strategy.apiVersion())),
+                forkedChainId,
+                address(strategy)
+            )
+        );
+        assertEq(forkedSeparator, expectedSeparator, "Forked separator should match recomputed value");
+
+        // Restore original chain ID -- cached value should be returned again
+        vm.chainId(originalChainId);
+        assertEq(strategy.DOMAIN_SEPARATOR(), originalSeparator, "Should return cached separator on original chain");
+    }
+
+    function testPermitInvalidatedAfterChainFork() public {
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp + 3600;
+
+        // Sign permit on the original chain
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        // Simulate a chain fork
+        vm.chainId(block.chainid + 1);
+
+        // Permit signed on the original chain must revert
+        vm.expectRevert();
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+    }
+
     // Helper function to generate permit digest according to EIP-712
     function _getPermitDigest(
         address token,

--- a/test/unit/strategies/yieldSkimming/Permit.t.sol
+++ b/test/unit/strategies/yieldSkimming/Permit.t.sol
@@ -1,0 +1,157 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.18;
+
+import { Setup } from "./utils/Setup.sol";
+import { TokenizedStrategy } from "src/core/TokenizedStrategy.sol";
+import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+
+contract PermitTest is Setup {
+    uint256 constant AMOUNT = 10 ** 18;
+    uint256 constant PRIVATE_KEY = 0xabcd; // Known private key for tests
+    bytes32 constant EIP712DOMAIN_TYPEHASH =
+        keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
+    bytes32 constant PERMIT_TYPEHASH =
+        keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+    address public spender;
+
+    function setUp() public override {
+        super.setUp();
+        spender = address(0x1234);
+        vm.label(spender, "spender");
+    }
+
+    function testPermit() public {
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp + 3600;
+
+        assertEq(strategy.allowance(owner, spender), 0);
+
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+
+        assertEq(strategy.allowance(owner, spender), AMOUNT);
+    }
+
+    function testDomainSeparatorUsesStrategyName() public view {
+        bytes32 nameHash = keccak256(bytes(strategy.name()));
+        bytes32 versionHash = keccak256(bytes(strategy.apiVersion()));
+        bytes32 expectedDomainSeparator = keccak256(
+            abi.encode(EIP712DOMAIN_TYPEHASH, nameHash, versionHash, block.chainid, address(strategy))
+        );
+
+        assertEq(strategy.DOMAIN_SEPARATOR(), expectedDomainSeparator);
+    }
+
+    function testDomainSeparatorUpdatesOnNameChange() public {
+        bytes32 originalDomainSeparator = strategy.DOMAIN_SEPARATOR();
+
+        // Change name
+        string memory newName = "New Strategy Name";
+        vm.prank(management);
+        strategy.setName(newName);
+
+        // Verify domain separator changed
+        bytes32 newDomainSeparator = strategy.DOMAIN_SEPARATOR();
+        assertTrue(newDomainSeparator != originalDomainSeparator, "Domain separator should change with name");
+
+        // Verify new domain separator matches expected value
+        bytes32 expectedDomainSeparator = keccak256(
+            abi.encode(
+                EIP712DOMAIN_TYPEHASH,
+                keccak256(bytes(newName)),
+                keccak256(bytes(strategy.apiVersion())),
+                block.chainid,
+                address(strategy)
+            )
+        );
+        assertEq(newDomainSeparator, expectedDomainSeparator, "Domain separator should use new name");
+    }
+
+    function testPermitInvalidatedAfterNameChange() public {
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp + 3600;
+
+        // Sign permit with original name
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        // Change name before using permit
+        vm.prank(management);
+        strategy.setName("New Name");
+
+        // Old permit should fail (wrong domain separator)
+        vm.expectRevert();
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+    }
+
+    function testPermitWorksAfterNameChange() public {
+        // Change name first
+        vm.prank(management);
+        strategy.setName("New Name");
+
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp + 3600;
+
+        // Sign permit with new domain separator
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        // Permit should work
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+
+        assertEq(strategy.allowance(owner, spender), AMOUNT);
+    }
+
+    function testPermitWithUsedPermit() public {
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp + 3600;
+
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+
+        vm.expectRevert();
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+    }
+
+    function testPermitWithExpiredDeadline() public {
+        // Set block timestamp to 1000
+        vm.warp(1000);
+
+        address owner = vm.addr(PRIVATE_KEY);
+        uint256 deadline = block.timestamp - 600; // Expired deadline
+
+        bytes32 digest = _getPermitDigest(address(strategy), owner, spender, AMOUNT, strategy.nonces(owner), deadline);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(PRIVATE_KEY, digest);
+
+        vm.expectRevert("ERC20: PERMIT_DEADLINE_EXPIRED");
+        vm.prank(spender);
+        strategy.permit(owner, spender, AMOUNT, deadline, v, r, s);
+    }
+
+    // Helper function to generate permit digest according to EIP-712
+    function _getPermitDigest(
+        address token,
+        address owner,
+        address _spender,
+        uint256 value,
+        uint256 nonce,
+        uint256 deadline
+    ) internal view returns (bytes32) {
+        bytes32 structHash = keccak256(abi.encode(PERMIT_TYPEHASH, owner, _spender, value, nonce, deadline));
+
+        return keccak256(abi.encodePacked("\x19\x01", TokenizedStrategy(token).DOMAIN_SEPARATOR(), structHash));
+    }
+}


### PR DESCRIPTION
## Enable `setName` with Domain Separator Update for TokenizedStrategy

### Summary
Re-enables the `setName` function for `TokenizedStrategy` while properly updating the EIP-712 domain separator. This ensures permit signatures remain valid after deployment while allowing name changes when needed.

### Changes

#### TokenizedStrategy.sol
- **Replaced `permitNameHash` with cached domain separator pattern**
  - Added `cachedDomainSeparator` and `cachedChainId` to `StrategyData` struct
  - Removes single-purpose `permitNameHash` field

- **Updated `setName` to rebuild domain separator**
  - Name changes now update `cachedDomainSeparator` via `_buildDomainSeparator()`
  - Emits `UpdateName` event for off-chain tracking

- **Added `_buildDomainSeparator()` helper**
  - Computes domain separator from current name, version, chainId, and address

- **Updated `DOMAIN_SEPARATOR()` to use cache with fork protection**
  - Returns cached value if chainId unchanged
  - Rebuilds on chain fork (chainId mismatch)

- **Added `UpdateName` event**
