### PR TITLE
Feature/osu 1490 yield forwarded

### DIFF
--- a/partners/nouns_dao/script/GenerateProposalCalldata.s.sol
+++ b/partners/nouns_dao/script/GenerateProposalCalldata.s.sol
@@ -71,9 +71,10 @@ contract GenerateProposalCalldata is Script {
     /// @dev Placeholder - update with actual Nouns Payer contract address
     address constant NOUNS_PAYER = 0x0eCC079C20DaA9fDE0e26b6d745c0b38479ff200;
 
-    /// @notice Keeper bot address for calling report()
+    /// @notice Keeper bot EOA that triggers YieldForwarder.reportAndForward()
     /// @dev For testing: using deployer address. Update for production.
     /// @dev CRITICAL: Do NOT use Treasury - would require governance vote for each harvest
+    /// @dev The strategy's keeper will be the YieldForwarder itself (not this EOA directly)
     address constant KEEPER_BOT = 0x0eCC079C20DaA9fDE0e26b6d745c0b38479ff200;
 
     /// @notice Emergency admin address
@@ -215,20 +216,23 @@ contract GenerateProposalCalldata is Script {
         // Predict YieldForwarder address with explicit salt (avoids race conditions in governance)
         predictedYF = YieldForwarderFactory(YIELD_FORWARDER_FACTORY).computeYieldForwarderAddress(
             NOUNS_PAYER,
+            KEEPER_BOT,
             YIELD_FORWARDER_SALT,
             NOUNS_TREASURY
         );
 
         // Predict Strategy address using LidoStrategyFactory.computeStrategyAddress()
+        // NOTE: Strategy's _keeper is the YieldForwarder (so it can call report())
+        //       Strategy's _donationAddress is also the YieldForwarder (receives profit shares)
         predictedStrategy = LidoStrategyFactory(LIDO_STRATEGY_FACTORY).computeStrategyAddress(
             WSTETH, // _vault
             WSTETH, // _asset
             STRATEGY_NAME,
             STRATEGY_SYMBOL,
             NOUNS_TREASURY, // _management
-            KEEPER_BOT, // _keeper
+            predictedYF, // _keeper = YieldForwarder (calls report())
             EMERGENCY_ADMIN, // _emergencyAdmin
-            predictedYF, // _donationAddress
+            predictedYF, // _donationAddress = YieldForwarder (receives profit shares)
             false, // _enableBurning
             TOKENIZED_STRATEGY, // _tokenizedStrategyAddress
             NOUNS_TREASURY // _deployer (Treasury will deploy via governance)
@@ -253,8 +257,8 @@ contract GenerateProposalCalldata is Script {
     {
         target = YIELD_FORWARDER_FACTORY;
         value = 0;
-        signature = "createYieldForwarder(address,bytes32)";
-        calldataParams = abi.encode(NOUNS_PAYER, YIELD_FORWARDER_SALT);
+        signature = "createYieldForwarder(address,address,bytes32)";
+        calldataParams = abi.encode(NOUNS_PAYER, KEEPER_BOT, YIELD_FORWARDER_SALT);
     }
 
     /**
@@ -275,9 +279,9 @@ contract GenerateProposalCalldata is Script {
             STRATEGY_NAME,
             STRATEGY_SYMBOL,
             NOUNS_TREASURY,
-            KEEPER_BOT,
+            yieldForwarder, // _keeper = YieldForwarder (calls report())
             EMERGENCY_ADMIN,
-            yieldForwarder,
+            yieldForwarder, // _donationAddress = YieldForwarder (receives profit shares)
             false,
             TOKENIZED_STRATEGY
         );
@@ -345,6 +349,7 @@ contract GenerateProposalCalldata is Script {
         console.log("");
         console.log("PARAMETERS:");
         console.log("  receiver: ", NOUNS_PAYER);
+        console.log("  keeper:   ", KEEPER_BOT);
         console.log("  salt:     ");
         console.logBytes32(YIELD_FORWARDER_SALT);
         console.log("");
@@ -375,7 +380,7 @@ contract GenerateProposalCalldata is Script {
         console.log("  _name:                     %s", STRATEGY_NAME);
         console.log("  _symbol:                   %s", STRATEGY_SYMBOL);
         console.log("  _management:               ", NOUNS_TREASURY);
-        console.log("  _keeper:                   ", KEEPER_BOT);
+        console.log("  _keeper:                   ", yieldForwarder);
         console.log("  _emergencyAdmin:           ", EMERGENCY_ADMIN);
         console.log("  _donationAddress:          ", yieldForwarder);
         console.log("  _enableBurning:            false");
@@ -457,7 +462,7 @@ contract GenerateProposalCalldata is Script {
         console.log("TX 1 - Deploy YieldForwarder");
         console.log("--------------------------------------------------------------------------------");
         console.log("Target:   ", YIELD_FORWARDER_FACTORY);
-        console.log("Function: createYieldForwarder(address,bytes32)");
+        console.log("Function: createYieldForwarder(address,address,bytes32)");
         console.log("");
         console.log("--------------------------------------------------------------------------------");
         console.log("TX 2 - Deploy LidoStrategy");

--- a/partners/nouns_dao/script/GenerateProposalCalldata.s.sol
+++ b/partners/nouns_dao/script/GenerateProposalCalldata.s.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 import { Script, console } from "forge-std/Script.sol";
 
-import { PaymentSplitterFactory } from "src/factories/PaymentSplitterFactory.sol";
+import { YieldForwarderFactory } from "src/factories/YieldForwarderFactory.sol";
 import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
 
 /// @notice Minimal interface for wstETH conversion functions
@@ -25,7 +25,7 @@ interface IWstETH {
  * @dev Run with: forge script partners/nouns_dao/script/GenerateProposalCalldata.s.sol --fork-url $ETH_RPC_URL -vvvv
  *
  *      This script outputs ready-to-use data for the Nouns DAO UI (nouns.wtf/vote):
- *      - Transaction 1: Deploy PaymentSplitter via Factory
+ *      - Transaction 1: Deploy YieldForwarder via Factory
  *      - Transaction 2: Deploy LidoStrategy via Factory
  *      - Transaction 3: Approve wstETH to Strategy
  *      - Transaction 4: Deposit wstETH into Strategy
@@ -39,6 +39,7 @@ interface IWstETH {
  *
  *      PREREQUISITES:
  *      - LidoStrategyFactory must be deployed to mainnet (update LIDO_STRATEGY_FACTORY)
+ *      - YieldForwarderFactory must be deployed to mainnet (update YIELD_FORWARDER_FACTORY)
  *      - Update all placeholder addresses before production use
  */
 contract GenerateProposalCalldata is Script {
@@ -49,8 +50,9 @@ contract GenerateProposalCalldata is Script {
     /// @notice Nouns DAO Treasury (Executor/Timelock) - DO NOT CHANGE
     address constant NOUNS_TREASURY = 0xb1a32FC9F9D8b2cf86C068Cae13108809547ef71;
 
-    /// @notice PaymentSplitter Factory (already deployed on mainnet) - DO NOT CHANGE
-    address constant PAYMENT_SPLITTER_FACTORY = 0x5711765E0756B45224fc1FdA1B41ab344682bBcb;
+    /// @notice YieldForwarder Factory address
+    /// @dev Placeholder - update when deployed to mainnet
+    address constant YIELD_FORWARDER_FACTORY = 0x5711765E0756B45224fc1FdA1B41ab344682bBcb;
 
     /// @notice wstETH token address on Ethereum mainnet - DO NOT CHANGE
     address constant WSTETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
@@ -65,9 +67,9 @@ contract GenerateProposalCalldata is Script {
     /// @notice LidoStrategyFactory address - PRODUCTION
     address constant LIDO_STRATEGY_FACTORY = 0xB248Df1fc187Fdb6C89bDc30071e68D235DeC3c2;
 
-    /// @notice Dragon Funding Pool recipient address
-    /// @dev For testing: using deployer address. Update for production.
-    address constant DRAGON_FUNDING_POOL = 0x0eCC079C20DaA9fDE0e26b6d745c0b38479ff200;
+    /// @notice Nouns Payer contract address (receives forwarded wstETH yield)
+    /// @dev Placeholder - update with actual Nouns Payer contract address
+    address constant NOUNS_PAYER = 0x0eCC079C20DaA9fDE0e26b6d745c0b38479ff200;
 
     /// @notice Keeper bot address for calling report()
     /// @dev For testing: using deployer address. Update for production.
@@ -89,10 +91,10 @@ contract GenerateProposalCalldata is Script {
     /// @dev The actual wstETH amount deposited depends on the stETH/wstETH exchange rate at execution time
     uint256 constant TARGET_ETH_VALUE = 1000 ether;
 
-    /// @notice Salt for deterministic PaymentSplitter deployment
+    /// @notice Salt for deterministic YieldForwarder deployment
     /// @dev Using an explicit salt avoids race conditions where the deployment count
     ///      could change between proposal creation and execution
-    bytes32 constant PAYMENT_SPLITTER_SALT = keccak256("NounsDAO-LidoStrategy-PaymentSplitter-v1");
+    bytes32 constant YIELD_FORWARDER_SALT = keccak256("NounsDAO-LidoStrategy-YieldForwarder-v1");
 
     // ══════════════════════════════════════════════════════════════════════════════
     // MAIN SCRIPT
@@ -107,14 +109,14 @@ contract GenerateProposalCalldata is Script {
         _printHeader();
 
         // Precompute deterministic addresses
-        (address predictedPS, address predictedStrategy) = getPrecomputedAddresses();
+        (address predictedYF, address predictedStrategy) = getPrecomputedAddresses();
 
         _printConfiguration();
-        _printPrecomputedAddresses(predictedPS, predictedStrategy);
+        _printPrecomputedAddresses(predictedYF, predictedStrategy);
 
         // Generate and print all 4 transactions
-        _printTransaction1_DeployPaymentSplitter();
-        _printTransaction2_DeployStrategy(predictedPS);
+        _printTransaction1_DeployYieldForwarder();
+        _printTransaction2_DeployStrategy(predictedYF);
         _printTransaction3_ApproveWstETH(predictedStrategy);
         _printTransaction4_DepositWstETH(predictedStrategy);
 
@@ -129,14 +131,14 @@ contract GenerateProposalCalldata is Script {
     // ══════════════════════════════════════════════════════════════════════════════
 
     /**
-     * @notice Get precomputed CREATE2 addresses for PaymentSplitter and Strategy
-     * @return predictedPaymentSplitter The deterministic address where PaymentSplitter will deploy
+     * @notice Get precomputed CREATE2 addresses for YieldForwarder and Strategy
+     * @return predictedYieldForwarder The deterministic address where YieldForwarder will deploy
      * @return predictedStrategy The deterministic address where LidoStrategy will deploy
      */
     function getPrecomputedAddresses()
         public
         view
-        returns (address predictedPaymentSplitter, address predictedStrategy)
+        returns (address predictedYieldForwarder, address predictedStrategy)
     {
         return _computeAddresses();
     }
@@ -159,18 +161,18 @@ contract GenerateProposalCalldata is Script {
             bytes[] memory calldatas
         )
     {
-        (address predictedPS, address predictedStrategy) = _computeAddresses();
+        (address predictedYF, address predictedStrategy) = _computeAddresses();
 
         targets = new address[](4);
         values = new uint256[](4);
         signatures = new string[](4);
         calldatas = new bytes[](4);
 
-        // TX 1: Deploy PaymentSplitter
-        (targets[0], values[0], signatures[0], calldatas[0]) = _getTransaction1_DeployPaymentSplitter();
+        // TX 1: Deploy YieldForwarder
+        (targets[0], values[0], signatures[0], calldatas[0]) = _getTransaction1_DeployYieldForwarder();
 
         // TX 2: Deploy LidoStrategy
-        (targets[1], values[1], signatures[1], calldatas[1]) = _getTransaction2_DeployStrategy(predictedPS);
+        (targets[1], values[1], signatures[1], calldatas[1]) = _getTransaction2_DeployStrategy(predictedYF);
 
         // TX 3: Approve wstETH to Strategy
         (targets[2], values[2], signatures[2], calldatas[2]) = _getTransaction3_ApproveWstETH(predictedStrategy);
@@ -209,19 +211,12 @@ contract GenerateProposalCalldata is Script {
     // INTERNAL HELPERS
     // ══════════════════════════════════════════════════════════════════════════════
 
-    function _computeAddresses() internal view returns (address predictedPS, address predictedStrategy) {
-        // Build payees and shares for salt-based prediction
-        address[] memory payees = new address[](1);
-        payees[0] = DRAGON_FUNDING_POOL;
-        uint256[] memory shares = new uint256[](1);
-        shares[0] = 100;
-
-        // Predict PaymentSplitter address with explicit salt (avoids race conditions in governance)
-        predictedPS = PaymentSplitterFactory(PAYMENT_SPLITTER_FACTORY).predictDeterministicAddressWithSalt(
-            NOUNS_TREASURY,
-            payees,
-            shares,
-            PAYMENT_SPLITTER_SALT
+    function _computeAddresses() internal view returns (address predictedYF, address predictedStrategy) {
+        // Predict YieldForwarder address with explicit salt (avoids race conditions in governance)
+        predictedYF = YieldForwarderFactory(YIELD_FORWARDER_FACTORY).computeYieldForwarderAddress(
+            NOUNS_PAYER,
+            YIELD_FORWARDER_SALT,
+            NOUNS_TREASURY
         );
 
         // Predict Strategy address using LidoStrategyFactory.computeStrategyAddress()
@@ -233,7 +228,7 @@ contract GenerateProposalCalldata is Script {
             NOUNS_TREASURY, // _management
             KEEPER_BOT, // _keeper
             EMERGENCY_ADMIN, // _emergencyAdmin
-            predictedPS, // _donationAddress
+            predictedYF, // _donationAddress
             false, // _enableBurning
             TOKENIZED_STRATEGY, // _tokenizedStrategyAddress
             NOUNS_TREASURY // _deployer (Treasury will deploy via governance)
@@ -245,40 +240,33 @@ contract GenerateProposalCalldata is Script {
     // ══════════════════════════════════════════════════════════════════════════════
 
     /**
-     * @notice Get TX 1 data: Deploy PaymentSplitter
+     * @notice Get TX 1 data: Deploy YieldForwarder
      * @return target Contract address to call
      * @return value ETH value (0)
      * @return signature Function signature
      * @return calldataParams ABI-encoded parameters
      */
-    function _getTransaction1_DeployPaymentSplitter()
+    function _getTransaction1_DeployYieldForwarder()
         internal
         pure
         returns (address target, uint256 value, string memory signature, bytes memory calldataParams)
     {
-        address[] memory payees = new address[](1);
-        payees[0] = DRAGON_FUNDING_POOL;
-        string[] memory payeeNames = new string[](1);
-        payeeNames[0] = "NounsGrants";
-        uint256[] memory shares = new uint256[](1);
-        shares[0] = 100;
-
-        target = PAYMENT_SPLITTER_FACTORY;
+        target = YIELD_FORWARDER_FACTORY;
         value = 0;
-        signature = "createPaymentSplitterWithSalt(address[],string[],uint256[],bytes32)";
-        calldataParams = abi.encode(payees, payeeNames, shares, PAYMENT_SPLITTER_SALT);
+        signature = "createYieldForwarder(address,bytes32)";
+        calldataParams = abi.encode(NOUNS_PAYER, YIELD_FORWARDER_SALT);
     }
 
     /**
      * @notice Get TX 2 data: Deploy LidoStrategy
-     * @param paymentSplitter The predicted PaymentSplitter address
+     * @param yieldForwarder The predicted YieldForwarder address
      * @return target Contract address to call
      * @return value ETH value (0)
      * @return signature Function signature
      * @return calldataParams ABI-encoded parameters
      */
     function _getTransaction2_DeployStrategy(
-        address paymentSplitter
+        address yieldForwarder
     ) internal pure returns (address target, uint256 value, string memory signature, bytes memory calldataParams) {
         target = LIDO_STRATEGY_FACTORY;
         value = 0;
@@ -289,7 +277,7 @@ contract GenerateProposalCalldata is Script {
             NOUNS_TREASURY,
             KEEPER_BOT,
             EMERGENCY_ADMIN,
-            paymentSplitter,
+            yieldForwarder,
             false,
             TOKENIZED_STRATEGY
         );
@@ -333,17 +321,17 @@ contract GenerateProposalCalldata is Script {
     // TRANSACTION PRINTERS - Use _getTransaction* for data, then print
     // ══════════════════════════════════════════════════════════════════════════════
 
-    function _printTransaction1_DeployPaymentSplitter() internal pure {
+    function _printTransaction1_DeployYieldForwarder() internal pure {
         (
             address target,
             ,
             string memory signature,
             bytes memory calldataParams
-        ) = _getTransaction1_DeployPaymentSplitter();
+        ) = _getTransaction1_DeployYieldForwarder();
 
         console.log("");
         console.log("================================================================================");
-        console.log("TRANSACTION 1: Deploy PaymentSplitter");
+        console.log("TRANSACTION 1: Deploy YieldForwarder");
         console.log("================================================================================");
         console.log("");
         console.log("TARGET (copy this):");
@@ -356,19 +344,17 @@ contract GenerateProposalCalldata is Script {
         console.log("  ", signature);
         console.log("");
         console.log("PARAMETERS:");
-        console.log("  payees:     [", DRAGON_FUNDING_POOL, "]");
-        console.log('  payeeNames: ["NounsGrants"]');
-        console.log("  shares:     [100]");
-        console.log("  salt:       ");
-        console.logBytes32(PAYMENT_SPLITTER_SALT);
+        console.log("  receiver: ", NOUNS_PAYER);
+        console.log("  salt:     ");
+        console.logBytes32(YIELD_FORWARDER_SALT);
         console.log("");
         console.log("CALLDATA (copy this - parameters only, no selector):");
         console.logBytes(calldataParams);
     }
 
-    function _printTransaction2_DeployStrategy(address paymentSplitter) internal pure {
+    function _printTransaction2_DeployStrategy(address yieldForwarder) internal pure {
         (address target, , string memory signature, bytes memory calldataParams) = _getTransaction2_DeployStrategy(
-            paymentSplitter
+            yieldForwarder
         );
 
         console.log("");
@@ -391,7 +377,7 @@ contract GenerateProposalCalldata is Script {
         console.log("  _management:               ", NOUNS_TREASURY);
         console.log("  _keeper:                   ", KEEPER_BOT);
         console.log("  _emergencyAdmin:           ", EMERGENCY_ADMIN);
-        console.log("  _donationAddress:          ", paymentSplitter);
+        console.log("  _donationAddress:          ", yieldForwarder);
         console.log("  _enableBurning:            false");
         console.log("  _tokenizedStrategyAddress: ", TOKENIZED_STRATEGY);
         console.log("");
@@ -468,10 +454,10 @@ contract GenerateProposalCalldata is Script {
         console.log("Add these 4 transactions in order on nouns.wtf/vote:");
         console.log("");
         console.log("--------------------------------------------------------------------------------");
-        console.log("TX 1 - Deploy PaymentSplitter");
+        console.log("TX 1 - Deploy YieldForwarder");
         console.log("--------------------------------------------------------------------------------");
-        console.log("Target:   ", PAYMENT_SPLITTER_FACTORY);
-        console.log("Function: createPaymentSplitterWithSalt(address[],string[],uint256[],bytes32)");
+        console.log("Target:   ", YIELD_FORWARDER_FACTORY);
+        console.log("Function: createYieldForwarder(address,bytes32)");
         console.log("");
         console.log("--------------------------------------------------------------------------------");
         console.log("TX 2 - Deploy LidoStrategy");
@@ -510,26 +496,26 @@ contract GenerateProposalCalldata is Script {
         uint256 depositAmount = getDepositAmount();
         console.log("CONFIGURATION:");
         console.log("--------------------------------------------------------------------------------");
-        console.log("  Treasury (Management):    ", NOUNS_TREASURY);
-        console.log("  PaymentSplitter Factory:  ", PAYMENT_SPLITTER_FACTORY);
-        console.log("  LidoStrategy Factory:     ", LIDO_STRATEGY_FACTORY);
-        console.log("  Dragon Funding Pool:      ", DRAGON_FUNDING_POOL);
-        console.log("  Keeper Bot:               ", KEEPER_BOT);
-        console.log("  Emergency Admin:          ", EMERGENCY_ADMIN);
-        console.log("  wstETH Token:             ", WSTETH);
-        console.log("  Tokenized Strategy Impl:  ", TOKENIZED_STRATEGY);
-        console.log("  Strategy Name:             %s", STRATEGY_NAME);
-        console.log("  Strategy Symbol:           %s", STRATEGY_SYMBOL);
-        console.log("  Target ETH Value:          %s ETH", TARGET_ETH_VALUE / 1e18);
-        console.log("  Deposit Amount:            %s wstETH (at current rate)", depositAmount / 1e18);
+        console.log("  Treasury (Management):      ", NOUNS_TREASURY);
+        console.log("  YieldForwarder Factory:     ", YIELD_FORWARDER_FACTORY);
+        console.log("  LidoStrategy Factory:       ", LIDO_STRATEGY_FACTORY);
+        console.log("  Nouns Payer:                ", NOUNS_PAYER);
+        console.log("  Keeper Bot:                 ", KEEPER_BOT);
+        console.log("  Emergency Admin:            ", EMERGENCY_ADMIN);
+        console.log("  wstETH Token:               ", WSTETH);
+        console.log("  Tokenized Strategy Impl:    ", TOKENIZED_STRATEGY);
+        console.log("  Strategy Name:               %s", STRATEGY_NAME);
+        console.log("  Strategy Symbol:             %s", STRATEGY_SYMBOL);
+        console.log("  Target ETH Value:            %s ETH", TARGET_ETH_VALUE / 1e18);
+        console.log("  Deposit Amount:              %s wstETH (at current rate)", depositAmount / 1e18);
         console.log("");
     }
 
-    function _printPrecomputedAddresses(address predictedPS, address predictedStrategy) internal pure {
+    function _printPrecomputedAddresses(address predictedYF, address predictedStrategy) internal pure {
         console.log("PRECOMPUTED ADDRESSES (via CREATE2):");
         console.log("--------------------------------------------------------------------------------");
-        console.log("  PaymentSplitter: ", predictedPS);
-        console.log("  Strategy:        ", predictedStrategy);
+        console.log("  YieldForwarder: ", predictedYF);
+        console.log("  Strategy:       ", predictedStrategy);
         console.log("");
         console.log("NOTE: These addresses are deterministic. The contracts will deploy to these");
         console.log("exact addresses when the proposal executes.");
@@ -542,10 +528,10 @@ contract GenerateProposalCalldata is Script {
         console.log("================================================================================");
         console.log("");
         console.log("1. Update placeholder addresses in this script:");
-        console.log("   - LIDO_STRATEGY_FACTORY: Deploy LidoStrategyFactory to mainnet");
-        console.log("   - DRAGON_FUNDING_POOL:   Get actual grant recipient address");
-        console.log("   - KEEPER_BOT:            Set up dedicated keeper EOA/bot");
-        console.log("   - EMERGENCY_ADMIN:       Decide on emergency admin (Treasury or multisig)");
+        console.log("   - YIELD_FORWARDER_FACTORY: Deploy YieldForwarderFactory to mainnet");
+        console.log("   - NOUNS_PAYER:             Get actual Nouns Payer contract address");
+        console.log("   - KEEPER_BOT:              Set up dedicated keeper EOA/bot");
+        console.log("   - EMERGENCY_ADMIN:         Decide on emergency admin (Treasury or multisig)");
         console.log("");
         console.log("2. Re-run this script to generate production calldata");
         console.log("");

--- a/src/core/YieldForwarder.sol
+++ b/src/core/YieldForwarder.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+/// @notice Minimal interface for strategy share redemption
+interface IRedeemable {
+    /// @notice Redeem shares for underlying assets
+    /// @param shares Amount of shares to redeem
+    /// @param receiver Address to receive the redeemed assets
+    /// @param owner Address whose shares are being redeemed
+    /// @param maxLoss Maximum acceptable loss in basis points
+    /// @return assets Amount of assets returned
+    function redeem(uint256 shares, address receiver, address owner, uint256 maxLoss) external returns (uint256 assets);
+}
+
+/**
+ * @title YieldForwarder
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice Immutable, single-purpose contract that redeems strategy shares and forwards
+ *         the underlying assets to a hardcoded receiver
+ * @dev Designed for trust-minimized yield flows where profit shares from a strategy
+ *      are automatically redeemed for the underlying asset and sent to a receiver.
+ *
+ *      DESIGN:
+ *      - Fully immutable: no admin, no upgrades, no sweep
+ *      - Zero-admin: receiver is set once at construction
+ *      - Permissionless: anyone can call redeemAndForward()
+ *      - Single-purpose: assets can only flow to the hardcoded receiver
+ *      - Strategy is passed as a call-time parameter to avoid circular dependencies
+ */
+contract YieldForwarder {
+    // ============================================
+    // ERRORS
+    // ============================================
+
+    /// @notice Thrown when the receiver address is zero
+    error InvalidReceiver();
+
+    /// @notice Thrown when there are no shares to redeem
+    error NoSharesToRedeem();
+
+    // ============================================
+    // EVENTS
+    // ============================================
+
+    /// @notice Emitted when shares are redeemed and assets forwarded to the receiver
+    /// @param strategy Address of the strategy whose shares were redeemed
+    /// @param receiver Address that received the underlying assets
+    /// @param shares Amount of shares redeemed
+    /// @param assets Amount of underlying assets forwarded
+    event YieldForwarded(address indexed strategy, address indexed receiver, uint256 shares, uint256 assets);
+
+    // ============================================
+    // STATE
+    // ============================================
+
+    /// @notice The address that receives all redeemed assets
+    /// @dev Set once at construction, cannot be changed
+    address public immutable receiver;
+
+    // ============================================
+    // CONSTRUCTOR
+    // ============================================
+
+    /// @notice Creates a new YieldForwarder with a fixed receiver
+    /// @param _receiver Address that will receive all forwarded assets
+    constructor(address _receiver) {
+        if (_receiver == address(0)) revert InvalidReceiver();
+        receiver = _receiver;
+    }
+
+    // ============================================
+    // EXTERNAL FUNCTIONS
+    // ============================================
+
+    /**
+     * @notice Redeems all strategy shares held by this contract and forwards assets to receiver
+     * @dev Permissionless - anyone can call this to trigger redemption and forwarding.
+     *      The strategy address is passed as a parameter to avoid circular deployment dependencies.
+     * @param strategy Address of the strategy contract (must implement IRedeemable and IERC20)
+     * @param maxLoss Maximum acceptable loss in basis points for the redemption
+     * @return assets Amount of underlying assets forwarded to receiver
+     */
+    function redeemAndForward(address strategy, uint256 maxLoss) external returns (uint256 assets) {
+        uint256 shares = IERC20(strategy).balanceOf(address(this));
+        if (shares == 0) revert NoSharesToRedeem();
+
+        assets = IRedeemable(strategy).redeem(shares, receiver, address(this), maxLoss);
+
+        emit YieldForwarded(strategy, receiver, shares, assets);
+    }
+}

--- a/src/core/YieldForwarder.sol
+++ b/src/core/YieldForwarder.sol
@@ -14,19 +14,32 @@ interface IRedeemable {
     function redeem(uint256 shares, address receiver, address owner, uint256 maxLoss) external returns (uint256 assets);
 }
 
+/// @notice Minimal interface for triggering a strategy report
+interface IReportable {
+    /// @notice Trigger a strategy report (realize gains/losses, mint profit shares)
+    /// @return profit Amount of profit realized
+    /// @return loss Amount of loss realized
+    function report() external returns (uint256 profit, uint256 loss);
+}
+
 /**
  * @title YieldForwarder
  * @author [Golem Foundation](https://golem.foundation)
  * @custom:security-contact security@golem.foundation
- * @notice Immutable, single-purpose contract that redeems strategy shares and forwards
- *         the underlying assets to a hardcoded receiver
- * @dev Designed for trust-minimized yield flows where profit shares from a strategy
- *      are automatically redeemed for the underlying asset and sent to a receiver.
+ * @notice Immutable, single-purpose contract that calls report() on a strategy,
+ *         redeems any resulting profit shares, and forwards the underlying assets
+ *         to a hardcoded receiver
+ * @dev Designed for trust-minimized yield flows where this contract serves as both
+ *      the strategy's keeper (authorized to call report()) and the donation address
+ *      (receives profit shares). Only an authorized keeper EOA can trigger it.
+ *
+ *      CALL CHAIN:
+ *      Keeper EOA → reportAndForward() → strategy.report() → profit shares minted
+ *      to this contract → redeem shares → assets forwarded to receiver
  *
  *      DESIGN:
  *      - Fully immutable: no admin, no upgrades, no sweep
- *      - Zero-admin: receiver is set once at construction
- *      - Permissionless: anyone can call redeemAndForward()
+ *      - Keeper-gated: only the designated keeper can trigger
  *      - Single-purpose: assets can only flow to the hardcoded receiver
  *      - Strategy is passed as a call-time parameter to avoid circular dependencies
  */
@@ -38,8 +51,11 @@ contract YieldForwarder {
     /// @notice Thrown when the receiver address is zero
     error InvalidReceiver();
 
-    /// @notice Thrown when there are no shares to redeem
-    error NoSharesToRedeem();
+    /// @notice Thrown when the keeper address is zero
+    error InvalidKeeper();
+
+    /// @notice Thrown when caller is not the authorized keeper
+    error OnlyKeeper();
 
     // ============================================
     // EVENTS
@@ -60,15 +76,22 @@ contract YieldForwarder {
     /// @dev Set once at construction, cannot be changed
     address public immutable receiver;
 
+    /// @notice The address authorized to trigger report and forward
+    /// @dev Set once at construction, cannot be changed
+    address public immutable keeper;
+
     // ============================================
     // CONSTRUCTOR
     // ============================================
 
-    /// @notice Creates a new YieldForwarder with a fixed receiver
+    /// @notice Creates a new YieldForwarder with a fixed receiver and keeper
     /// @param _receiver Address that will receive all forwarded assets
-    constructor(address _receiver) {
+    /// @param _keeper Address authorized to call reportAndForward
+    constructor(address _receiver, address _keeper) {
         if (_receiver == address(0)) revert InvalidReceiver();
+        if (_keeper == address(0)) revert InvalidKeeper();
         receiver = _receiver;
+        keeper = _keeper;
     }
 
     // ============================================
@@ -76,16 +99,25 @@ contract YieldForwarder {
     // ============================================
 
     /**
-     * @notice Redeems all strategy shares held by this contract and forwards assets to receiver
-     * @dev Permissionless - anyone can call this to trigger redemption and forwarding.
-     *      The strategy address is passed as a parameter to avoid circular deployment dependencies.
-     * @param strategy Address of the strategy contract (must implement IRedeemable and IERC20)
+     * @notice Calls report() on the strategy, redeems any profit shares, and forwards assets
+     * @dev Only callable by the authorized keeper. This contract must be set as the
+     *      strategy's keeper (so it can call report()) and as its donation address
+     *      (so profit shares are minted here).
+     *
+     *      If report() produces no profit shares, the function returns 0 without reverting
+     *      (the report itself may still be useful for loss accounting).
+     *
+     * @param strategy Address of the strategy contract (must implement IReportable, IRedeemable, IERC20)
      * @param maxLoss Maximum acceptable loss in basis points for the redemption
-     * @return assets Amount of underlying assets forwarded to receiver
+     * @return assets Amount of underlying assets forwarded to receiver (0 if no profit shares)
      */
-    function redeemAndForward(address strategy, uint256 maxLoss) external returns (uint256 assets) {
+    function reportAndForward(address strategy, uint256 maxLoss) external returns (uint256 assets) {
+        if (msg.sender != keeper) revert OnlyKeeper();
+
+        IReportable(strategy).report();
+
         uint256 shares = IERC20(strategy).balanceOf(address(this));
-        if (shares == 0) revert NoSharesToRedeem();
+        if (shares == 0) return 0;
 
         assets = IRedeemable(strategy).redeem(shares, receiver, address(this), maxLoss);
 

--- a/src/factories/YieldForwarderFactory.sol
+++ b/src/factories/YieldForwarderFactory.sol
@@ -13,7 +13,7 @@ import { YieldForwarder } from "src/core/YieldForwarder.sol";
  *
  *      DEPLOYMENT PATTERN:
  *      - Full bytecode deployment via CREATE2 for deterministic addresses
- *      - Salt includes receiver, caller-provided salt, and deployer for uniqueness
+ *      - Salt includes receiver, keeper, caller-provided salt, and deployer for uniqueness
  *      - Each deployment tracked per deployer
  *
  *      FEATURES:
@@ -35,6 +35,8 @@ contract YieldForwarderFactory {
         address forwarderAddress;
         /// @notice Address of the receiver configured in the forwarder
         address receiver;
+        /// @notice Address of the keeper configured in the forwarder
+        address keeper;
     }
 
     // ============================================
@@ -54,11 +56,13 @@ contract YieldForwarderFactory {
     /// @param forwarderAddress Address of the deployed forwarder
     /// @param salt Caller-provided salt used for CREATE2
     /// @param receiver Address configured as the forwarder's receiver
+    /// @param keeper Address configured as the forwarder's keeper
     event YieldForwarderCreated(
         address indexed deployer,
         address indexed forwarderAddress,
         bytes32 indexed salt,
-        address receiver
+        address receiver,
+        address keeper
     );
 
     // ============================================
@@ -74,15 +78,20 @@ contract YieldForwarderFactory {
 
     /**
      * @notice Creates a new YieldForwarder instance with deterministic address
-     * @dev Uses CREATE2 with a salt derived from receiver, caller-provided salt, and msg.sender.
+     * @dev Uses CREATE2 with a salt derived from receiver, keeper, caller-provided salt, and msg.sender.
      *      This allows governance proposals to use a fixed salt, avoiding race conditions.
      * @param _receiver Address that will receive forwarded assets
+     * @param _keeper Address authorized to call reportAndForward on the forwarder
      * @param _salt Caller-provided salt for deterministic address
      * @return forwarder Address of newly created YieldForwarder
      */
-    function createYieldForwarder(address _receiver, bytes32 _salt) external returns (address forwarder) {
-        bytes32 finalSalt = _computeFinalSalt(_receiver, _salt, msg.sender);
-        bytes memory bytecode = _getCreationBytecode(_receiver);
+    function createYieldForwarder(
+        address _receiver,
+        address _keeper,
+        bytes32 _salt
+    ) external returns (address forwarder) {
+        bytes32 finalSalt = _computeFinalSalt(_receiver, _keeper, _salt, msg.sender);
+        bytes memory bytecode = _getCreationBytecode(_receiver, _keeper);
 
         // Check if forwarder already exists at predicted address
         address predicted = Create2.computeAddress(finalSalt, keccak256(bytecode));
@@ -93,26 +102,28 @@ contract YieldForwarderFactory {
         forwarder = Create2.deploy(0, finalSalt, bytecode);
 
         // Track deployment
-        deployerToForwarders[msg.sender].push(ForwarderInfo(forwarder, _receiver));
+        deployerToForwarders[msg.sender].push(ForwarderInfo(forwarder, _receiver, _keeper));
 
-        emit YieldForwarderCreated(msg.sender, forwarder, _salt, _receiver);
+        emit YieldForwarderCreated(msg.sender, forwarder, _salt, _receiver, _keeper);
     }
 
     /**
      * @notice Predicts the deterministic address where a YieldForwarder will be deployed
      * @dev Uses CREATE2 address computation with the same salt derivation as createYieldForwarder
      * @param _receiver Address that will be the forwarder's receiver
+     * @param _keeper Address that will be the forwarder's keeper
      * @param _salt The same salt that will be passed to createYieldForwarder
      * @param _deployer Address that will call createYieldForwarder
      * @return predicted Predicted address of deployment
      */
     function computeYieldForwarderAddress(
         address _receiver,
+        address _keeper,
         bytes32 _salt,
         address _deployer
     ) external view returns (address predicted) {
-        bytes32 finalSalt = _computeFinalSalt(_receiver, _salt, _deployer);
-        bytes memory bytecode = _getCreationBytecode(_receiver);
+        bytes32 finalSalt = _computeFinalSalt(_receiver, _keeper, _salt, _deployer);
+        bytes memory bytecode = _getCreationBytecode(_receiver, _keeper);
         predicted = Create2.computeAddress(finalSalt, keccak256(bytecode));
     }
 
@@ -131,22 +142,29 @@ contract YieldForwarderFactory {
     // ============================================
 
     /**
-     * @dev Computes the final CREATE2 salt from receiver, caller salt, and deployer
+     * @dev Computes the final CREATE2 salt from receiver, keeper, caller salt, and deployer
      * @param _receiver Forwarder receiver address
+     * @param _keeper Forwarder keeper address
      * @param _salt Caller-provided salt
      * @param _deployer Deployer address
      * @return Final salt for CREATE2
      */
-    function _computeFinalSalt(address _receiver, bytes32 _salt, address _deployer) internal pure returns (bytes32) {
-        return keccak256(abi.encodePacked(keccak256(abi.encode(_receiver, _salt)), _deployer));
+    function _computeFinalSalt(
+        address _receiver,
+        address _keeper,
+        bytes32 _salt,
+        address _deployer
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(keccak256(abi.encode(_receiver, _keeper, _salt)), _deployer));
     }
 
     /**
-     * @dev Returns the creation bytecode for a YieldForwarder with the given receiver
+     * @dev Returns the creation bytecode for a YieldForwarder with the given params
      * @param _receiver Receiver address to encode in constructor args
+     * @param _keeper Keeper address to encode in constructor args
      * @return Creation bytecode including constructor args
      */
-    function _getCreationBytecode(address _receiver) internal pure returns (bytes memory) {
-        return abi.encodePacked(type(YieldForwarder).creationCode, abi.encode(_receiver));
+    function _getCreationBytecode(address _receiver, address _keeper) internal pure returns (bytes memory) {
+        return abi.encodePacked(type(YieldForwarder).creationCode, abi.encode(_receiver, _keeper));
     }
 }

--- a/src/factories/YieldForwarderFactory.sol
+++ b/src/factories/YieldForwarderFactory.sol
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+/**
+ * @title YieldForwarder Factory
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice Factory for deploying YieldForwarder instances via CREATE2
+ * @dev Uses full CREATE2 deployment (not proxy) since the contract is tiny.
+ *
+ *      DEPLOYMENT PATTERN:
+ *      - Full bytecode deployment via CREATE2 for deterministic addresses
+ *      - Salt includes receiver, caller-provided salt, and deployer for uniqueness
+ *      - Each deployment tracked per deployer
+ *
+ *      FEATURES:
+ *      - Deterministic addresses via CREATE2
+ *      - Deployment tracking per deployer
+ *      - Address prediction for governance proposals
+ */
+contract YieldForwarderFactory {
+    // ============================================
+    // STRUCTS
+    // ============================================
+
+    /**
+     * @notice Information about a deployed yield forwarder
+     * @dev Stored for each deployer to track their forwarders
+     */
+    struct ForwarderInfo {
+        /// @notice Address of the deployed forwarder contract
+        address forwarderAddress;
+        /// @notice Address of the receiver configured in the forwarder
+        address receiver;
+    }
+
+    // ============================================
+    // STATE VARIABLES
+    // ============================================
+
+    /// @notice Mapping of deployers to their deployed forwarders
+    /// @dev Allows tracking and enumeration of forwarders per deployer
+    mapping(address => ForwarderInfo[]) public deployerToForwarders;
+
+    // ============================================
+    // EVENTS
+    // ============================================
+
+    /// @notice Emitted when a new YieldForwarder is created
+    /// @param deployer Address that deployed the forwarder
+    /// @param forwarderAddress Address of the deployed forwarder
+    /// @param salt Caller-provided salt used for CREATE2
+    /// @param receiver Address configured as the forwarder's receiver
+    event YieldForwarderCreated(
+        address indexed deployer,
+        address indexed forwarderAddress,
+        bytes32 indexed salt,
+        address receiver
+    );
+
+    // ============================================
+    // ERRORS
+    // ============================================
+
+    /// @notice Thrown when a forwarder already exists at the predicted address
+    error ForwarderAlreadyExists(address existingForwarder);
+
+    // ============================================
+    // EXTERNAL FUNCTIONS
+    // ============================================
+
+    /**
+     * @notice Creates a new YieldForwarder instance with deterministic address
+     * @dev Uses CREATE2 with a salt derived from receiver, caller-provided salt, and msg.sender.
+     *      This allows governance proposals to use a fixed salt, avoiding race conditions.
+     * @param _receiver Address that will receive forwarded assets
+     * @param _salt Caller-provided salt for deterministic address
+     * @return forwarder Address of newly created YieldForwarder
+     */
+    function createYieldForwarder(address _receiver, bytes32 _salt) external returns (address forwarder) {
+        bytes32 finalSalt = _computeFinalSalt(_receiver, _salt, msg.sender);
+        bytes memory bytecode = _getCreationBytecode(_receiver);
+
+        // Check if forwarder already exists at predicted address
+        address predicted = Create2.computeAddress(finalSalt, keccak256(bytecode));
+        if (predicted.code.length > 0) {
+            revert ForwarderAlreadyExists(predicted);
+        }
+
+        forwarder = Create2.deploy(0, finalSalt, bytecode);
+
+        // Track deployment
+        deployerToForwarders[msg.sender].push(ForwarderInfo(forwarder, _receiver));
+
+        emit YieldForwarderCreated(msg.sender, forwarder, _salt, _receiver);
+    }
+
+    /**
+     * @notice Predicts the deterministic address where a YieldForwarder will be deployed
+     * @dev Uses CREATE2 address computation with the same salt derivation as createYieldForwarder
+     * @param _receiver Address that will be the forwarder's receiver
+     * @param _salt The same salt that will be passed to createYieldForwarder
+     * @param _deployer Address that will call createYieldForwarder
+     * @return predicted Predicted address of deployment
+     */
+    function computeYieldForwarderAddress(
+        address _receiver,
+        bytes32 _salt,
+        address _deployer
+    ) external view returns (address predicted) {
+        bytes32 finalSalt = _computeFinalSalt(_receiver, _salt, _deployer);
+        bytes memory bytecode = _getCreationBytecode(_receiver);
+        predicted = Create2.computeAddress(finalSalt, keccak256(bytecode));
+    }
+
+    /**
+     * @notice Returns all yield forwarders created by a specific deployer
+     * @dev May be expensive for deployers with many forwarders
+     * @param _deployer Address to query forwarders for
+     * @return forwarders Array of deployed forwarders with receiver info
+     */
+    function getForwardersByDeployer(address _deployer) external view returns (ForwarderInfo[] memory) {
+        return deployerToForwarders[_deployer];
+    }
+
+    // ============================================
+    // INTERNAL HELPERS
+    // ============================================
+
+    /**
+     * @dev Computes the final CREATE2 salt from receiver, caller salt, and deployer
+     * @param _receiver Forwarder receiver address
+     * @param _salt Caller-provided salt
+     * @param _deployer Deployer address
+     * @return Final salt for CREATE2
+     */
+    function _computeFinalSalt(address _receiver, bytes32 _salt, address _deployer) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(keccak256(abi.encode(_receiver, _salt)), _deployer));
+    }
+
+    /**
+     * @dev Returns the creation bytecode for a YieldForwarder with the given receiver
+     * @param _receiver Receiver address to encode in constructor args
+     * @return Creation bytecode including constructor args
+     */
+    function _getCreationBytecode(address _receiver) internal pure returns (bytes memory) {
+        return abi.encodePacked(type(YieldForwarder).creationCode, abi.encode(_receiver));
+    }
+}

--- a/test/integration/nouns/GenerateProposalCalldataGovernance.t.sol
+++ b/test/integration/nouns/GenerateProposalCalldataGovernance.t.sol
@@ -275,7 +275,9 @@ contract GenerateProposalCalldataGovernanceTest is Test {
 
         // Event signatures
         bytes32 strategyDeploySelector = keccak256("StrategyDeploy(address,address,address,string)");
-        bytes32 yieldForwarderCreatedSelector = keccak256("YieldForwarderCreated(address,address,bytes32,address)");
+        bytes32 yieldForwarderCreatedSelector = keccak256(
+            "YieldForwarderCreated(address,address,bytes32,address,address)"
+        );
 
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].topics[0] == strategyDeploySelector) {
@@ -299,12 +301,15 @@ contract GenerateProposalCalldataGovernanceTest is Test {
         // VERIFY: YieldForwarder deployed and receiver matches expected Payer
         // ════════════════════════════════════════════════════════════════════════
         assertTrue(deployedYieldForwarder.code.length > 0, "YieldForwarder should have bytecode deployed");
-        address forwarderReceiver = YieldForwarder(deployedYieldForwarder).receiver();
-        // The receiver should be NOUNS_PAYER (0x0eCC079C20DaA9fDE0e26b6d745c0b38479ff200)
         assertEq(
-            forwarderReceiver,
+            YieldForwarder(deployedYieldForwarder).receiver(),
             0x0eCC079C20DaA9fDE0e26b6d745c0b38479ff200,
             "YieldForwarder receiver should match Nouns Payer"
+        );
+        assertEq(
+            YieldForwarder(deployedYieldForwarder).keeper(),
+            0x0eCC079C20DaA9fDE0e26b6d745c0b38479ff200,
+            "YieldForwarder keeper should match Keeper Bot"
         );
 
         // ════════════════════════════════════════════════════════════════════════

--- a/test/integration/nouns/GenerateProposalCalldataGovernance.t.sol
+++ b/test/integration/nouns/GenerateProposalCalldataGovernance.t.sol
@@ -8,9 +8,10 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 // Import the actual script we're testing
 import { GenerateProposalCalldata } from "partners/nouns_dao/script/GenerateProposalCalldata.s.sol";
 
-// Import factories for event definitions
+// Import factories for event definitions and bytecode etching
 import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
-import { PaymentSplitterFactory } from "src/factories/PaymentSplitterFactory.sol";
+import { YieldForwarderFactory } from "src/factories/YieldForwarderFactory.sol";
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
 
 /// @notice Nouns DAO Governor interface (minimal)
 interface INounsDAOProxy {
@@ -56,7 +57,7 @@ interface IWstETH {
  *      2. Calls getProposalTransactions() to get the EXACT calldata
  *      3. Creates a Nouns DAO proposal with that calldata
  *      4. Executes full governance flow: propose → vote → queue → execute
- *      5. Verifies: PaymentSplitter deployed, Strategy deployed, Treasury has shares
+ *      5. Verifies: YieldForwarder deployed, Strategy deployed, Treasury has shares
  *
  *      If the script changes, this test automatically uses the new values.
  */
@@ -74,8 +75,8 @@ contract GenerateProposalCalldataGovernanceTest is Test {
     /// @notice wstETH token address
     address public constant WSTETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
 
-    /// @notice PaymentSplitterFactory mainnet address (needs bytecode etch for new salt-based methods)
-    address public constant PAYMENT_SPLITTER_FACTORY = 0x5711765E0756B45224fc1FdA1B41ab344682bBcb;
+    /// @notice YieldForwarderFactory address (same placeholder as script for bytecode etching)
+    address public constant YIELD_FORWARDER_FACTORY = 0x5711765E0756B45224fc1FdA1B41ab344682bBcb;
 
     /// @notice Vote type: For
     uint8 public constant VOTE_FOR = 1;
@@ -103,7 +104,7 @@ contract GenerateProposalCalldataGovernanceTest is Test {
     uint256 public depositAmount;
 
     /// @notice Actual deployed addresses (captured from events after execution)
-    address public deployedPaymentSplitter;
+    address public deployedYieldForwarder;
     address public deployedStrategy;
 
     // ══════════════════════════════════════════════════════════════════════════════
@@ -117,12 +118,11 @@ contract GenerateProposalCalldataGovernanceTest is Test {
 
         // ════════════════════════════════════════════════════════════════════════
         // ETCH UPDATED FACTORY BYTECODE
-        // The mainnet-deployed PaymentSplitterFactory doesn't have the new
-        // salt-based methods yet. Deploy a fresh instance and etch its
-        // runtime bytecode onto the mainnet address.
+        // The mainnet address doesn't have the YieldForwarderFactory yet.
+        // Deploy a fresh instance and etch its runtime bytecode onto the address.
         // ════════════════════════════════════════════════════════════════════════
-        PaymentSplitterFactory updatedFactory = new PaymentSplitterFactory();
-        vm.etch(PAYMENT_SPLITTER_FACTORY, address(updatedFactory).code);
+        YieldForwarderFactory updatedFactory = new YieldForwarderFactory();
+        vm.etch(YIELD_FORWARDER_FACTORY, address(updatedFactory).code);
 
         // ════════════════════════════════════════════════════════════════════════
         // INSTANTIATE THE SCRIPT - This is the key part!
@@ -275,32 +275,37 @@ contract GenerateProposalCalldataGovernanceTest is Test {
 
         // Event signatures
         bytes32 strategyDeploySelector = keccak256("StrategyDeploy(address,address,address,string)");
-        bytes32 paymentSplitterCreatedSelector = keccak256(
-            "PaymentSplitterCreatedWithSalt(address,address,bytes32,address[],string[],uint256[])"
-        );
+        bytes32 yieldForwarderCreatedSelector = keccak256("YieldForwarderCreated(address,address,bytes32,address)");
 
         for (uint256 i = 0; i < logs.length; i++) {
             if (logs[i].topics[0] == strategyDeploySelector) {
                 // StrategyDeploy: topic1=deployer, topic2=donationAddress, topic3=strategyAddress
                 deployedStrategy = address(uint160(uint256(logs[i].topics[3])));
                 vm.label(deployedStrategy, "DeployedStrategy");
-            } else if (logs[i].topics[0] == paymentSplitterCreatedSelector) {
-                // PaymentSplitterCreated: topic1=deployer, topic2=paymentSplitter
-                deployedPaymentSplitter = address(uint160(uint256(logs[i].topics[2])));
-                vm.label(deployedPaymentSplitter, "DeployedPaymentSplitter");
+            } else if (logs[i].topics[0] == yieldForwarderCreatedSelector) {
+                // YieldForwarderCreated: topic1=deployer, topic2=forwarderAddress
+                deployedYieldForwarder = address(uint160(uint256(logs[i].topics[2])));
+                vm.label(deployedYieldForwarder, "DeployedYieldForwarder");
             }
         }
 
         // Verify we found both addresses
         require(deployedStrategy != address(0), "StrategyDeploy event not found");
-        require(deployedPaymentSplitter != address(0), "PaymentSplitterCreated event not found");
+        require(deployedYieldForwarder != address(0), "YieldForwarderCreated event not found");
     }
 
     function _verifyExecution() internal view {
         // ════════════════════════════════════════════════════════════════════════
-        // VERIFY: PaymentSplitter deployed (address captured from event)
+        // VERIFY: YieldForwarder deployed and receiver matches expected Payer
         // ════════════════════════════════════════════════════════════════════════
-        assertTrue(deployedPaymentSplitter.code.length > 0, "PaymentSplitter should have bytecode deployed");
+        assertTrue(deployedYieldForwarder.code.length > 0, "YieldForwarder should have bytecode deployed");
+        address forwarderReceiver = YieldForwarder(deployedYieldForwarder).receiver();
+        // The receiver should be NOUNS_PAYER (0x0eCC079C20DaA9fDE0e26b6d745c0b38479ff200)
+        assertEq(
+            forwarderReceiver,
+            0x0eCC079C20DaA9fDE0e26b6d745c0b38479ff200,
+            "YieldForwarder receiver should match Nouns Payer"
+        );
 
         // ════════════════════════════════════════════════════════════════════════
         // VERIFY: LidoStrategy deployed (address captured from event)

--- a/test/unit/core/YieldForwarder.t.sol
+++ b/test/unit/core/YieldForwarder.t.sol
@@ -1,0 +1,181 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { YieldForwarder, IRedeemable } from "src/core/YieldForwarder.sol";
+
+/// @notice Mock strategy that acts as both an ERC20 (shares) and implements redeem
+/// @dev Mints shares to simulate strategy share allocation, redeems by burning shares
+///      and transferring a separate "asset" token to the receiver
+contract MockRedeemableStrategy is ERC20 {
+    ERC20 public asset;
+
+    constructor(ERC20 _asset) ERC20("Mock Strategy", "mSTRAT") {
+        asset = _asset;
+    }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    /// @notice Simulates strategy redemption: burns shares from owner, transfers assets to receiver
+    /// @dev Returns assets 1:1 with shares for simplicity
+    function redeem(
+        uint256 shares,
+        address receiver,
+        address owner,
+        uint256 maxLoss
+    ) external returns (uint256 assets) {
+        // Silence unused param warning
+        maxLoss;
+
+        _burn(owner, shares);
+        assets = shares; // 1:1 for testing
+        asset.transfer(receiver, assets);
+    }
+}
+
+/// @notice Simple mock asset token
+contract MockAsset is ERC20 {
+    constructor() ERC20("Mock Asset", "mASSET") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}
+
+contract YieldForwarderTest is Test {
+    YieldForwarder public forwarder;
+    MockAsset public asset;
+    MockRedeemableStrategy public strategy;
+
+    address public receiver = address(0xBEEF);
+    address public caller = address(0xCAFE);
+
+    function setUp() public {
+        asset = new MockAsset();
+        strategy = new MockRedeemableStrategy(asset);
+        forwarder = new YieldForwarder(receiver);
+
+        vm.label(receiver, "Receiver");
+        vm.label(caller, "Caller");
+        vm.label(address(forwarder), "YieldForwarder");
+        vm.label(address(strategy), "MockStrategy");
+        vm.label(address(asset), "MockAsset");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // CONSTRUCTOR TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_constructor_setsReceiver() public view {
+        assertEq(forwarder.receiver(), receiver);
+    }
+
+    function test_constructor_revertsOnZeroReceiver() public {
+        vm.expectRevert(YieldForwarder.InvalidReceiver.selector);
+        new YieldForwarder(address(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // redeemAndForward TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_redeemAndForward_success() public {
+        uint256 shareAmount = 100e18;
+
+        // Give forwarder some strategy shares
+        strategy.mint(address(forwarder), shareAmount);
+        // Fund strategy with assets so it can pay out
+        asset.mint(address(strategy), shareAmount);
+
+        // Anyone can call
+        vm.prank(caller);
+        uint256 assets = forwarder.redeemAndForward(address(strategy), 0);
+
+        // Assets should arrive at receiver
+        assertEq(assets, shareAmount);
+        assertEq(asset.balanceOf(receiver), shareAmount);
+        // Forwarder should have no shares left
+        assertEq(strategy.balanceOf(address(forwarder)), 0);
+    }
+
+    function test_redeemAndForward_revertsOnZeroShares() public {
+        // No shares allocated to forwarder
+        vm.expectRevert(YieldForwarder.NoSharesToRedeem.selector);
+        forwarder.redeemAndForward(address(strategy), 0);
+    }
+
+    function test_redeemAndForward_emitsEvent() public {
+        uint256 shareAmount = 50e18;
+
+        strategy.mint(address(forwarder), shareAmount);
+        asset.mint(address(strategy), shareAmount);
+
+        vm.expectEmit(true, true, false, true);
+        emit YieldForwarder.YieldForwarded(address(strategy), receiver, shareAmount, shareAmount);
+
+        forwarder.redeemAndForward(address(strategy), 0);
+    }
+
+    function test_redeemAndForward_permissionless_multipleCaller() public {
+        // First caller
+        uint256 amount1 = 30e18;
+        strategy.mint(address(forwarder), amount1);
+        asset.mint(address(strategy), amount1);
+
+        vm.prank(address(0x1111));
+        forwarder.redeemAndForward(address(strategy), 0);
+        assertEq(asset.balanceOf(receiver), amount1);
+
+        // Second caller
+        uint256 amount2 = 70e18;
+        strategy.mint(address(forwarder), amount2);
+        asset.mint(address(strategy), amount2);
+
+        vm.prank(address(0x2222));
+        forwarder.redeemAndForward(address(strategy), 0);
+        assertEq(asset.balanceOf(receiver), amount1 + amount2);
+    }
+
+    function test_redeemAndForward_multipleStrategies() public {
+        // Create a second strategy with a separate asset
+        MockAsset asset2 = new MockAsset();
+        MockRedeemableStrategy strategy2 = new MockRedeemableStrategy(asset2);
+
+        uint256 amount1 = 40e18;
+        uint256 amount2 = 60e18;
+
+        // Fund both strategies
+        strategy.mint(address(forwarder), amount1);
+        asset.mint(address(strategy), amount1);
+
+        strategy2.mint(address(forwarder), amount2);
+        asset2.mint(address(strategy2), amount2);
+
+        // Redeem from strategy 1
+        forwarder.redeemAndForward(address(strategy), 0);
+        assertEq(asset.balanceOf(receiver), amount1);
+
+        // Redeem from strategy 2
+        forwarder.redeemAndForward(address(strategy2), 0);
+        assertEq(asset2.balanceOf(receiver), amount2);
+
+        // Forwarder should have no shares in either
+        assertEq(strategy.balanceOf(address(forwarder)), 0);
+        assertEq(strategy2.balanceOf(address(forwarder)), 0);
+    }
+
+    function test_redeemAndForward_passesMaxLoss() public {
+        // This test verifies the maxLoss parameter is passed through
+        // by checking that the call succeeds with a non-zero maxLoss
+        uint256 shareAmount = 10e18;
+        strategy.mint(address(forwarder), shareAmount);
+        asset.mint(address(strategy), shareAmount);
+
+        uint256 assets = forwarder.redeemAndForward(address(strategy), 100); // 100 basis points
+        assertEq(assets, shareAmount);
+    }
+}

--- a/test/unit/core/YieldForwarder.t.sol
+++ b/test/unit/core/YieldForwarder.t.sol
@@ -3,81 +3,93 @@ pragma solidity ^0.8.25;
 
 import { Test, Vm } from "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { YieldForwarder, IRedeemable, IReportable } from "src/core/YieldForwarder.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
-/// @notice Mock strategy that acts as both an ERC20 (shares) and implements report + redeem
-/// @dev On report(), mints profit shares to the configured donation address.
-///      On redeem(), burns shares from owner and transfers assets 1:1 to receiver.
-contract MockRedeemableStrategy is ERC20 {
-    ERC20 public asset;
-    address public donationAddress;
-    uint256 public profitPerReport;
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 
-    constructor(ERC20 _asset) ERC20("Mock Strategy", "mSTRAT") {
-        asset = _asset;
-    }
-
-    function setDonationAddress(address _addr) external {
-        donationAddress = _addr;
-    }
-
-    function setProfitPerReport(uint256 _amount) external {
-        profitPerReport = _amount;
-    }
-
-    /// @notice Simulates strategy report: mints profit shares to donation address
-    function report() external returns (uint256 profit, uint256 loss) {
-        if (profitPerReport > 0) {
-            _mint(donationAddress, profitPerReport);
-        }
-        return (profitPerReport, 0);
-    }
-
-    /// @notice Simulates strategy redemption: burns shares from owner, transfers assets to receiver
-    function redeem(
-        uint256 shares,
-        address receiver,
-        address owner,
-        uint256 maxLoss
-    ) external returns (uint256 assets) {
-        maxLoss; // silence unused param
-        _burn(owner, shares);
-        assets = shares; // 1:1 for testing
-        asset.transfer(receiver, assets);
-    }
-}
-
-/// @notice Simple mock asset token
-contract MockAsset is ERC20 {
-    constructor() ERC20("Mock Asset", "mASSET") {}
-
-    function mint(address to, uint256 amount) external {
-        _mint(to, amount);
-    }
-}
+import { MockFactory } from "test/mocks/MockFactory.sol";
+import { MockStrategy } from "test/mocks/core/tokenized-strategies/MockStrategy.sol";
+import { MockYieldSource } from "test/mocks/core/tokenized-strategies/MockYieldSource.sol";
+import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
 
 contract YieldForwarderTest is Test {
     YieldForwarder public forwarder;
-    MockAsset public asset;
-    MockRedeemableStrategy public strategy;
+    ERC20Mock public asset;
+    IMockStrategy public strategy;
+    MockYieldSource public yieldSource;
+    MockFactory public mockFactory;
+    YieldDonatingTokenizedStrategy public implementation;
 
     address public receiver = address(0xBEEF);
     address public keeperEOA = address(0xCAFE);
+    address public management = address(0xA1);
+    address public emergencyAdmin = address(0xA2);
+    address public user = address(0xA3);
+    address public protocolFeeRecipient = address(0xA4);
+
+    uint256 public constant DEPOSIT_AMOUNT = 100e18;
 
     function setUp() public {
-        asset = new MockAsset();
-        strategy = new MockRedeemableStrategy(asset);
+        // Deploy factory (0 fees for clean test math)
+        mockFactory = new MockFactory(0, protocolFeeRecipient);
+
+        // Deploy YieldDonatingTokenizedStrategy implementation
+        implementation = new YieldDonatingTokenizedStrategy();
+
+        // Deploy asset and yield source
+        asset = new ERC20Mock();
+        yieldSource = new MockYieldSource(address(asset));
+
+        // Deploy YieldForwarder first (address needed for strategy config)
         forwarder = new YieldForwarder(receiver, keeperEOA);
 
-        // Configure mock: profit shares go to the forwarder
-        strategy.setDonationAddress(address(forwarder));
+        // Deploy strategy with the forwarder as both keeper and donation address
+        strategy = IMockStrategy(
+            address(
+                new MockStrategy(
+                    address(asset),
+                    address(yieldSource),
+                    management,
+                    address(forwarder), // keeper = forwarder (so forwarder can call report())
+                    emergencyAdmin,
+                    address(forwarder), // donationAddress = forwarder (profit shares go here)
+                    address(implementation)
+                )
+            )
+        );
 
+        // Configure strategy roles
+        vm.startPrank(management);
+        strategy.setKeeper(address(forwarder));
+        strategy.setEmergencyAdmin(emergencyAdmin);
+        strategy.setPendingManagement(management);
+        strategy.acceptManagement();
+        vm.stopPrank();
+
+        // Labels
         vm.label(receiver, "Receiver");
         vm.label(keeperEOA, "KeeperEOA");
         vm.label(address(forwarder), "YieldForwarder");
-        vm.label(address(strategy), "MockStrategy");
-        vm.label(address(asset), "MockAsset");
+        vm.label(address(strategy), "Strategy");
+        vm.label(address(asset), "Asset");
+        vm.label(address(yieldSource), "YieldSource");
+        vm.label(management, "Management");
+        vm.label(user, "User");
+    }
+
+    /// @dev Mints assets to a user, approves, and deposits into the strategy
+    function _depositIntoStrategy(address _user, uint256 _amount) internal {
+        asset.mint(_user, _amount);
+        vm.startPrank(_user);
+        asset.approve(address(strategy), _amount);
+        strategy.deposit(_amount, _user);
+        vm.stopPrank();
+    }
+
+    /// @dev Simulates yield by minting extra assets directly to the yield source
+    function _simulateProfit(uint256 _profit) internal {
+        asset.mint(address(yieldSource), _profit);
     }
 
     // ═══════════════════════════════════════════════════════════
@@ -103,23 +115,32 @@ contract YieldForwarderTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════
-    // reportAndForward TESTS
+    // reportAndForward — FULL VAULT INTEGRATION TESTS
     // ═══════════════════════════════════════════════════════════
 
-    function test_reportAndForward_success() public {
-        uint256 profitAmount = 100e18;
-        strategy.setProfitPerReport(profitAmount);
-        // Fund strategy with assets so it can pay out on redeem
-        asset.mint(address(strategy), profitAmount);
+    function test_reportAndForward_fullFlow() public {
+        // 1. User deposits into strategy
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
 
+        // 2. Strategy deploys funds to yield source on report
+        //    (initial report to move idle → deployed)
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        // 3. Simulate profit in yield source
+        uint256 profit = 10e18;
+        _simulateProfit(profit);
+
+        // 4. Keeper triggers reportAndForward
+        uint256 receiverBalanceBefore = asset.balanceOf(receiver);
         vm.prank(keeperEOA);
-        uint256 assets = forwarder.reportAndForward(address(strategy), 0);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 10_000);
 
-        // Assets should arrive at receiver
-        assertEq(assets, profitAmount);
-        assertEq(asset.balanceOf(receiver), profitAmount);
-        // Forwarder should have no shares left
-        assertEq(strategy.balanceOf(address(forwarder)), 0);
+        // 5. Verify: assets forwarded to receiver
+        assertGt(assets, 0, "Should forward nonzero assets");
+        assertEq(asset.balanceOf(receiver), receiverBalanceBefore + assets, "Receiver should get forwarded assets");
+        // 6. Forwarder should hold no shares
+        assertEq(strategy.balanceOf(address(forwarder)), 0, "Forwarder should have 0 shares");
     }
 
     function test_reportAndForward_revertsWhenNotKeeper() public {
@@ -130,33 +151,53 @@ contract YieldForwarderTest is Test {
     }
 
     function test_reportAndForward_zeroProfit_returnsZero() public {
-        // No profit configured (default 0)
-        vm.prank(keeperEOA);
-        uint256 assets = forwarder.reportAndForward(address(strategy), 0);
+        // Deposit but no yield → report produces no profit
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
 
-        assertEq(assets, 0);
-        assertEq(asset.balanceOf(receiver), 0);
+        // Initial report to deploy funds
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        // No profit simulated; second report has nothing new
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 10_000);
+
+        assertEq(assets, 0, "Should return 0 when no profit");
+        assertEq(asset.balanceOf(receiver), 0, "Receiver should get nothing");
     }
 
     function test_reportAndForward_emitsEvent() public {
-        uint256 profitAmount = 50e18;
-        strategy.setProfitPerReport(profitAmount);
-        asset.mint(address(strategy), profitAmount);
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
 
-        vm.expectEmit(true, true, false, true);
-        emit YieldForwarder.YieldForwarded(address(strategy), receiver, profitAmount, profitAmount);
+        // Deploy funds
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        // Simulate profit
+        uint256 profit = 20e18;
+        _simulateProfit(profit);
+
+        // We expect a YieldForwarded event with the strategy and receiver addresses
+        // The exact shares/assets depend on vault math, so check indexed params only
+        vm.expectEmit(true, true, false, false);
+        emit YieldForwarder.YieldForwarded(address(strategy), receiver, 0, 0);
 
         vm.prank(keeperEOA);
-        forwarder.reportAndForward(address(strategy), 0);
+        forwarder.reportAndForward(address(strategy), 10_000);
     }
 
     function test_reportAndForward_noEventOnZeroProfit() public {
-        // With zero profit, no YieldForwarded event should be emitted
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+
+        // Deploy funds
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        // No profit — check no YieldForwarded event
         vm.recordLogs();
         vm.prank(keeperEOA);
-        forwarder.reportAndForward(address(strategy), 0);
+        forwarder.reportAndForward(address(strategy), 10_000);
 
-        // Check no YieldForwarded event was emitted
         bytes32 yieldForwardedSelector = keccak256("YieldForwarded(address,address,uint256,uint256)");
         Vm.Log[] memory logs = vm.getRecordedLogs();
         for (uint256 i = 0; i < logs.length; i++) {
@@ -168,57 +209,156 @@ contract YieldForwarderTest is Test {
     }
 
     function test_reportAndForward_multipleReports() public {
-        uint256 profit1 = 30e18;
-        uint256 profit2 = 70e18;
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
 
-        // First report
-        strategy.setProfitPerReport(profit1);
-        asset.mint(address(strategy), profit1);
-        vm.prank(keeperEOA);
-        forwarder.reportAndForward(address(strategy), 0);
-        assertEq(asset.balanceOf(receiver), profit1);
+        // Deploy funds
+        vm.prank(address(forwarder));
+        strategy.report();
 
-        // Second report
-        strategy.setProfitPerReport(profit2);
-        asset.mint(address(strategy), profit2);
+        // First profit cycle
+        uint256 profit1 = 5e18;
+        _simulateProfit(profit1);
+
         vm.prank(keeperEOA);
-        forwarder.reportAndForward(address(strategy), 0);
-        assertEq(asset.balanceOf(receiver), profit1 + profit2);
+        uint256 assets1 = forwarder.reportAndForward(address(strategy), 10_000);
+        assertGt(assets1, 0, "First report should yield assets");
+
+        // Second profit cycle
+        uint256 profit2 = 15e18;
+        _simulateProfit(profit2);
+
+        vm.prank(keeperEOA);
+        uint256 assets2 = forwarder.reportAndForward(address(strategy), 10_000);
+        assertGt(assets2, 0, "Second report should yield assets");
+
+        // Receiver accumulated both payouts
+        assertEq(asset.balanceOf(receiver), assets1 + assets2, "Receiver should accumulate all payouts");
     }
 
     function test_reportAndForward_multipleStrategies() public {
-        // Create a second strategy with a separate asset
-        MockAsset asset2 = new MockAsset();
-        MockRedeemableStrategy strategy2 = new MockRedeemableStrategy(asset2);
-        strategy2.setDonationAddress(address(forwarder));
+        // Create a second independent vault + yield source
+        ERC20Mock asset2 = new ERC20Mock();
+        MockYieldSource yieldSource2 = new MockYieldSource(address(asset2));
 
-        uint256 profit1 = 40e18;
-        uint256 profit2 = 60e18;
+        IMockStrategy strategy2 = IMockStrategy(
+            address(
+                new MockStrategy(
+                    address(asset2),
+                    address(yieldSource2),
+                    management,
+                    address(forwarder),
+                    emergencyAdmin,
+                    address(forwarder),
+                    address(implementation)
+                )
+            )
+        );
 
-        // Fund both strategies
-        strategy.setProfitPerReport(profit1);
-        asset.mint(address(strategy), profit1);
-        strategy2.setProfitPerReport(profit2);
-        asset2.mint(address(strategy2), profit2);
+        vm.startPrank(management);
+        strategy2.setKeeper(address(forwarder));
+        strategy2.setEmergencyAdmin(emergencyAdmin);
+        strategy2.setPendingManagement(management);
+        strategy2.acceptManagement();
+        vm.stopPrank();
 
-        // Report from strategy 1
+        // Deposit into both strategies
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+
+        asset2.mint(user, DEPOSIT_AMOUNT);
+        vm.startPrank(user);
+        asset2.approve(address(strategy2), DEPOSIT_AMOUNT);
+        strategy2.deposit(DEPOSIT_AMOUNT, user);
+        vm.stopPrank();
+
+        // Deploy funds for both
+        vm.prank(address(forwarder));
+        strategy.report();
+        vm.prank(address(forwarder));
+        strategy2.report();
+
+        // Simulate profit in both
+        uint256 profit1 = 8e18;
+        uint256 profit2 = 12e18;
+        asset.mint(address(yieldSource), profit1);
+        asset2.mint(address(yieldSource2), profit2);
+
+        // Forward from strategy 1
         vm.prank(keeperEOA);
-        forwarder.reportAndForward(address(strategy), 0);
-        assertEq(asset.balanceOf(receiver), profit1);
+        uint256 assets1 = forwarder.reportAndForward(address(strategy), 10_000);
+        assertGt(assets1, 0, "Strategy 1 should produce assets");
+        assertEq(asset.balanceOf(receiver), assets1);
 
-        // Report from strategy 2
+        // Forward from strategy 2
         vm.prank(keeperEOA);
-        forwarder.reportAndForward(address(strategy2), 0);
-        assertEq(asset2.balanceOf(receiver), profit2);
+        uint256 assets2 = forwarder.reportAndForward(address(strategy2), 10_000);
+        assertGt(assets2, 0, "Strategy 2 should produce assets");
+        assertEq(asset2.balanceOf(receiver), assets2);
     }
 
     function test_reportAndForward_passesMaxLoss() public {
-        uint256 profitAmount = 10e18;
-        strategy.setProfitPerReport(profitAmount);
-        asset.mint(address(strategy), profitAmount);
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+
+        // Deploy funds
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        // Simulate profit
+        _simulateProfit(10e18);
+
+        // Use specific maxLoss (100 bps = 1%)
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 100);
+        assertGt(assets, 0, "Should succeed with maxLoss=100bps");
+    }
+
+    function test_reportAndForward_lossScenario_noSharesMinted() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+
+        // Deploy funds
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        // Simulate a loss in yield source (assets disappear)
+        uint256 loss = 5e18;
+        vm.prank(address(strategy));
+        yieldSource.simulateLoss(loss);
+
+        // Report should register loss; no profit shares minted to forwarder
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 10_000);
+
+        assertEq(assets, 0, "Loss report should return 0 assets");
+        assertEq(strategy.balanceOf(address(forwarder)), 0, "No shares should remain");
+        assertEq(asset.balanceOf(receiver), 0, "Receiver gets nothing on loss");
+    }
+
+    function test_reportAndForward_fuzz_profitAmount(uint256 profit) public {
+        profit = bound(profit, 1e15, 1e27);
+
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+
+        // Deploy funds
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        // Simulate fuzzed profit
+        _simulateProfit(profit);
 
         vm.prank(keeperEOA);
-        uint256 assets = forwarder.reportAndForward(address(strategy), 100); // 100 basis points
-        assertEq(assets, profitAmount);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 10_000);
+
+        assertGt(assets, 0, "Should always forward positive assets for positive profit");
+        assertEq(strategy.balanceOf(address(forwarder)), 0, "Forwarder should redeem all shares");
+        assertEq(asset.balanceOf(receiver), assets, "Receiver balance should match returned assets");
+    }
+
+    function test_reportAndForward_donationAddressIsForwarder() public view {
+        // Verify the strategy's dragonRouter (donation address) is the forwarder
+        assertEq(strategy.dragonRouter(), address(forwarder), "Strategy donation address should be forwarder");
+    }
+
+    function test_reportAndForward_keeperIsForwarder() public view {
+        // Verify the strategy's keeper is the forwarder
+        assertEq(strategy.keeper(), address(forwarder), "Strategy keeper should be forwarder");
     }
 }

--- a/test/unit/core/YieldForwarder.t.sol
+++ b/test/unit/core/YieldForwarder.t.sol
@@ -1,36 +1,47 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { Test } from "forge-std/Test.sol";
+import { Test, Vm } from "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import { YieldForwarder, IRedeemable } from "src/core/YieldForwarder.sol";
+import { YieldForwarder, IRedeemable, IReportable } from "src/core/YieldForwarder.sol";
 
-/// @notice Mock strategy that acts as both an ERC20 (shares) and implements redeem
-/// @dev Mints shares to simulate strategy share allocation, redeems by burning shares
-///      and transferring a separate "asset" token to the receiver
+/// @notice Mock strategy that acts as both an ERC20 (shares) and implements report + redeem
+/// @dev On report(), mints profit shares to the configured donation address.
+///      On redeem(), burns shares from owner and transfers assets 1:1 to receiver.
 contract MockRedeemableStrategy is ERC20 {
     ERC20 public asset;
+    address public donationAddress;
+    uint256 public profitPerReport;
 
     constructor(ERC20 _asset) ERC20("Mock Strategy", "mSTRAT") {
         asset = _asset;
     }
 
-    function mint(address to, uint256 amount) external {
-        _mint(to, amount);
+    function setDonationAddress(address _addr) external {
+        donationAddress = _addr;
+    }
+
+    function setProfitPerReport(uint256 _amount) external {
+        profitPerReport = _amount;
+    }
+
+    /// @notice Simulates strategy report: mints profit shares to donation address
+    function report() external returns (uint256 profit, uint256 loss) {
+        if (profitPerReport > 0) {
+            _mint(donationAddress, profitPerReport);
+        }
+        return (profitPerReport, 0);
     }
 
     /// @notice Simulates strategy redemption: burns shares from owner, transfers assets to receiver
-    /// @dev Returns assets 1:1 with shares for simplicity
     function redeem(
         uint256 shares,
         address receiver,
         address owner,
         uint256 maxLoss
     ) external returns (uint256 assets) {
-        // Silence unused param warning
-        maxLoss;
-
+        maxLoss; // silence unused param
         _burn(owner, shares);
         assets = shares; // 1:1 for testing
         asset.transfer(receiver, assets);
@@ -52,15 +63,18 @@ contract YieldForwarderTest is Test {
     MockRedeemableStrategy public strategy;
 
     address public receiver = address(0xBEEF);
-    address public caller = address(0xCAFE);
+    address public keeperEOA = address(0xCAFE);
 
     function setUp() public {
         asset = new MockAsset();
         strategy = new MockRedeemableStrategy(asset);
-        forwarder = new YieldForwarder(receiver);
+        forwarder = new YieldForwarder(receiver, keeperEOA);
+
+        // Configure mock: profit shares go to the forwarder
+        strategy.setDonationAddress(address(forwarder));
 
         vm.label(receiver, "Receiver");
-        vm.label(caller, "Caller");
+        vm.label(keeperEOA, "KeeperEOA");
         vm.label(address(forwarder), "YieldForwarder");
         vm.label(address(strategy), "MockStrategy");
         vm.label(address(asset), "MockAsset");
@@ -74,108 +88,137 @@ contract YieldForwarderTest is Test {
         assertEq(forwarder.receiver(), receiver);
     }
 
+    function test_constructor_setsKeeper() public view {
+        assertEq(forwarder.keeper(), keeperEOA);
+    }
+
     function test_constructor_revertsOnZeroReceiver() public {
         vm.expectRevert(YieldForwarder.InvalidReceiver.selector);
-        new YieldForwarder(address(0));
+        new YieldForwarder(address(0), keeperEOA);
+    }
+
+    function test_constructor_revertsOnZeroKeeper() public {
+        vm.expectRevert(YieldForwarder.InvalidKeeper.selector);
+        new YieldForwarder(receiver, address(0));
     }
 
     // ═══════════════════════════════════════════════════════════
-    // redeemAndForward TESTS
+    // reportAndForward TESTS
     // ═══════════════════════════════════════════════════════════
 
-    function test_redeemAndForward_success() public {
-        uint256 shareAmount = 100e18;
+    function test_reportAndForward_success() public {
+        uint256 profitAmount = 100e18;
+        strategy.setProfitPerReport(profitAmount);
+        // Fund strategy with assets so it can pay out on redeem
+        asset.mint(address(strategy), profitAmount);
 
-        // Give forwarder some strategy shares
-        strategy.mint(address(forwarder), shareAmount);
-        // Fund strategy with assets so it can pay out
-        asset.mint(address(strategy), shareAmount);
-
-        // Anyone can call
-        vm.prank(caller);
-        uint256 assets = forwarder.redeemAndForward(address(strategy), 0);
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 0);
 
         // Assets should arrive at receiver
-        assertEq(assets, shareAmount);
-        assertEq(asset.balanceOf(receiver), shareAmount);
+        assertEq(assets, profitAmount);
+        assertEq(asset.balanceOf(receiver), profitAmount);
         // Forwarder should have no shares left
         assertEq(strategy.balanceOf(address(forwarder)), 0);
     }
 
-    function test_redeemAndForward_revertsOnZeroShares() public {
-        // No shares allocated to forwarder
-        vm.expectRevert(YieldForwarder.NoSharesToRedeem.selector);
-        forwarder.redeemAndForward(address(strategy), 0);
+    function test_reportAndForward_revertsWhenNotKeeper() public {
+        address nonKeeper = address(0x1111);
+        vm.prank(nonKeeper);
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        forwarder.reportAndForward(address(strategy), 0);
     }
 
-    function test_redeemAndForward_emitsEvent() public {
-        uint256 shareAmount = 50e18;
+    function test_reportAndForward_zeroProfit_returnsZero() public {
+        // No profit configured (default 0)
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 0);
 
-        strategy.mint(address(forwarder), shareAmount);
-        asset.mint(address(strategy), shareAmount);
+        assertEq(assets, 0);
+        assertEq(asset.balanceOf(receiver), 0);
+    }
+
+    function test_reportAndForward_emitsEvent() public {
+        uint256 profitAmount = 50e18;
+        strategy.setProfitPerReport(profitAmount);
+        asset.mint(address(strategy), profitAmount);
 
         vm.expectEmit(true, true, false, true);
-        emit YieldForwarder.YieldForwarded(address(strategy), receiver, shareAmount, shareAmount);
+        emit YieldForwarder.YieldForwarded(address(strategy), receiver, profitAmount, profitAmount);
 
-        forwarder.redeemAndForward(address(strategy), 0);
+        vm.prank(keeperEOA);
+        forwarder.reportAndForward(address(strategy), 0);
     }
 
-    function test_redeemAndForward_permissionless_multipleCaller() public {
-        // First caller
-        uint256 amount1 = 30e18;
-        strategy.mint(address(forwarder), amount1);
-        asset.mint(address(strategy), amount1);
+    function test_reportAndForward_noEventOnZeroProfit() public {
+        // With zero profit, no YieldForwarded event should be emitted
+        vm.recordLogs();
+        vm.prank(keeperEOA);
+        forwarder.reportAndForward(address(strategy), 0);
 
-        vm.prank(address(0x1111));
-        forwarder.redeemAndForward(address(strategy), 0);
-        assertEq(asset.balanceOf(receiver), amount1);
-
-        // Second caller
-        uint256 amount2 = 70e18;
-        strategy.mint(address(forwarder), amount2);
-        asset.mint(address(strategy), amount2);
-
-        vm.prank(address(0x2222));
-        forwarder.redeemAndForward(address(strategy), 0);
-        assertEq(asset.balanceOf(receiver), amount1 + amount2);
+        // Check no YieldForwarded event was emitted
+        bytes32 yieldForwardedSelector = keccak256("YieldForwarded(address,address,uint256,uint256)");
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i = 0; i < logs.length; i++) {
+            assertTrue(
+                logs[i].topics[0] != yieldForwardedSelector,
+                "YieldForwarded should not be emitted on zero profit"
+            );
+        }
     }
 
-    function test_redeemAndForward_multipleStrategies() public {
+    function test_reportAndForward_multipleReports() public {
+        uint256 profit1 = 30e18;
+        uint256 profit2 = 70e18;
+
+        // First report
+        strategy.setProfitPerReport(profit1);
+        asset.mint(address(strategy), profit1);
+        vm.prank(keeperEOA);
+        forwarder.reportAndForward(address(strategy), 0);
+        assertEq(asset.balanceOf(receiver), profit1);
+
+        // Second report
+        strategy.setProfitPerReport(profit2);
+        asset.mint(address(strategy), profit2);
+        vm.prank(keeperEOA);
+        forwarder.reportAndForward(address(strategy), 0);
+        assertEq(asset.balanceOf(receiver), profit1 + profit2);
+    }
+
+    function test_reportAndForward_multipleStrategies() public {
         // Create a second strategy with a separate asset
         MockAsset asset2 = new MockAsset();
         MockRedeemableStrategy strategy2 = new MockRedeemableStrategy(asset2);
+        strategy2.setDonationAddress(address(forwarder));
 
-        uint256 amount1 = 40e18;
-        uint256 amount2 = 60e18;
+        uint256 profit1 = 40e18;
+        uint256 profit2 = 60e18;
 
         // Fund both strategies
-        strategy.mint(address(forwarder), amount1);
-        asset.mint(address(strategy), amount1);
+        strategy.setProfitPerReport(profit1);
+        asset.mint(address(strategy), profit1);
+        strategy2.setProfitPerReport(profit2);
+        asset2.mint(address(strategy2), profit2);
 
-        strategy2.mint(address(forwarder), amount2);
-        asset2.mint(address(strategy2), amount2);
+        // Report from strategy 1
+        vm.prank(keeperEOA);
+        forwarder.reportAndForward(address(strategy), 0);
+        assertEq(asset.balanceOf(receiver), profit1);
 
-        // Redeem from strategy 1
-        forwarder.redeemAndForward(address(strategy), 0);
-        assertEq(asset.balanceOf(receiver), amount1);
-
-        // Redeem from strategy 2
-        forwarder.redeemAndForward(address(strategy2), 0);
-        assertEq(asset2.balanceOf(receiver), amount2);
-
-        // Forwarder should have no shares in either
-        assertEq(strategy.balanceOf(address(forwarder)), 0);
-        assertEq(strategy2.balanceOf(address(forwarder)), 0);
+        // Report from strategy 2
+        vm.prank(keeperEOA);
+        forwarder.reportAndForward(address(strategy2), 0);
+        assertEq(asset2.balanceOf(receiver), profit2);
     }
 
-    function test_redeemAndForward_passesMaxLoss() public {
-        // This test verifies the maxLoss parameter is passed through
-        // by checking that the call succeeds with a non-zero maxLoss
-        uint256 shareAmount = 10e18;
-        strategy.mint(address(forwarder), shareAmount);
-        asset.mint(address(strategy), shareAmount);
+    function test_reportAndForward_passesMaxLoss() public {
+        uint256 profitAmount = 10e18;
+        strategy.setProfitPerReport(profitAmount);
+        asset.mint(address(strategy), profitAmount);
 
-        uint256 assets = forwarder.redeemAndForward(address(strategy), 100); // 100 basis points
-        assertEq(assets, shareAmount);
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 100); // 100 basis points
+        assertEq(assets, profitAmount);
     }
 }

--- a/test/unit/factories/YieldForwarderFactory.t.sol
+++ b/test/unit/factories/YieldForwarderFactory.t.sol
@@ -9,6 +9,7 @@ contract YieldForwarderFactoryTest is Test {
     YieldForwarderFactory public factory;
 
     address public receiver = address(0xBEEF);
+    address public keeperEOA = address(0xCAFE);
     address public alice = address(0x1);
     address public bob = address(0x2);
 
@@ -16,6 +17,7 @@ contract YieldForwarderFactoryTest is Test {
         factory = new YieldForwarderFactory();
 
         vm.label(receiver, "Receiver");
+        vm.label(keeperEOA, "KeeperEOA");
         vm.label(alice, "Alice");
         vm.label(bob, "Bob");
     }
@@ -24,20 +26,21 @@ contract YieldForwarderFactoryTest is Test {
     // CREATION TESTS
     // ═══════════════════════════════════════════════════════════
 
-    function test_createYieldForwarder_createsWithCorrectReceiver() public {
+    function test_createYieldForwarder_createsWithCorrectParams() public {
         bytes32 salt = keccak256("test-salt-v1");
 
-        address forwarderAddr = factory.createYieldForwarder(receiver, salt);
+        address forwarderAddr = factory.createYieldForwarder(receiver, keeperEOA, salt);
 
         assertTrue(forwarderAddr != address(0));
         assertEq(YieldForwarder(forwarderAddr).receiver(), receiver);
+        assertEq(YieldForwarder(forwarderAddr).keeper(), keeperEOA);
     }
 
     function test_createYieldForwarder_create2PredictionMatchesActual() public {
         bytes32 salt = keccak256("predict-test-v1");
 
-        address predicted = factory.computeYieldForwarderAddress(receiver, salt, address(this));
-        address actual = factory.createYieldForwarder(receiver, salt);
+        address predicted = factory.computeYieldForwarderAddress(receiver, keeperEOA, salt, address(this));
+        address actual = factory.createYieldForwarder(receiver, keeperEOA, salt);
 
         assertEq(actual, predicted, "CREATE2 prediction should match actual deployment");
     }
@@ -46,24 +49,24 @@ contract YieldForwarderFactoryTest is Test {
         bytes32 salt = keccak256("unique-salt");
 
         // First deployment succeeds
-        factory.createYieldForwarder(receiver, salt);
+        factory.createYieldForwarder(receiver, keeperEOA, salt);
 
         // Second deployment with same salt should fail
         vm.expectRevert(
             abi.encodeWithSelector(
                 YieldForwarderFactory.ForwarderAlreadyExists.selector,
-                factory.computeYieldForwarderAddress(receiver, salt, address(this))
+                factory.computeYieldForwarderAddress(receiver, keeperEOA, salt, address(this))
             )
         );
-        factory.createYieldForwarder(receiver, salt);
+        factory.createYieldForwarder(receiver, keeperEOA, salt);
     }
 
     function test_createYieldForwarder_differentSaltsProduceDifferentAddresses() public {
         bytes32 salt1 = keccak256("salt-1");
         bytes32 salt2 = keccak256("salt-2");
 
-        address addr1 = factory.createYieldForwarder(receiver, salt1);
-        address addr2 = factory.createYieldForwarder(receiver, salt2);
+        address addr1 = factory.createYieldForwarder(receiver, keeperEOA, salt1);
+        address addr2 = factory.createYieldForwarder(receiver, keeperEOA, salt2);
 
         assertTrue(addr1 != addr2, "Different salts should produce different addresses");
     }
@@ -72,11 +75,11 @@ contract YieldForwarderFactoryTest is Test {
         bytes32 salt = keccak256("shared-salt");
 
         // Deploy from this contract
-        address addr1 = factory.createYieldForwarder(receiver, salt);
+        address addr1 = factory.createYieldForwarder(receiver, keeperEOA, salt);
 
-        // Deploy from alice with same salt and receiver
+        // Deploy from alice with same salt and params
         vm.prank(alice);
-        address addr2 = factory.createYieldForwarder(receiver, salt);
+        address addr2 = factory.createYieldForwarder(receiver, keeperEOA, salt);
 
         assertTrue(addr1 != addr2, "Different deployers should get different addresses");
     }
@@ -90,17 +93,20 @@ contract YieldForwarderFactoryTest is Test {
         bytes32 salt2 = keccak256("track-2");
 
         address receiver2 = address(0xDEAD);
+        address keeper2 = address(0xFACE);
 
-        address addr1 = factory.createYieldForwarder(receiver, salt1);
-        address addr2 = factory.createYieldForwarder(receiver2, salt2);
+        address addr1 = factory.createYieldForwarder(receiver, keeperEOA, salt1);
+        address addr2 = factory.createYieldForwarder(receiver2, keeper2, salt2);
 
         YieldForwarderFactory.ForwarderInfo[] memory forwarders = factory.getForwardersByDeployer(address(this));
 
         assertEq(forwarders.length, 2, "Should have 2 forwarders");
         assertEq(forwarders[0].forwarderAddress, addr1);
         assertEq(forwarders[0].receiver, receiver);
+        assertEq(forwarders[0].keeper, keeperEOA);
         assertEq(forwarders[1].forwarderAddress, addr2);
         assertEq(forwarders[1].receiver, receiver2);
+        assertEq(forwarders[1].keeper, keeper2);
     }
 
     function test_getForwardersByDeployer_emptyForUnknownDeployer() public view {
@@ -114,12 +120,12 @@ contract YieldForwarderFactoryTest is Test {
 
     function test_createYieldForwarder_emitsEvent() public {
         bytes32 salt = keccak256("event-test-salt");
-        address predicted = factory.computeYieldForwarderAddress(receiver, salt, address(this));
+        address predicted = factory.computeYieldForwarderAddress(receiver, keeperEOA, salt, address(this));
 
         vm.expectEmit(true, true, true, true);
-        emit YieldForwarderFactory.YieldForwarderCreated(address(this), predicted, salt, receiver);
+        emit YieldForwarderFactory.YieldForwarderCreated(address(this), predicted, salt, receiver, keeperEOA);
 
-        factory.createYieldForwarder(receiver, salt);
+        factory.createYieldForwarder(receiver, keeperEOA, salt);
     }
 
     // ═══════════════════════════════════════════════════════════
@@ -131,6 +137,14 @@ contract YieldForwarderFactoryTest is Test {
 
         // Should bubble up InvalidReceiver from YieldForwarder constructor
         vm.expectRevert();
-        factory.createYieldForwarder(address(0), salt);
+        factory.createYieldForwarder(address(0), keeperEOA, salt);
+    }
+
+    function test_createYieldForwarder_revertsOnZeroKeeper() public {
+        bytes32 salt = keccak256("zero-keeper-test");
+
+        // Should bubble up InvalidKeeper from YieldForwarder constructor
+        vm.expectRevert();
+        factory.createYieldForwarder(receiver, address(0), salt);
     }
 }

--- a/test/unit/factories/YieldForwarderFactory.t.sol
+++ b/test/unit/factories/YieldForwarderFactory.t.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { YieldForwarderFactory } from "src/factories/YieldForwarderFactory.sol";
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+contract YieldForwarderFactoryTest is Test {
+    YieldForwarderFactory public factory;
+
+    address public receiver = address(0xBEEF);
+    address public alice = address(0x1);
+    address public bob = address(0x2);
+
+    function setUp() public {
+        factory = new YieldForwarderFactory();
+
+        vm.label(receiver, "Receiver");
+        vm.label(alice, "Alice");
+        vm.label(bob, "Bob");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // CREATION TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_createYieldForwarder_createsWithCorrectReceiver() public {
+        bytes32 salt = keccak256("test-salt-v1");
+
+        address forwarderAddr = factory.createYieldForwarder(receiver, salt);
+
+        assertTrue(forwarderAddr != address(0));
+        assertEq(YieldForwarder(forwarderAddr).receiver(), receiver);
+    }
+
+    function test_createYieldForwarder_create2PredictionMatchesActual() public {
+        bytes32 salt = keccak256("predict-test-v1");
+
+        address predicted = factory.computeYieldForwarderAddress(receiver, salt, address(this));
+        address actual = factory.createYieldForwarder(receiver, salt);
+
+        assertEq(actual, predicted, "CREATE2 prediction should match actual deployment");
+    }
+
+    function test_createYieldForwarder_duplicateReverts() public {
+        bytes32 salt = keccak256("unique-salt");
+
+        // First deployment succeeds
+        factory.createYieldForwarder(receiver, salt);
+
+        // Second deployment with same salt should fail
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                YieldForwarderFactory.ForwarderAlreadyExists.selector,
+                factory.computeYieldForwarderAddress(receiver, salt, address(this))
+            )
+        );
+        factory.createYieldForwarder(receiver, salt);
+    }
+
+    function test_createYieldForwarder_differentSaltsProduceDifferentAddresses() public {
+        bytes32 salt1 = keccak256("salt-1");
+        bytes32 salt2 = keccak256("salt-2");
+
+        address addr1 = factory.createYieldForwarder(receiver, salt1);
+        address addr2 = factory.createYieldForwarder(receiver, salt2);
+
+        assertTrue(addr1 != addr2, "Different salts should produce different addresses");
+    }
+
+    function test_createYieldForwarder_differentDeployersProduceDifferentAddresses() public {
+        bytes32 salt = keccak256("shared-salt");
+
+        // Deploy from this contract
+        address addr1 = factory.createYieldForwarder(receiver, salt);
+
+        // Deploy from alice with same salt and receiver
+        vm.prank(alice);
+        address addr2 = factory.createYieldForwarder(receiver, salt);
+
+        assertTrue(addr1 != addr2, "Different deployers should get different addresses");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // TRACKING TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_getForwardersByDeployer_returnsCorrectData() public {
+        bytes32 salt1 = keccak256("track-1");
+        bytes32 salt2 = keccak256("track-2");
+
+        address receiver2 = address(0xDEAD);
+
+        address addr1 = factory.createYieldForwarder(receiver, salt1);
+        address addr2 = factory.createYieldForwarder(receiver2, salt2);
+
+        YieldForwarderFactory.ForwarderInfo[] memory forwarders = factory.getForwardersByDeployer(address(this));
+
+        assertEq(forwarders.length, 2, "Should have 2 forwarders");
+        assertEq(forwarders[0].forwarderAddress, addr1);
+        assertEq(forwarders[0].receiver, receiver);
+        assertEq(forwarders[1].forwarderAddress, addr2);
+        assertEq(forwarders[1].receiver, receiver2);
+    }
+
+    function test_getForwardersByDeployer_emptyForUnknownDeployer() public view {
+        YieldForwarderFactory.ForwarderInfo[] memory forwarders = factory.getForwardersByDeployer(address(0xDEAD));
+        assertEq(forwarders.length, 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // EVENT TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_createYieldForwarder_emitsEvent() public {
+        bytes32 salt = keccak256("event-test-salt");
+        address predicted = factory.computeYieldForwarderAddress(receiver, salt, address(this));
+
+        vm.expectEmit(true, true, true, true);
+        emit YieldForwarderFactory.YieldForwarderCreated(address(this), predicted, salt, receiver);
+
+        factory.createYieldForwarder(receiver, salt);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // VALIDATION TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_createYieldForwarder_revertsOnZeroReceiver() public {
+        bytes32 salt = keccak256("zero-receiver-test");
+
+        // Should bubble up InvalidReceiver from YieldForwarder constructor
+        vm.expectRevert();
+        factory.createYieldForwarder(address(0), salt);
+    }
+}


### PR DESCRIPTION
## Replace PaymentSplitter with YieldForwarder for Nouns DAO yield flow

### Problem

The current PaymentSplitter is pull-based — it receives profit shares but doesn't redeem them or trigger reports. This requires manual claims and separate keeper logic.

### Solution

`YieldForwarder` is a single-purpose, immutable contract that atomically reports, redeems, and forwards yield in one call:

```
Keeper EOA → YieldForwarder.reportAndForward()
  → strategy.report()        // triggers profit accounting, shares minted to forwarder
  → strategy.redeem()         // burns shares, sends underlying assets to receiver
  → assets arrive at receiver (Nouns Payer)
```

The YieldForwarder acts as both the strategy's **keeper** (authorized to call `report()`) and its **donation address** (receives profit shares). This eliminates the need for a separate splitter or manual redemption step.

### Changes

- **`src/core/YieldForwarder.sol`** — immutable `receiver` + `keeper`, single `reportAndForward(strategy, maxLoss)` function, zero-admin
- **`src/factories/YieldForwarderFactory.sol`** — CREATE2 factory with deterministic addressing and deployment tracking for governance proposals
- **`partners/nouns_dao/script/GenerateProposalCalldata.s.sol`** — updated proposal: TX1 deploys forwarder, TX2-4 deploy strategy with forwarder as both keeper and donation address
- **`test/`** — 22 unit tests + updated governance integration test
