### PR TITLE
Feature/osu 1347 rewritten on develop

### DIFF
--- a/src/core/MultistrategyLockedVault.sol
+++ b/src/core/MultistrategyLockedVault.sol
@@ -482,10 +482,12 @@ contract MultistrategyLockedVault is MultistrategyVault, IMultistrategyLockedVau
         super._transfer(sender_, receiver_, amount_);
     }
 
+    /// @inheritdoc IMultistrategyLockedVault
     function getPendingRageQuitCooldownPeriod() external view returns (uint256) {
         return pendingRageQuitCooldownPeriod;
     }
 
+    /// @inheritdoc IMultistrategyLockedVault
     function getRageQuitCooldownPeriodChangeTimestamp() external view returns (uint256) {
         return rageQuitCooldownPeriodChangeTimestamp;
     }

--- a/src/core/MultistrategyLockedVault.sol
+++ b/src/core/MultistrategyLockedVault.sol
@@ -572,4 +572,95 @@ contract MultistrategyLockedVault is MultistrategyVault, IMultistrategyLockedVau
         // Otherwise, they can rage quit all their shares
         return balanceOf(user);
     }
+
+    /**
+     * @notice Get the maximum amount of assets that can be withdrawn by an owner
+     * @param owner_ The address that owns the shares
+     * @param maxLoss_ Custom max_loss if any
+     * @param strategiesArray_ Custom strategies queue if any
+     * @return The maximum amount of assets that can be withdrawn
+     * @dev This override accounts for custody constraints - returns 0 if:
+     *      - Custody is still in cooldown period
+     *      - Otherwise returns min of parent calculation and custodied shares in asset terms
+     */
+    function maxWithdraw(
+        address owner_,
+        uint256 maxLoss_,
+        address[] calldata strategiesArray_
+    ) external view override(MultistrategyVault, IMultistrategyVault) returns (uint256) {
+        CustodyInfo memory custody = custodyInfo[owner_];
+        if (block.timestamp < custody.unlockTime) {
+            return 0;
+        }
+
+        // Get the max from parent implementation
+        uint256 parentMax = _maxWithdraw(owner_, maxLoss_, strategiesArray_);
+
+        // Convert custodied shares to assets
+        uint256 custodyAssets = _convertToAssets(custody.lockedShares, Rounding.ROUND_DOWN);
+
+        // Return minimum of parent max and custody limit
+        return Math.min(parentMax, custodyAssets);
+    }
+
+    /**
+     * @notice Get the maximum amount of shares that can be redeemed by an owner
+     * @param owner_ The address that owns the shares
+     * @param maxLoss_ Custom max_loss if any
+     * @param strategiesArray_ Custom strategies queue if any
+     * @return The maximum amount of shares that can be redeemed
+     * @dev This override accounts for custody constraints - returns 0 if:
+     *      - Custody is still in cooldown period
+     *      - Otherwise returns min of balance and custodied shares
+     */
+    function maxRedeem(
+        address owner_,
+        uint256 maxLoss_,
+        address[] calldata strategiesArray_
+    ) external view override(MultistrategyVault, IMultistrategyVault) returns (uint256) {
+        CustodyInfo memory custody = custodyInfo[owner_];
+
+        if (block.timestamp < custody.unlockTime) {
+            return 0;
+        }
+
+        // Get max shares from parent calculation
+        uint256 parentMax = Math.min(
+            _convertToShares(_maxWithdraw(owner_, maxLoss_, strategiesArray_), Rounding.ROUND_DOWN),
+            balanceOf(owner_)
+        );
+
+        // Get custody info to determine locked shares
+        uint256 lockedShares = custody.lockedShares;
+
+        // Return minimum of parent max and custody limit
+        return Math.min(parentMax, lockedShares);
+    }
+
+    /**
+     * @notice Get the amount of shares that can be transferred by a user
+     * @param user The address to check transferable shares for
+     * @return The amount of shares available for transfer (not locked in custody)
+     * @dev Returns total balance minus shares currently locked in custody
+     */
+    function getTransferableShares(address user) external view returns (uint256) {
+        uint256 totalShares = balanceOf(user);
+        uint256 lockedShares = custodyInfo[user].lockedShares;
+        return totalShares - lockedShares;
+    }
+
+    /**
+     * @notice Get the amount of shares available for rage quit initiation
+     * @param user The address to check rage quitable shares for
+     * @return The amount of shares available for initiating rage quit
+     * @dev Returns 0 if user already has active custody, otherwise returns full balance
+     */
+    function getRageQuitableShares(address user) external view returns (uint256) {
+        // If user already has active custody, they cannot initiate new rage quit
+        if (custodyInfo[user].lockedShares > 0) {
+            return 0;
+        }
+        // Otherwise, they can rage quit all their shares
+        return balanceOf(user);
+    }
 }

--- a/src/core/MultistrategyLockedVault.sol
+++ b/src/core/MultistrategyLockedVault.sol
@@ -482,6 +482,14 @@ contract MultistrategyLockedVault is MultistrategyVault, IMultistrategyLockedVau
         super._transfer(sender_, receiver_, amount_);
     }
 
+    function getPendingRageQuitCooldownPeriod() external view returns (uint256) {
+        return pendingRageQuitCooldownPeriod;
+    }
+
+    function getRageQuitCooldownPeriodChangeTimestamp() external view returns (uint256) {
+        return rageQuitCooldownPeriodChangeTimestamp;
+    }
+
     /**
      * @notice Get the maximum amount of assets that can be withdrawn by an owner
      * @param owner_ Address owning shares to check withdrawal limits for
@@ -562,97 +570,6 @@ contract MultistrategyLockedVault is MultistrategyVault, IMultistrategyLockedVau
      * @notice Get the amount of shares available for rage quit initiation
      * @param user Address to check rage quitable shares for
      * @return Amount of shares available for initiating rage quit
-     * @dev Returns 0 if user already has active custody, otherwise returns full balance
-     */
-    function getRageQuitableShares(address user) external view returns (uint256) {
-        // If user already has active custody, they cannot initiate new rage quit
-        if (custodyInfo[user].lockedShares > 0) {
-            return 0;
-        }
-        // Otherwise, they can rage quit all their shares
-        return balanceOf(user);
-    }
-
-    /**
-     * @notice Get the maximum amount of assets that can be withdrawn by an owner
-     * @param owner_ The address that owns the shares
-     * @param maxLoss_ Custom max_loss if any
-     * @param strategiesArray_ Custom strategies queue if any
-     * @return The maximum amount of assets that can be withdrawn
-     * @dev This override accounts for custody constraints - returns 0 if:
-     *      - Custody is still in cooldown period
-     *      - Otherwise returns min of parent calculation and custodied shares in asset terms
-     */
-    function maxWithdraw(
-        address owner_,
-        uint256 maxLoss_,
-        address[] calldata strategiesArray_
-    ) external view override(MultistrategyVault, IMultistrategyVault) returns (uint256) {
-        CustodyInfo memory custody = custodyInfo[owner_];
-        if (block.timestamp < custody.unlockTime) {
-            return 0;
-        }
-
-        // Get the max from parent implementation
-        uint256 parentMax = _maxWithdraw(owner_, maxLoss_, strategiesArray_);
-
-        // Convert custodied shares to assets
-        uint256 custodyAssets = _convertToAssets(custody.lockedShares, Rounding.ROUND_DOWN);
-
-        // Return minimum of parent max and custody limit
-        return Math.min(parentMax, custodyAssets);
-    }
-
-    /**
-     * @notice Get the maximum amount of shares that can be redeemed by an owner
-     * @param owner_ The address that owns the shares
-     * @param maxLoss_ Custom max_loss if any
-     * @param strategiesArray_ Custom strategies queue if any
-     * @return The maximum amount of shares that can be redeemed
-     * @dev This override accounts for custody constraints - returns 0 if:
-     *      - Custody is still in cooldown period
-     *      - Otherwise returns min of balance and custodied shares
-     */
-    function maxRedeem(
-        address owner_,
-        uint256 maxLoss_,
-        address[] calldata strategiesArray_
-    ) external view override(MultistrategyVault, IMultistrategyVault) returns (uint256) {
-        CustodyInfo memory custody = custodyInfo[owner_];
-
-        if (block.timestamp < custody.unlockTime) {
-            return 0;
-        }
-
-        // Get max shares from parent calculation
-        uint256 parentMax = Math.min(
-            _convertToShares(_maxWithdraw(owner_, maxLoss_, strategiesArray_), Rounding.ROUND_DOWN),
-            balanceOf(owner_)
-        );
-
-        // Get custody info to determine locked shares
-        uint256 lockedShares = custody.lockedShares;
-
-        // Return minimum of parent max and custody limit
-        return Math.min(parentMax, lockedShares);
-    }
-
-    /**
-     * @notice Get the amount of shares that can be transferred by a user
-     * @param user The address to check transferable shares for
-     * @return The amount of shares available for transfer (not locked in custody)
-     * @dev Returns total balance minus shares currently locked in custody
-     */
-    function getTransferableShares(address user) external view returns (uint256) {
-        uint256 totalShares = balanceOf(user);
-        uint256 lockedShares = custodyInfo[user].lockedShares;
-        return totalShares - lockedShares;
-    }
-
-    /**
-     * @notice Get the amount of shares available for rage quit initiation
-     * @param user The address to check rage quitable shares for
-     * @return The amount of shares available for initiating rage quit
      * @dev Returns 0 if user already has active custody, otherwise returns full balance
      */
     function getRageQuitableShares(address user) external view returns (uint256) {

--- a/src/core/interfaces/IMultistrategyLockedVault.sol
+++ b/src/core/interfaces/IMultistrategyLockedVault.sol
@@ -107,7 +107,10 @@ interface IMultistrategyLockedVault is IMultistrategyVault {
      * @custom:security Only regen governance
      */
     function cancelRageQuitCooldownPeriodChange() external;
+    /// @notice Get the pending rage quit cooldown period awaiting governance timelock
     function getPendingRageQuitCooldownPeriod() external view returns (uint256);
+
+    /// @notice Get the timestamp when the rage quit cooldown period change was initiated
     function getRageQuitCooldownPeriodChangeTimestamp() external view returns (uint256);
 
     /**

--- a/src/core/interfaces/IMultistrategyLockedVault.sol
+++ b/src/core/interfaces/IMultistrategyLockedVault.sol
@@ -81,6 +81,25 @@ interface IMultistrategyLockedVault is IMultistrategyVault {
     error RageQuitCooldownPeriodChangeDelayElapsed();
     error InvalidGovernanceAddress();
 
+    // Events
+    event RageQuitInitiated(address indexed user, uint256 shares, uint256 unlockTime);
+    event RageQuitCooldownPeriodChanged(uint256 oldPeriod, uint256 newPeriod);
+    event PendingRageQuitCooldownPeriodChange(uint256 newPeriod, uint256 effectiveTimestamp);
+    event RageQuitCancelled(address indexed user, uint256 freedShares);
+    event RegenGovernanceChanged(address indexed previousGovernance, address indexed newGovernance);
+
+    // Storage for lockup information per user
+    struct LockupInfo {
+        uint256 lockupTime; // When the lockup started
+        uint256 unlockTime; // When shares become fully unlocked
+    }
+
+    // Custody struct to track locked shares during rage quit
+    struct CustodyInfo {
+        uint256 lockedShares; // Amount of shares locked for rage quit
+        uint256 unlockTime; // When the shares can be withdrawn
+    }
+
     /**
      * @notice Initiates a rage quit by locking shares until the unlock time is reached
      * @param shares Amount of vault shares to lock for rage quit
@@ -107,6 +126,8 @@ interface IMultistrategyLockedVault is IMultistrategyVault {
      * @custom:security Only regen governance
      */
     function cancelRageQuitCooldownPeriodChange() external;
+    function getPendingRageQuitCooldownPeriod() external view returns (uint256);
+    function getRageQuitCooldownPeriodChangeTimestamp() external view returns (uint256);
 
     /**
      * @notice Sets the regen governance address authorized to manage rage quit parameters
@@ -119,7 +140,6 @@ interface IMultistrategyLockedVault is IMultistrategyVault {
      * @notice Cancels an active rage quit for the caller and frees any locked shares
      */
     function cancelRageQuit() external;
-    function getCustodyInfo(address user) external view returns (uint256 lockedShares, uint256 unlockTime);
 
     /**
      * @notice Get the amount of shares that can be transferred by a user

--- a/src/core/interfaces/IMultistrategyLockedVault.sol
+++ b/src/core/interfaces/IMultistrategyLockedVault.sol
@@ -79,25 +79,7 @@ interface IMultistrategyLockedVault is IMultistrategyVault {
     error NoPendingRageQuitCooldownPeriodChange();
     error RageQuitCooldownPeriodChangeDelayNotElapsed();
     error InvalidGovernanceAddress();
-
-    // Events
-    event RageQuitInitiated(address indexed user, uint256 shares, uint256 unlockTime);
-    event RageQuitCooldownPeriodChanged(uint256 oldPeriod, uint256 newPeriod);
-    event PendingRageQuitCooldownPeriodChange(uint256 newPeriod, uint256 effectiveTimestamp);
-    event RageQuitCancelled(address indexed user, uint256 freedShares);
-    event RegenGovernanceChanged(address indexed previousGovernance, address indexed newGovernance);
-
-    // Storage for lockup information per user
-    struct LockupInfo {
-        uint256 lockupTime; // When the lockup started
-        uint256 unlockTime; // When shares become fully unlocked
-    }
-
-    // Custody struct to track locked shares during rage quit
-    struct CustodyInfo {
-        uint256 lockedShares; // Amount of shares locked for rage quit
-        uint256 unlockTime; // When the shares can be withdrawn
-    }
+    error RageQuitCooldownPeriodChangeDelayElapsed();
 
     /**
      * @notice Initiates a rage quit by locking shares until the unlock time is reached

--- a/src/core/interfaces/IMultistrategyLockedVault.sol
+++ b/src/core/interfaces/IMultistrategyLockedVault.sol
@@ -78,7 +78,6 @@ interface IMultistrategyLockedVault is IMultistrategyVault {
     error TransferExceedsAvailableShares();
     error NoPendingRageQuitCooldownPeriodChange();
     error RageQuitCooldownPeriodChangeDelayNotElapsed();
-    error RageQuitCooldownPeriodChangeDelayElapsed();
     error InvalidGovernanceAddress();
 
     // Events

--- a/src/core/interfaces/IMultistrategyLockedVault.sol
+++ b/src/core/interfaces/IMultistrategyLockedVault.sol
@@ -119,4 +119,19 @@ interface IMultistrategyLockedVault is IMultistrategyVault {
      * @notice Cancels an active rage quit for the caller and frees any locked shares
      */
     function cancelRageQuit() external;
+    function getCustodyInfo(address user) external view returns (uint256 lockedShares, uint256 unlockTime);
+
+    /**
+     * @notice Get the amount of shares that can be transferred by a user
+     * @param user The address to check transferable shares for
+     * @return The amount of shares available for transfer (not locked in custody)
+     */
+    function getTransferableShares(address user) external view returns (uint256);
+
+    /**
+     * @notice Get the amount of shares available for rage quit initiation
+     * @param user The address to check rage quitable shares for
+     * @return The amount of shares available for initiating rage quit
+     */
+    function getRageQuitableShares(address user) external view returns (uint256);
 }

--- a/src/regen/RegenStakerBase.sol
+++ b/src/regen/RegenStakerBase.sol
@@ -132,6 +132,10 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
     error CompoundingNotSupported();
     error CannotRaiseMinimumStakeAmountDuringActiveReward();
     error CannotRaiseMaxBumpTipDuringActiveReward();
+
+    /// @notice Error thrown when attempting to change earning power calculator during active reward
+    error CannotChangeEarningPowerCalculatorDuringActiveReward();
+
     error ZeroOperation();
     error NoOperation();
     error DisablingAllocationMechanismAllowsetNotAllowed();
@@ -830,6 +834,14 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
     }
 
     // === Overridden Functions ===
+
+    /// @inheritdoc Staker
+    /// @dev Overrides to block changes during active reward periods
+    function setEarningPowerCalculator(address _newEarningPowerCalculator) external virtual override {
+        _revertIfNotAdmin();
+        require(block.timestamp > rewardEndTime, CannotChangeEarningPowerCalculatorDuringActiveReward());
+        _setEarningPowerCalculator(_newEarningPowerCalculator);
+    }
 
     /// @notice Prevents staking 0, staking below the minimum, staking when paused, and unauthorized staking.
     /// @dev Uses reentrancy guard

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -750,8 +750,8 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         uint256 oldDragonBalance = _balanceOf(S, oldDragonRouter);
         uint256 newDragonBalance = _balanceOf(S, newDragonRouter);
 
-        if (_isVaultInsolvent() && oldDragonBalance > 0) {
-            revert("Dragon cannot operate during insolvency");
+        if (oldDragonBalance > 0) {
+            _requireDragonSolvency(oldDragonRouter);
         }
 
         // Migrate debt accounting:

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -340,11 +340,12 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
     }
 
     /**
-     * @notice Transfer shares with dragon solvency protection
+     * @notice Transfer shares with dragon solvency protection and debt rebalancing
      * @dev Special behaviors for dragon router:
      *      - Dragon cannot transfer to itself (reverts)
      *      - Dragon transfers trigger solvency checks to prevent user debt undercoverage
      *      - Transfers blocked if they would make vault unable to cover user debt
+     *      - Dragon-involved transfers rebalance debt tracking (sender loses debt, receiver gains it)
      *      For non-dragon transfers, behaves like standard ERC20 transfer
      * @param to Address receiving shares
      * @param amount Amount of shares to transfer
@@ -372,11 +373,12 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
     }
 
     /**
-     * @notice Transfer shares from one address to another with dragon solvency protection
+     * @notice Transfer shares from one address to another with dragon solvency protection and debt rebalancing
      * @dev Special behaviors for dragon router:
      *      - Dragon cannot transfer to itself (reverts)
      *      - Dragon transfers trigger solvency checks to prevent user debt undercoverage
      *      - Transfers blocked if they would make vault unable to cover user debt
+     *      - Dragon-involved transfers rebalance debt tracking (sender loses debt, receiver gains it)
      *      For non-dragon transfers, behaves like standard ERC20 transferFrom
      * @param from Address transferring shares
      * @param to Address receiving shares

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -305,10 +305,18 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      */
     function maxWithdraw(address owner) public view override returns (uint256) {
         StrategyData storage S = _strategyStorage();
-        if (owner == S.dragonRouter && _isVaultInsolvent()) {
-            return 0;
+
+        uint256 baseMaxWithdraw = super.maxWithdraw(owner);
+
+        // Apply dragon-specific restrictions
+        if (owner == S.dragonRouter) {
+            uint256 dragonMaxRedeemShares = _maxDragonRedeemableShares();
+
+            uint256 dragonMaxWithdrawAssets = _convertToAssets(S, dragonMaxRedeemShares, Math.Rounding.Floor);
+            return Math.min(dragonMaxWithdrawAssets, baseMaxWithdraw);
         }
-        return super.maxWithdraw(owner);
+
+        return baseMaxWithdraw;
     }
 
     /**
@@ -319,10 +327,17 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      */
     function maxRedeem(address owner) public view override returns (uint256) {
         StrategyData storage S = _strategyStorage();
-        if (owner == S.dragonRouter && _isVaultInsolvent()) {
-            return 0;
+
+        // Get base max redeem from parent
+        uint256 baseMaxRedeem = super.maxRedeem(owner);
+
+        // Apply dragon-specific restrictions
+        if (owner == S.dragonRouter) {
+            uint256 dragonMaxRedeem = _maxDragonRedeemableShares();
+            return Math.min(baseMaxRedeem, dragonMaxRedeem);
         }
-        return super.maxRedeem(owner);
+
+        return baseMaxRedeem;
     }
 
     /**
@@ -369,9 +384,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             revert("Dragon cannot transfer to itself");
         }
 
-        // Dragon can only transfer when vault is solvent
-        _requireDragonSolvency(msg.sender);
-
         // Handle debt rebalancing when dragon is involved
         if (msg.sender == S.dragonRouter || to == S.dragonRouter) {
             _rebalanceDebtOnDragonTransfer(msg.sender, to, amount);
@@ -379,6 +391,9 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
         // Use base contract logic for actual transfer
         _transfer(S, msg.sender, to, amount);
+
+        _requireDragonSolvency(msg.sender);
+
         return true;
     }
 
@@ -402,9 +417,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             revert("Dragon cannot transfer to itself");
         }
 
-        // Dragon can only transfer when vault is solvent
-        _requireDragonSolvency(from);
-
         // Handle debt rebalancing when dragon is involved
         if (from == S.dragonRouter || to == S.dragonRouter) {
             _rebalanceDebtOnDragonTransfer(from, to, amount);
@@ -413,6 +425,9 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         // Use base contract logic for actual transfer
         _spendAllowance(S, from, msg.sender, amount);
         _transfer(S, from, to, amount);
+
+        _requireDragonSolvency(from);
+
         return true;
     }
 
@@ -593,9 +608,40 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         uint256 currentRate = _currentRateRay();
         uint256 currentVaultValue = S.totalAssets.mulDiv(currentRate, WadRayMath.RAY);
 
-        return
-            (YS.totalDebtOwedToUserInAssetValue > 0 || YS.dragonRouterDebtInAssetValue > 0) &&
-            currentVaultValue < YS.totalDebtOwedToUserInAssetValue + YS.dragonRouterDebtInAssetValue;
+        // Vault is only insolvent if it cannot cover user debt
+        // Dragon debt is excluded as dragon shares are designed to absorb losses
+        return YS.totalDebtOwedToUserInAssetValue > 0 && currentVaultValue < YS.totalDebtOwedToUserInAssetValue;
+    }
+
+    /**
+     * @dev Calculates the maximum amount of shares the dragon can redeem without making the vault unable to cover user debt
+     * @return maxDragonRedeemable Maximum shares the dragon can redeem
+     */
+    function _maxDragonRedeemableShares() internal view returns (uint256 maxDragonRedeemable) {
+        StrategyData storage S = _strategyStorage();
+
+        YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
+        uint256 currentRate = _currentRateRay();
+        uint256 currentVaultValue = S.totalAssets.mulDiv(currentRate, WadRayMath.RAY);
+
+        // if enableBurning is false, dragon can redeem its full balance
+        if (!S.enableBurning) {
+            return _balanceOf(S, S.dragonRouter);
+        }
+
+        // If vault value is already below user debt, dragon cannot withdraw
+        if (currentVaultValue <= YS.totalDebtOwedToUserInAssetValue) {
+            return 0;
+        }
+
+        // Calculate excess value available for dragon (vault value - user debt)
+        uint256 excessValue = currentVaultValue - YS.totalDebtOwedToUserInAssetValue;
+
+        // Dragon can only redeem up to their debt or the excess value, whichever is lower
+        uint256 dragonWithdrawableValue = Math.min(YS.dragonRouterDebtInAssetValue, excessValue);
+
+        // Since dragon shares are 1:1 with value debt, return the value directly
+        return dragonWithdrawableValue;
     }
 
     /**
@@ -629,6 +675,11 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      */
     function _requireDragonSolvency(address account) internal view {
         StrategyData storage S = _strategyStorage();
+
+        // if enableBurning is false, dragon can withdraw its full balance
+        if (!S.enableBurning) {
+            return;
+        }
 
         // Only check if account is dragon router
         if (account == S.dragonRouter && _isVaultInsolvent()) {

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -13,16 +13,18 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
  * @title YieldSkimmingTokenizedStrategy
  * @author [Golem Foundation](https://golem.foundation)
  * @custom:security-contact security@golem.foundation
- * @notice Specialized TokenizedStrategy for yield-bearing assets (appreciating exchange rate).
+ * @notice Specialized TokenizedStrategy for yield-bearing assets with appreciating exchange rates.
  * @dev Mechanism:
- *      - Tracks value debt separately for users and dragon router (units: value-shares; 1 share = 1 asset value)
- *      - On report(), compares total vault value (assets * rate in RAY) vs total value debt (users + dragon)
- *        • Profit: mints value-shares to dragon and increases dragon value debt
- *        • Loss: burns dragon shares (if enabled and available) and reduces dragon value debt
+ *      - Shares represent ETH value (1 share = 1 ETH value) rather than asset amounts
+ *      - On report(), compares total vault value (assets * rate) vs total outstanding shares
+ *        • Profit: mints dragon shares equal to excess value above total share debt
+ *        • Loss: burns dragon shares (if enabled) up to available balance to cover shortfall
+ *      - Insolvency determination: vault cannot cover user debt (excludes dragon shares as loss buffer)
  *      - Dual conversion modes:
  *        • Solvent: rate-based conversions using current exchange rate (RAY precision)
- *        • Insolvent: proportional distribution using base TokenizedStrategy logic; dragon operations blocked
- *      - Dragon transfers trigger value-debt rebalancing; self-transfers by dragon are disallowed
+ *        • Insolvent: proportional distribution using base TokenizedStrategy logic
+ *      - Dragon solvency protection: prevents dragon operations that would compromise user debt coverage
+ *      - Dragon restrictions: cannot deposit/mint, cannot transfer to self, operations blocked during insolvency
  */
 contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
     using Math for uint256;
@@ -153,15 +155,16 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         StrategyData storage S = _strategyStorage();
         YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
 
-        // Dragon cannot withdraw during insolvency - must protect users
-        _requireDragonSolvency(owner);
-
         // Calculate actual value returned for debt tracking (before redemption)
         uint256 valueToReturn = shares; // 1 share = 1 ETH value, except in case of uncovered loss (regardless of actual assets received)
 
         // Validate inputs and check limits (replaces super.redeem validation)
         require(shares <= _maxRedeem(S, owner), "ERC4626: redeem more than max");
         require((assets = _convertToAssets(S, shares, Math.Rounding.Floor)) != 0, "ZERO_ASSETS");
+
+        // Check if dragon redemption would compromise vault solvency
+        _requireDragonSolvencyAfterOperation(owner, shares);
+
         assets = _withdraw(S, receiver, owner, assets, shares, maxLoss);
 
         // Update value debt after successful redemption (only for users)
@@ -180,9 +183,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             YS.totalDebtOwedToUserInAssetValue = 0;
             YS.dragonRouterDebtInAssetValue = 0;
         }
-
-        // Check solvency after withdrawal and debt update to prevent dragon from making vault insolvent
-        _requireDragonSolvency(owner);
 
         return assets;
     }
@@ -205,15 +205,16 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         StrategyData storage S = _strategyStorage();
         YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
 
-        // Dragon cannot withdraw during insolvency - must protect users
-        _requireDragonSolvency(owner);
-
         // Validate inputs and check limits (replaces super.withdraw validation)
         require(assets <= _maxWithdraw(S, owner), "ERC4626: withdraw more than max");
         require((shares = _convertToShares(S, assets, Math.Rounding.Ceil)) != 0, "ZERO_SHARES");
 
         // Calculate actual value returned for debt tracking (before withdrawal)
-        uint256 valueToReturn = shares; // 1 share = 1 ETH value, except in case of uncovered loss
+        uint256 valueToReturn = shares; // 1 share = 1 ETH value
+
+        // Check if dragon withdrawal would compromise vault solvency
+        _requireDragonSolvencyAfterOperation(owner, shares);
+
         _withdraw(S, receiver, owner, assets, shares, maxLoss);
 
         // Update value debt after successful withdrawal (only for users)
@@ -232,9 +233,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             YS.totalDebtOwedToUserInAssetValue = 0;
             YS.dragonRouterDebtInAssetValue = 0;
         }
-
-        // Check solvency after withdrawal and debt update to prevent dragon from making vault insolvent
-        _requireDragonSolvency(owner);
 
         return shares;
     }
@@ -275,7 +273,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
     /**
      * @notice Get the maximum amount of assets that can be withdrawn by a user
-     * @dev Returns 0 for dragon router during insolvency
+     * @dev Dragon router has restrictions based on solvency protection to ensure user debt coverage
      * @param owner Address whose shares would be burned
      * @return Maximum withdraw amount in asset base units
      */
@@ -297,7 +295,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
     /**
      * @notice Get the maximum amount of shares that can be redeemed by a user
-     * @dev Returns 0 for dragon router during insolvency
+     * @dev Dragon router has restrictions based on solvency protection to ensure user debt coverage
      * @param owner Address whose shares would be burned
      * @return Maximum redeem amount in shares
      */
@@ -342,15 +340,15 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
     }
 
     /**
-     * @notice Transfer shares with dragon solvency protection and debt rebalancing
+     * @notice Transfer shares with dragon solvency protection
      * @dev Special behaviors for dragon router:
      *      - Dragon cannot transfer to itself (reverts)
-     *      - Dragon transfers trigger value debt rebalancing
-     *      - Dragon can only transfer when vault is solvent
+     *      - Dragon transfers trigger solvency checks to prevent user debt undercoverage
+     *      - Transfers blocked if they would make vault unable to cover user debt
      *      For non-dragon transfers, behaves like standard ERC20 transfer
      * @param to Address receiving shares
      * @param amount Amount of shares to transfer
-     * @return success Whether transfer succeeded
+     * @return success Whether the transfer succeeded
      */
     function transfer(address to, uint256 amount) external override returns (bool success) {
         StrategyData storage S = _strategyStorage();
@@ -360,6 +358,8 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             revert("Dragon cannot transfer to itself");
         }
 
+        _requireDragonSolvencyAfterOperation(msg.sender, amount);
+
         // Handle debt rebalancing when dragon is involved
         if (msg.sender == S.dragonRouter || to == S.dragonRouter) {
             _rebalanceDebtOnDragonTransfer(msg.sender, to, amount);
@@ -368,22 +368,20 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         // Use base contract logic for actual transfer
         _transfer(S, msg.sender, to, amount);
 
-        _requireDragonSolvency(msg.sender);
-
         return true;
     }
 
     /**
-     * @notice Transfer shares from one address to another with dragon solvency protection and debt rebalancing
+     * @notice Transfer shares from one address to another with dragon solvency protection
      * @dev Special behaviors for dragon router:
      *      - Dragon cannot transfer to itself (reverts)
-     *      - Dragon transfers trigger value debt rebalancing
-     *      - Dragon can only transfer when vault is solvent
+     *      - Dragon transfers trigger solvency checks to prevent user debt undercoverage
+     *      - Transfers blocked if they would make vault unable to cover user debt
      *      For non-dragon transfers, behaves like standard ERC20 transferFrom
      * @param from Address transferring shares
      * @param to Address receiving shares
      * @param amount Amount of shares to transfer
-     * @return success Whether transfer succeeded
+     * @return success Whether the transfer succeeded
      */
     function transferFrom(address from, address to, uint256 amount) external override returns (bool success) {
         StrategyData storage S = _strategyStorage();
@@ -392,6 +390,8 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         if (from == S.dragonRouter && to == S.dragonRouter) {
             revert("Dragon cannot transfer to itself");
         }
+
+        _requireDragonSolvencyAfterOperation(from, amount);
 
         // Handle debt rebalancing when dragon is involved
         if (from == S.dragonRouter || to == S.dragonRouter) {
@@ -402,24 +402,22 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         _spendAllowance(S, from, msg.sender, amount);
         _transfer(S, from, to, amount);
 
-        _requireDragonSolvency(from);
-
         return true;
     }
 
     /**
-     * @notice Reports yield skimming strategy performance and handles value debt adjustments
-     * @dev Overrides report to handle yield appreciation and loss recovery using value debt approach.
+     * @notice Reports yield skimming strategy performance and handles profit distribution and loss coverage
+     * @dev Overrides report to handle yield appreciation and loss recovery through dragon share minting/burning.
      *
      * Health check effectiveness depends on report() frequency. Exchange rate checks
      * become less effective over time if reports are infrequent, as profit limits may be exceeded.
      * Management should ensure regular reporting or adjust profit/loss ratios based on expected frequency.
      *
      * Key behaviors:
-     * 1. **Value Debt Tracking**: Compares current total value (assets * exchange rate) vs total debt (user debt + dragon router debt combined)
-     * 2. **Profit Capture**: When current value exceeds total debt, mints shares to dragonRouter and increases dragon debt accordingly
-     * 3. **Loss Protection**: When current value is less than total debt, burns dragon shares (up to available balance) and reduces dragon debt
-     * 4. **Insolvency Handling**: If dragon buffer insufficient for losses, remaining shortfall is handled through proportional asset distribution during withdrawals, not by modifying debt balances
+     * 1. **Value Comparison**: Compares current total value (assets * exchange rate) vs total outstanding shares
+     * 2. **Profit Capture**: When current value exceeds total shares, mints dragon shares equal to excess value
+     * 3. **Loss Protection**: When current value is less than total shares, burns dragon shares (if enabled) to cover shortfall
+     * 4. **Insolvency Handling**: If dragon buffer insufficient for losses, remaining shortfall is handled through proportional asset distribution during withdrawals
      *
      * @return profit Profit in assets from underlying value appreciation
      * @return loss Loss in assets from underlying value depreciation
@@ -445,7 +443,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         uint256 currentRate = _currentRateRay();
         uint256 totalAssets = totalAssetsBalance;
         uint256 currentValue = totalAssets.mulDiv(currentRate, WadRayMath.RAY);
-        // Compare current value to total debt (user + dragon)
+        // Compare current value to total debt (user debt + dragon router debt combined)
 
         if (currentValue > YS.totalDebtOwedToUserInAssetValue + YS.dragonRouterDebtInAssetValue) {
             // Yield captured! Mint profit shares to dragon
@@ -489,11 +487,12 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
     /**
      * @notice Check if the vault is currently insolvent
-     * @return isInsolvent True if vault cannot cover user value debt and dragon router debt
+     * @return isInsolvent True if vault cannot cover user debt (excludes dragon shares as they absorb losses)
      */
     function isVaultInsolvent() external view returns (bool) {
         return _isVaultInsolvent();
     }
+
 
     /**
      * @dev Converts assets to shares using value debt approach with solvency awareness
@@ -561,7 +560,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
         // Vault is only insolvent if it cannot cover user debt
         // Dragon debt is excluded as dragon shares are designed to absorb losses
-        return YS.totalDebtOwedToUserInAssetValue > 0 && currentVaultValue < YS.totalDebtOwedToUserInAssetValue;
+        return YS.totalUserDebtInAssetValue > 0 && currentVaultValue < YS.totalUserDebtInAssetValue;
     }
 
     /**
@@ -570,7 +569,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      */
     function _maxDragonRedeemableShares() internal view returns (uint256 maxDragonRedeemable) {
         StrategyData storage S = _strategyStorage();
-
         YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
         uint256 currentRate = _currentRateRay();
         uint256 currentVaultValue = S.totalAssets.mulDiv(currentRate, WadRayMath.RAY);
@@ -581,18 +579,69 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         }
 
         // If vault value is already below user debt, dragon cannot withdraw
-        if (currentVaultValue <= YS.totalDebtOwedToUserInAssetValue) {
+        if (currentVaultValue <= YS.totalUserDebtInAssetValue) {
             return 0;
         }
 
         // Calculate excess value available for dragon (vault value - user debt)
-        uint256 excessValue = currentVaultValue - YS.totalDebtOwedToUserInAssetValue;
+        uint256 excessValue = currentVaultValue - YS.totalUserDebtInAssetValue;
 
         // Dragon can only redeem up to their debt or the excess value, whichever is lower
         uint256 dragonWithdrawableValue = Math.min(YS.dragonRouterDebtInAssetValue, excessValue);
 
         // Since dragon shares are 1:1 with value debt, return the value directly
         return dragonWithdrawableValue;
+    }
+
+    /**
+     * @dev Blocks dragon router from withdrawing during vault insolvency
+     * @param account The address to check (only blocks if it's the dragon router)
+     */
+    function _requireDragonSolvency(address account) internal view {
+        StrategyData storage S = _strategyStorage();
+
+        // if enableBurning is false, dragon can withdraw its full balance
+        if (!S.enableBurning) {
+            return;
+        }
+
+        // Only check if account is dragon router
+        if (account == S.dragonRouter && _isVaultInsolvent()) {
+            revert("Dragon cannot operate during insolvency");
+        }
+    }
+
+    /**
+     * @dev Checks vault solvency when dragon sends shares out (transfer, redeem, withdraw)
+     * @param from Address shares are coming from
+     * @param amount Amount of shares being moved
+     * @dev Only checks when dragon is SENDING shares. Transfers TO dragon always improve
+     *      user debt coverage so no check is needed for those.
+     */
+    function _requireDragonSolvencyAfterOperation(address from, uint256 amount) internal view {
+        StrategyData storage S = _strategyStorage();
+        YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
+
+        // if enableBurning is false, dragon can transfer freely
+        if (!S.enableBurning) {
+            return;
+        }
+
+        // Only check if dragon router is sending shares (user transfers to dragon always improve solvency)
+        if (from != S.dragonRouter) {
+            return;
+        }
+
+        // Calculate current vault value
+        uint256 currentRate = _currentRateRay();
+        uint256 currentVaultValue = S.totalAssets.mulDiv(currentRate, WadRayMath.RAY);
+
+        // Dragon is sending shares - user debt will increase by the amount transferred
+        uint256 currentUserDebt = YS.totalUserDebtInAssetValue;
+        uint256 userDebtAfterTransfer = currentUserDebt + amount;
+        if (currentVaultValue < userDebtAfterTransfer) {
+            revert("Transfer would cause vault insolvency");
+        }
     }
 
     /**
@@ -617,24 +666,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
                 YS.totalDebtOwedToUserInAssetValue -= transferAmount;
             }
             YS.dragonRouterDebtInAssetValue += transferAmount;
-        }
-    }
-
-    /**
-     * @dev Blocks dragon router from withdrawing during vault insolvency
-     * @param account Address to check (only blocks if it's dragon router)
-     */
-    function _requireDragonSolvency(address account) internal view {
-        StrategyData storage S = _strategyStorage();
-
-        // if enableBurning is false, dragon can withdraw its full balance
-        if (!S.enableBurning) {
-            return;
-        }
-
-        // Only check if account is dragon router
-        if (account == S.dragonRouter && _isVaultInsolvent()) {
-            revert("Dragon cannot operate during insolvency");
         }
     }
 

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -493,7 +493,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         return _isVaultInsolvent();
     }
 
-
     /**
      * @dev Converts assets to shares using value debt approach with solvency awareness
      * @param S Strategy storage
@@ -560,7 +559,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
         // Vault is only insolvent if it cannot cover user debt
         // Dragon debt is excluded as dragon shares are designed to absorb losses
-        return YS.totalUserDebtInAssetValue > 0 && currentVaultValue < YS.totalUserDebtInAssetValue;
+        return YS.totalDebtOwedToUserInAssetValue > 0 && currentVaultValue < YS.totalDebtOwedToUserInAssetValue;
     }
 
     /**
@@ -579,12 +578,12 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         }
 
         // If vault value is already below user debt, dragon cannot withdraw
-        if (currentVaultValue <= YS.totalUserDebtInAssetValue) {
+        if (currentVaultValue <= YS.totalDebtOwedToUserInAssetValue) {
             return 0;
         }
 
         // Calculate excess value available for dragon (vault value - user debt)
-        uint256 excessValue = currentVaultValue - YS.totalUserDebtInAssetValue;
+        uint256 excessValue = currentVaultValue - YS.totalDebtOwedToUserInAssetValue;
 
         // Dragon can only redeem up to their debt or the excess value, whichever is lower
         uint256 dragonWithdrawableValue = Math.min(YS.dragonRouterDebtInAssetValue, excessValue);
@@ -637,7 +636,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         uint256 currentVaultValue = S.totalAssets.mulDiv(currentRate, WadRayMath.RAY);
 
         // Dragon is sending shares - user debt will increase by the amount transferred
-        uint256 currentUserDebt = YS.totalUserDebtInAssetValue;
+        uint256 currentUserDebt = YS.totalDebtOwedToUserInAssetValue;
         uint256 userDebtAfterTransfer = currentUserDebt + amount;
         if (currentVaultValue < userDebtAfterTransfer) {
             revert("Transfer would cause vault insolvency");

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -136,18 +136,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
     }
 
     /**
-     * @notice Redeem shares from the strategy with default maxLoss
-     * @dev Wrapper that calls the full redeem function with MAX_BPS maxLoss
-     * @param shares Amount of shares to redeem
-     * @param receiver Address to receive the assets
-     * @param owner Address whose shares are being redeemed
-     * @return assets Amount of assets returned in asset base units
-     */
-    function redeem(uint256 shares, address receiver, address owner) external override returns (uint256 assets) {
-        return redeem(shares, receiver, owner, MAX_BPS);
-    }
-
-    /**
      * @notice Redeem shares from the strategy with value debt tracking
      * @dev Shares represent ETH value (1 share = 1 ETH value, except in case of uncovered loss)
      * @param shares Amount of shares to redeem
@@ -249,18 +237,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         _requireDragonSolvency(owner);
 
         return shares;
-    }
-
-    /**
-     * @notice Withdraw assets from the strategy with default maxLoss
-     * @dev Wrapper that calls the full withdraw function with 0 maxLoss
-     * @param assets Amount of assets to withdraw in asset base units
-     * @param receiver Address to receive withdrawn assets
-     * @param owner Address whose shares are being redeemed
-     * @return shares Amount of shares burned in share base units
-     */
-    function withdraw(uint256 assets, address receiver, address owner) external override returns (uint256 shares) {
-        return withdraw(assets, receiver, owner, 0);
     }
 
     /**
@@ -517,31 +493,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      */
     function isVaultInsolvent() external view returns (bool) {
         return _isVaultInsolvent();
-    }
-
-    /**
-     * @dev Internal deposit function that handles asset transfers and share minting
-     * @param S Strategy data storage reference
-     * @param receiver Address receiving minted shares
-     * @param assets Amount of assets being deposited in asset base units
-     * @param shares Amount of shares to mint
-     */
-    function _deposit(StrategyData storage S, address receiver, uint256 assets, uint256 shares) internal override {
-        // Cache storage variables used more than once.
-        ERC20 _asset = S.asset;
-
-        _asset.safeTransferFrom(msg.sender, address(this), assets);
-
-        // We can deploy the full loose balance currently held.
-        IBaseStrategy(address(this)).deployFunds(_asset.balanceOf(address(this)));
-
-        // Adjust total Assets.
-        S.totalAssets += assets;
-
-        // mint shares
-        _mint(S, receiver, shares);
-
-        emit Deposit(msg.sender, receiver, assets, shares);
     }
 
     /**

--- a/test/integration/regen/RegenStakerGLMWETHIntegration.t.sol
+++ b/test/integration/regen/RegenStakerGLMWETHIntegration.t.sol
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import { AccessMode } from "src/constants.sol";
+import { Test } from "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { RegenStakerWithoutDelegateSurrogateVotes } from "src/regen/RegenStakerWithoutDelegateSurrogateVotes.sol";
+import { RegenStakerBase } from "src/regen/RegenStakerBase.sol";
+import { IAddressSet } from "src/utils/IAddressSet.sol";
+import { AddressSet } from "src/utils/AddressSet.sol";
+import { Staker } from "staker/Staker.sol";
+import { Pausable } from "@openzeppelin/contracts/utils/Pausable.sol";
+import { RegenEarningPowerCalculator } from "src/regen/RegenEarningPowerCalculator.sol";
+import { IEarningPowerCalculator } from "staker/interfaces/IEarningPowerCalculator.sol";
+
+/// @title RegenStakerGLMWETHIntegrationTest
+/// @notice Integration tests for RegenStakerWithoutDelegateSurrogateVotes against mainnet GLM/WETH
+contract RegenStakerGLMWETHIntegrationTest is Test {
+    IERC20 public constant GLM = IERC20(0x7DD9c5Cba05E151C895FDe1CF355C9A1D5DA6429);
+    IERC20 public constant WETH = IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
+
+    RegenStakerWithoutDelegateSurrogateVotes public staker;
+    RegenEarningPowerCalculator public earningPowerCalculator;
+    AddressSet public allocationAllowset;
+
+    uint256 internal constant ALICE_PK = 0xA11CE;
+    address public admin = makeAddr("admin");
+    address public alice = vm.addr(ALICE_PK);
+    address public bob = makeAddr("bob");
+    address public notifier = makeAddr("notifier");
+
+    uint256 internal constant STAKE_AMOUNT = 1000 ether;
+    uint256 internal constant REWARD_AMOUNT = 500 ether;
+    uint128 internal constant REWARD_DURATION = 30 days;
+    uint256 internal constant HALF_REWARD_DURATION = REWARD_DURATION / 2;
+    uint256 internal constant PAST_REWARD_END = REWARD_DURATION + 1 days;
+    uint256 internal constant INITIAL_BALANCE = 100_000 ether;
+
+    function setUp() public {
+        vm.createSelectFork(vm.envString("TEST_RPC_URL"));
+
+        earningPowerCalculator = new RegenEarningPowerCalculator(
+            admin, IAddressSet(address(0)), IAddressSet(address(0)), AccessMode.NONE
+        );
+        allocationAllowset = new AddressSet();
+
+        staker = new RegenStakerWithoutDelegateSurrogateVotes(
+            WETH, GLM, earningPowerCalculator, 0, admin, REWARD_DURATION, 0,
+            IAddressSet(address(0)), IAddressSet(address(0)), AccessMode.NONE, allocationAllowset
+        );
+
+        vm.prank(admin);
+        staker.setRewardNotifier(notifier, true);
+
+        deal(address(GLM), alice, INITIAL_BALANCE);
+        deal(address(GLM), bob, INITIAL_BALANCE);
+        deal(address(WETH), notifier, INITIAL_BALANCE);
+    }
+
+    function _deployStaker(
+        IEarningPowerCalculator calc,
+        IAddressSet _allowset,
+        IAddressSet _blockset,
+        AccessMode mode
+    ) internal returns (RegenStakerWithoutDelegateSurrogateVotes) {
+        return new RegenStakerWithoutDelegateSurrogateVotes(
+            WETH, GLM, calc, 0, admin, REWARD_DURATION, 0,
+            _allowset, _blockset, mode, allocationAllowset
+        );
+    }
+
+    // --- Balance validation (different-token) ---
+
+    /// @notice Notifying without sufficient reward token balance should revert
+    function test_validateBalance_differentToken_productionConfig() public {
+        vm.startPrank(alice);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = staker.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        // Notifying without transferring WETH first should revert
+        vm.startPrank(notifier);
+        vm.expectRevert(
+            abi.encodeWithSelector(RegenStakerBase.InsufficientRewardBalance.selector, 0, REWARD_AMOUNT)
+        );
+        staker.notifyRewardAmount(REWARD_AMOUNT);
+        vm.stopPrank();
+
+        vm.startPrank(notifier);
+        WETH.transfer(address(staker), REWARD_AMOUNT);
+        staker.notifyRewardAmount(REWARD_AMOUNT);
+        vm.stopPrank();
+
+        // required does NOT include totalStaked when tokens differ
+        assertEq(staker.totalRewards(), REWARD_AMOUNT);
+        assertEq(staker.totalClaimedRewards(), 0);
+        assertEq(staker.totalStaked(), STAKE_AMOUNT);
+        assertEq(WETH.balanceOf(address(staker)), REWARD_AMOUNT);
+        assertEq(GLM.balanceOf(address(staker)), STAKE_AMOUNT);
+
+        vm.warp(block.timestamp + HALF_REWARD_DURATION);
+
+        vm.prank(alice);
+        uint256 claimed = staker.claimReward(depositId);
+        assertGt(claimed, 0);
+
+        // Re-notify after partial claim: carryOver reflects claimed amount
+        uint256 newRewardAmount = 200 ether;
+        vm.startPrank(notifier);
+        WETH.transfer(address(staker), newRewardAmount);
+        staker.notifyRewardAmount(newRewardAmount);
+        vm.stopPrank();
+
+        assertEq(staker.totalRewards(), REWARD_AMOUNT + newRewardAmount);
+        assertEq(staker.totalClaimedRewards(), claimed);
+    }
+
+    // --- totalClaimedRewards consistency ---
+
+    /// @notice claimReward should increment totalClaimedRewards exactly once
+    function test_totalClaimedRewards_claimPath() public {
+        vm.startPrank(alice);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = staker.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        vm.startPrank(notifier);
+        WETH.transfer(address(staker), REWARD_AMOUNT);
+        staker.notifyRewardAmount(REWARD_AMOUNT);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + HALF_REWARD_DURATION);
+        assertEq(staker.totalClaimedRewards(), 0);
+
+        vm.prank(alice);
+        uint256 claimed = staker.claimReward(depositId);
+        assertGt(claimed, 0);
+
+        assertEq(staker.totalClaimedRewards(), claimed);
+        assertEq(WETH.balanceOf(address(staker)), REWARD_AMOUNT - claimed);
+
+        uint256 carryOver = staker.totalRewards() - staker.totalClaimedRewards();
+        assertEq(carryOver, REWARD_AMOUNT - claimed);
+        assertGe(WETH.balanceOf(address(staker)), carryOver);
+    }
+
+    // --- Paused withdrawal ---
+
+    /// @notice Users can withdraw when paused; staking and claiming revert
+    function test_withdrawWorksWhenPaused() public {
+        vm.startPrank(alice);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = staker.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        vm.prank(admin);
+        staker.pause();
+
+        vm.startPrank(bob);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        staker.stake(STAKE_AMOUNT, bob, bob);
+        vm.stopPrank();
+
+        vm.prank(alice);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        staker.claimReward(depositId);
+
+        uint256 aliceBalanceBefore = GLM.balanceOf(alice);
+        vm.prank(alice);
+        staker.withdraw(depositId, STAKE_AMOUNT);
+        assertEq(GLM.balanceOf(alice), aliceBalanceBefore + STAKE_AMOUNT);
+        assertEq(staker.totalStaked(), 0);
+    }
+
+    /// @notice _stakeTokenSafeTransferFrom override allows withdrawal while paused
+    function test_withdrawPaused_stakeTokenSafeTransferFrom() public {
+        vm.startPrank(alice);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = staker.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        vm.startPrank(notifier);
+        WETH.transfer(address(staker), REWARD_AMOUNT);
+        staker.notifyRewardAmount(REWARD_AMOUNT);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + HALF_REWARD_DURATION);
+
+        vm.prank(admin);
+        staker.pause();
+
+        vm.prank(alice);
+        staker.withdraw(depositId, STAKE_AMOUNT);
+
+        assertEq(GLM.balanceOf(address(staker)), 0);
+        assertGt(WETH.balanceOf(address(staker)), 0);
+    }
+
+    // --- Delegation always reverts ---
+
+    /// @notice alterDelegatee reverts with DelegationNotSupported
+    function test_alterDelegatee_reverts() public {
+        vm.startPrank(alice);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = staker.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        vm.prank(alice);
+        vm.expectRevert(RegenStakerWithoutDelegateSurrogateVotes.DelegationNotSupported.selector);
+        staker.alterDelegatee(depositId, bob);
+    }
+
+    /// @notice alterDelegateeOnBehalf reverts even with a valid EIP-712 signature
+    function test_alterDelegateeOnBehalf_reverts() public {
+        vm.startPrank(alice);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = staker.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        uint256 deadline = block.timestamp + 1 hours;
+        uint256 nonce = staker.nonces(alice);
+        bytes32 structHash = keccak256(
+            abi.encode(staker.ALTER_DELEGATEE_TYPEHASH(), depositId, bob, alice, nonce, deadline)
+        );
+        bytes32 digest = keccak256(
+            abi.encodePacked("\x19\x01", staker.DOMAIN_SEPARATOR(), structHash)
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(ALICE_PK, digest);
+
+        vm.expectRevert(RegenStakerWithoutDelegateSurrogateVotes.DelegationNotSupported.selector);
+        staker.alterDelegateeOnBehalf(depositId, bob, alice, deadline, abi.encodePacked(r, s, v));
+    }
+
+    // --- surrogates() ---
+
+    /// @notice surrogates() returns address(this) for any input
+    function test_surrogates_returnsThis() public view {
+        assertEq(address(staker.surrogates(alice)), address(staker));
+        assertEq(address(staker.surrogates(address(0))), address(staker));
+        assertEq(address(staker.surrogates(address(1))), address(staker));
+    }
+
+    // --- Full lifecycle ---
+
+    /// @notice Stake → earn → partial claim → re-notify → full claim → withdraw
+    function test_fullLifecycle_productionConfig() public {
+        vm.startPrank(alice);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = staker.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        vm.startPrank(notifier);
+        WETH.transfer(address(staker), REWARD_AMOUNT);
+        staker.notifyRewardAmount(REWARD_AMOUNT);
+        vm.stopPrank();
+
+        assertEq(staker.totalRewards(), REWARD_AMOUNT);
+        assertEq(staker.totalClaimedRewards(), 0);
+
+        vm.warp(block.timestamp + HALF_REWARD_DURATION);
+
+        vm.prank(alice);
+        uint256 claimed1 = staker.claimReward(depositId);
+        assertGt(claimed1, 0);
+        assertEq(staker.totalClaimedRewards(), claimed1);
+        assertGt(staker.totalRewards() - staker.totalClaimedRewards(), 0);
+
+        uint256 additionalRewards = 300 ether;
+        vm.startPrank(notifier);
+        WETH.transfer(address(staker), additionalRewards);
+        staker.notifyRewardAmount(additionalRewards);
+        vm.stopPrank();
+
+        assertEq(staker.totalRewards(), REWARD_AMOUNT + additionalRewards);
+        assertEq(staker.totalClaimedRewards(), claimed1);
+
+        vm.warp(block.timestamp + PAST_REWARD_END);
+
+        vm.prank(alice);
+        uint256 claimed2 = staker.claimReward(depositId);
+
+        uint256 totalClaimed = staker.totalClaimedRewards();
+        assertEq(totalClaimed, claimed1 + claimed2);
+        assertApproxEqAbs(totalClaimed, REWARD_AMOUNT + additionalRewards, 2);
+
+        vm.prank(alice);
+        staker.withdraw(depositId, STAKE_AMOUNT);
+        assertEq(staker.totalStaked(), 0);
+        assertEq(GLM.balanceOf(alice), INITIAL_BALANCE);
+    }
+
+    // --- No double-counting ---
+
+    /// @notice _claimReward does NOT go through _consumeRewards (no double-count)
+    function test_noDoubleCounting_claimReward() public {
+        vm.startPrank(alice);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = staker.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        vm.startPrank(notifier);
+        WETH.transfer(address(staker), REWARD_AMOUNT);
+        staker.notifyRewardAmount(REWARD_AMOUNT);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + PAST_REWARD_END);
+
+        assertGt(staker.unclaimedReward(depositId), 0);
+
+        vm.prank(alice);
+        uint256 claimed = staker.claimReward(depositId);
+
+        assertEq(staker.totalClaimedRewards(), claimed);
+
+        uint256 carryOver = staker.totalRewards() - staker.totalClaimedRewards();
+        assertGe(WETH.balanceOf(address(staker)), carryOver);
+    }
+
+    // --- Multiple stakers ---
+
+    /// @notice Equal stakers receive equal rewards over full period
+    function test_multipleStakers_fullDistribution() public {
+        vm.startPrank(alice);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier aliceDepositId = staker.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        vm.startPrank(bob);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier bobDepositId = staker.stake(STAKE_AMOUNT, bob, bob);
+        vm.stopPrank();
+
+        vm.startPrank(notifier);
+        WETH.transfer(address(staker), REWARD_AMOUNT);
+        staker.notifyRewardAmount(REWARD_AMOUNT);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + PAST_REWARD_END);
+
+        vm.prank(alice);
+        uint256 aliceClaimed = staker.claimReward(aliceDepositId);
+
+        vm.prank(bob);
+        uint256 bobClaimed = staker.claimReward(bobDepositId);
+
+        assertApproxEqAbs(aliceClaimed, bobClaimed, 2);
+        assertEq(staker.totalClaimedRewards(), aliceClaimed + bobClaimed);
+        assertApproxEqAbs(aliceClaimed + bobClaimed, REWARD_AMOUNT, 2);
+    }
+
+    // --- compoundRewards reverts on different-token staker ---
+
+    /// @notice compoundRewards reverts with CompoundingNotSupported on GLM/WETH staker
+    function test_compoundRewards_revertsOnDifferentToken() public {
+        vm.startPrank(alice);
+        GLM.approve(address(staker), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = staker.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        vm.startPrank(notifier);
+        WETH.transfer(address(staker), REWARD_AMOUNT);
+        staker.notifyRewardAmount(REWARD_AMOUNT);
+        vm.stopPrank();
+
+        vm.warp(block.timestamp + HALF_REWARD_DURATION);
+
+        vm.prank(alice);
+        vm.expectRevert(RegenStakerBase.CompoundingNotSupported.selector);
+        staker.compoundRewards(depositId);
+    }
+
+    // --- Access control (ALLOWSET / BLOCKSET) ---
+
+    /// @notice ALLOWSET mode: authorized can stake, unauthorized reverts
+    function test_allowsetMode_blocksUnauthorizedStake() public {
+        AddressSet stakerAllowset = new AddressSet();
+        stakerAllowset.add(alice);
+
+        RegenStakerWithoutDelegateSurrogateVotes s =
+            _deployStaker(earningPowerCalculator, IAddressSet(address(stakerAllowset)), IAddressSet(address(0)), AccessMode.ALLOWSET);
+
+        vm.prank(admin);
+        s.setRewardNotifier(notifier, true);
+
+        vm.startPrank(alice);
+        GLM.approve(address(s), STAKE_AMOUNT);
+        s.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+        assertEq(s.totalStaked(), STAKE_AMOUNT);
+
+        vm.startPrank(bob);
+        GLM.approve(address(s), STAKE_AMOUNT);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.StakerNotAllowed.selector, bob));
+        s.stake(STAKE_AMOUNT, bob, bob);
+        vm.stopPrank();
+    }
+
+    /// @notice BLOCKSET mode: blocklisted stakers revert
+    function test_blocksetMode_blocksBlockedStake() public {
+        AddressSet stakerBlockset = new AddressSet();
+        stakerBlockset.add(bob);
+
+        RegenStakerWithoutDelegateSurrogateVotes s =
+            _deployStaker(earningPowerCalculator, IAddressSet(address(0)), IAddressSet(address(stakerBlockset)), AccessMode.BLOCKSET);
+
+        vm.prank(admin);
+        s.setRewardNotifier(notifier, true);
+
+        vm.startPrank(alice);
+        GLM.approve(address(s), STAKE_AMOUNT);
+        s.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+        assertEq(s.totalStaked(), STAKE_AMOUNT);
+
+        vm.startPrank(bob);
+        GLM.approve(address(s), STAKE_AMOUNT);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.StakerBlocked.selector, bob));
+        s.stake(STAKE_AMOUNT, bob, bob);
+        vm.stopPrank();
+    }
+
+    /// @notice Grandfathered withdrawal after allowset removal; re-staking blocked
+    function test_allowsetMode_withdrawGrandfathered() public {
+        AddressSet stakerAllowset = new AddressSet();
+        stakerAllowset.add(alice);
+
+        RegenStakerWithoutDelegateSurrogateVotes s =
+            _deployStaker(earningPowerCalculator, IAddressSet(address(stakerAllowset)), IAddressSet(address(0)), AccessMode.ALLOWSET);
+
+        vm.prank(admin);
+        s.setRewardNotifier(notifier, true);
+
+        vm.startPrank(alice);
+        GLM.approve(address(s), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = s.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        stakerAllowset.remove(alice);
+
+        // Withdraw still works (no access check on _withdraw)
+        uint256 balBefore = GLM.balanceOf(alice);
+        vm.prank(alice);
+        s.withdraw(depositId, STAKE_AMOUNT);
+        assertEq(GLM.balanceOf(alice), balBefore + STAKE_AMOUNT);
+
+        // Re-staking blocked
+        vm.startPrank(alice);
+        GLM.approve(address(s), STAKE_AMOUNT);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.StakerNotAllowed.selector, alice));
+        s.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+    }
+
+    // --- bumpEarningPower (real RegenEarningPowerCalculator) ---
+
+    function _deployCalcWithAllowset(address who) internal returns (RegenEarningPowerCalculator calc, AddressSet calcAllowset) {
+        calcAllowset = new AddressSet();
+        calcAllowset.add(who);
+        calc = new RegenEarningPowerCalculator(
+            address(this), IAddressSet(address(calcAllowset)), IAddressSet(address(0)), AccessMode.ALLOWSET
+        );
+    }
+
+    function _deployStakerWithCalc(RegenEarningPowerCalculator calc)
+        internal
+        returns (RegenStakerWithoutDelegateSurrogateVotes s)
+    {
+        s = _deployStaker(IEarningPowerCalculator(address(calc)), IAddressSet(address(0)), IAddressSet(address(0)), AccessMode.NONE);
+        vm.prank(admin);
+        s.setRewardNotifier(notifier, true);
+    }
+
+    /// @notice Down-bump when user removed from calculator allowset
+    function test_bumpEarningPower_qualifiedDownBump() public {
+        (RegenEarningPowerCalculator calc, AddressSet calcAllowset) = _deployCalcWithAllowset(alice);
+        RegenStakerWithoutDelegateSurrogateVotes s = _deployStakerWithCalc(calc);
+
+        vm.startPrank(alice);
+        GLM.approve(address(s), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = s.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        (, , uint96 epBefore, , , , ) = s.deposits(depositId);
+        assertEq(uint256(epBefore), STAKE_AMOUNT);
+
+        calcAllowset.remove(alice);
+
+        vm.prank(bob);
+        s.bumpEarningPower(depositId, bob, 0);
+
+        (, , uint96 epAfter, , , , ) = s.deposits(depositId);
+        assertEq(uint256(epAfter), 0);
+    }
+
+    /// @notice Up-bump when user re-added to calculator allowset
+    function test_bumpEarningPower_qualifiedUpBump() public {
+        (RegenEarningPowerCalculator calc, AddressSet calcAllowset) = _deployCalcWithAllowset(alice);
+        RegenStakerWithoutDelegateSurrogateVotes s = _deployStakerWithCalc(calc);
+
+        vm.startPrank(alice);
+        GLM.approve(address(s), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = s.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        calcAllowset.remove(alice);
+        vm.prank(bob);
+        s.bumpEarningPower(depositId, bob, 0);
+
+        (, , uint96 epDown, , , , ) = s.deposits(depositId);
+        assertEq(uint256(epDown), 0);
+
+        calcAllowset.add(alice);
+        vm.prank(bob);
+        s.bumpEarningPower(depositId, bob, 0);
+
+        (, , uint96 epUp, , , , ) = s.deposits(depositId);
+        assertEq(uint256(epUp), STAKE_AMOUNT);
+    }
+
+    /// @notice Bump reverts when earning power hasn't changed
+    function test_bumpEarningPower_unqualifiedReverts() public {
+        (RegenEarningPowerCalculator calc, ) = _deployCalcWithAllowset(alice);
+        RegenStakerWithoutDelegateSurrogateVotes s = _deployStakerWithCalc(calc);
+
+        vm.startPrank(alice);
+        GLM.approve(address(s), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = s.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(Staker.Staker__Unqualified.selector, STAKE_AMOUNT));
+        s.bumpEarningPower(depositId, bob, 0);
+    }
+
+    /// @notice bumpEarningPower reverts when paused
+    function test_bumpEarningPower_revertsWhenPaused() public {
+        (RegenEarningPowerCalculator calc, AddressSet calcAllowset) = _deployCalcWithAllowset(alice);
+        RegenStakerWithoutDelegateSurrogateVotes s = _deployStakerWithCalc(calc);
+
+        vm.startPrank(alice);
+        GLM.approve(address(s), STAKE_AMOUNT);
+        Staker.DepositIdentifier depositId = s.stake(STAKE_AMOUNT, alice, alice);
+        vm.stopPrank();
+
+        calcAllowset.remove(alice);
+
+        vm.prank(admin);
+        s.pause();
+
+        vm.prank(bob);
+        vm.expectRevert(Pausable.EnforcedPause.selector);
+        s.bumpEarningPower(depositId, bob, 0);
+    }
+}

--- a/test/integration/regen/RegenStakerGLMWETHIntegration.t.sol
+++ b/test/integration/regen/RegenStakerGLMWETHIntegration.t.sol
@@ -40,13 +40,25 @@ contract RegenStakerGLMWETHIntegrationTest is Test {
         vm.createSelectFork(vm.envString("TEST_RPC_URL"));
 
         earningPowerCalculator = new RegenEarningPowerCalculator(
-            admin, IAddressSet(address(0)), IAddressSet(address(0)), AccessMode.NONE
+            admin,
+            IAddressSet(address(0)),
+            IAddressSet(address(0)),
+            AccessMode.NONE
         );
         allocationAllowset = new AddressSet();
 
         staker = new RegenStakerWithoutDelegateSurrogateVotes(
-            WETH, GLM, earningPowerCalculator, 0, admin, REWARD_DURATION, 0,
-            IAddressSet(address(0)), IAddressSet(address(0)), AccessMode.NONE, allocationAllowset
+            WETH,
+            GLM,
+            earningPowerCalculator,
+            0,
+            admin,
+            REWARD_DURATION,
+            0,
+            IAddressSet(address(0)),
+            IAddressSet(address(0)),
+            AccessMode.NONE,
+            allocationAllowset
         );
 
         vm.prank(admin);
@@ -63,10 +75,20 @@ contract RegenStakerGLMWETHIntegrationTest is Test {
         IAddressSet _blockset,
         AccessMode mode
     ) internal returns (RegenStakerWithoutDelegateSurrogateVotes) {
-        return new RegenStakerWithoutDelegateSurrogateVotes(
-            WETH, GLM, calc, 0, admin, REWARD_DURATION, 0,
-            _allowset, _blockset, mode, allocationAllowset
-        );
+        return
+            new RegenStakerWithoutDelegateSurrogateVotes(
+                WETH,
+                GLM,
+                calc,
+                0,
+                admin,
+                REWARD_DURATION,
+                0,
+                _allowset,
+                _blockset,
+                mode,
+                allocationAllowset
+            );
     }
 
     // --- Balance validation (different-token) ---
@@ -80,9 +102,7 @@ contract RegenStakerGLMWETHIntegrationTest is Test {
 
         // Notifying without transferring WETH first should revert
         vm.startPrank(notifier);
-        vm.expectRevert(
-            abi.encodeWithSelector(RegenStakerBase.InsufficientRewardBalance.selector, 0, REWARD_AMOUNT)
-        );
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.InsufficientRewardBalance.selector, 0, REWARD_AMOUNT));
         staker.notifyRewardAmount(REWARD_AMOUNT);
         vm.stopPrank();
 
@@ -223,9 +243,7 @@ contract RegenStakerGLMWETHIntegrationTest is Test {
         bytes32 structHash = keccak256(
             abi.encode(staker.ALTER_DELEGATEE_TYPEHASH(), depositId, bob, alice, nonce, deadline)
         );
-        bytes32 digest = keccak256(
-            abi.encodePacked("\x19\x01", staker.DOMAIN_SEPARATOR(), structHash)
-        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", staker.DOMAIN_SEPARATOR(), structHash));
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(ALICE_PK, digest);
 
         vm.expectRevert(RegenStakerWithoutDelegateSurrogateVotes.DelegationNotSupported.selector);
@@ -377,8 +395,12 @@ contract RegenStakerGLMWETHIntegrationTest is Test {
         AddressSet stakerAllowset = new AddressSet();
         stakerAllowset.add(alice);
 
-        RegenStakerWithoutDelegateSurrogateVotes s =
-            _deployStaker(earningPowerCalculator, IAddressSet(address(stakerAllowset)), IAddressSet(address(0)), AccessMode.ALLOWSET);
+        RegenStakerWithoutDelegateSurrogateVotes s = _deployStaker(
+            earningPowerCalculator,
+            IAddressSet(address(stakerAllowset)),
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
 
         vm.prank(admin);
         s.setRewardNotifier(notifier, true);
@@ -401,8 +423,12 @@ contract RegenStakerGLMWETHIntegrationTest is Test {
         AddressSet stakerBlockset = new AddressSet();
         stakerBlockset.add(bob);
 
-        RegenStakerWithoutDelegateSurrogateVotes s =
-            _deployStaker(earningPowerCalculator, IAddressSet(address(0)), IAddressSet(address(stakerBlockset)), AccessMode.BLOCKSET);
+        RegenStakerWithoutDelegateSurrogateVotes s = _deployStaker(
+            earningPowerCalculator,
+            IAddressSet(address(0)),
+            IAddressSet(address(stakerBlockset)),
+            AccessMode.BLOCKSET
+        );
 
         vm.prank(admin);
         s.setRewardNotifier(notifier, true);
@@ -425,8 +451,12 @@ contract RegenStakerGLMWETHIntegrationTest is Test {
         AddressSet stakerAllowset = new AddressSet();
         stakerAllowset.add(alice);
 
-        RegenStakerWithoutDelegateSurrogateVotes s =
-            _deployStaker(earningPowerCalculator, IAddressSet(address(stakerAllowset)), IAddressSet(address(0)), AccessMode.ALLOWSET);
+        RegenStakerWithoutDelegateSurrogateVotes s = _deployStaker(
+            earningPowerCalculator,
+            IAddressSet(address(stakerAllowset)),
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
 
         vm.prank(admin);
         s.setRewardNotifier(notifier, true);
@@ -454,19 +484,28 @@ contract RegenStakerGLMWETHIntegrationTest is Test {
 
     // --- bumpEarningPower (real RegenEarningPowerCalculator) ---
 
-    function _deployCalcWithAllowset(address who) internal returns (RegenEarningPowerCalculator calc, AddressSet calcAllowset) {
+    function _deployCalcWithAllowset(
+        address who
+    ) internal returns (RegenEarningPowerCalculator calc, AddressSet calcAllowset) {
         calcAllowset = new AddressSet();
         calcAllowset.add(who);
         calc = new RegenEarningPowerCalculator(
-            address(this), IAddressSet(address(calcAllowset)), IAddressSet(address(0)), AccessMode.ALLOWSET
+            address(this),
+            IAddressSet(address(calcAllowset)),
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
         );
     }
 
-    function _deployStakerWithCalc(RegenEarningPowerCalculator calc)
-        internal
-        returns (RegenStakerWithoutDelegateSurrogateVotes s)
-    {
-        s = _deployStaker(IEarningPowerCalculator(address(calc)), IAddressSet(address(0)), IAddressSet(address(0)), AccessMode.NONE);
+    function _deployStakerWithCalc(
+        RegenEarningPowerCalculator calc
+    ) internal returns (RegenStakerWithoutDelegateSurrogateVotes s) {
+        s = _deployStaker(
+            IEarningPowerCalculator(address(calc)),
+            IAddressSet(address(0)),
+            IAddressSet(address(0)),
+            AccessMode.NONE
+        );
         vm.prank(admin);
         s.setRewardNotifier(notifier, true);
     }

--- a/test/integration/strategies/PrivilegedYieldDonating/PrivilegedMorphoCompounderStrategy.t.sol
+++ b/test/integration/strategies/PrivilegedYieldDonating/PrivilegedMorphoCompounderStrategy.t.sol
@@ -222,8 +222,8 @@ contract PrivilegedMorphoCompounderStrategyTest is BasePrivilegedYieldDonatingIn
         (uint256 profit, uint256 loss) = vault.report();
         vm.stopPrank();
 
-        // Allow 1 wei tolerance for Morpho rounding
-        assertApproxEqAbs(profit, profitAmount, 1, "Should have captured profit");
+        // Allow 2 wei tolerance for Morpho + profit-to-shares conversion rounding
+        assertApproxEqAbs(profit, profitAmount, 2, "Should have captured profit");
         assertEq(loss, 0, "Should have no loss");
         assertEq(vault.balanceOf(user), userSharesBefore, "User shares should not change");
         assertGt(vault.totalAssets(), totalAssetsBefore, "Total assets should increase");

--- a/test/integration/strategies/YieldSkimming/LidoStrategy.t.sol
+++ b/test/integration/strategies/YieldSkimming/LidoStrategy.t.sol
@@ -153,6 +153,7 @@ contract LidoStrategyTest is Test {
         vm.startPrank(params.management);
         address strategyAddress = factory.createStrategy(
             params.vaultSharesName,
+            "osLIDO",
             params.management,
             params.keeper,
             params.emergencyAdmin,

--- a/test/integration/strategies/YieldSkimming/LidoStrategy.t.sol
+++ b/test/integration/strategies/YieldSkimming/LidoStrategy.t.sol
@@ -1,198 +1,1617 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { Test } from "forge-std/Test.sol";
+import { console2 } from "forge-std/console2.sol";
+import { MockERC20 } from "test/mocks/MockERC20.sol";
 import { LidoStrategy } from "src/strategies/yieldSkimming/LidoStrategy.sol";
 import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
-import { BaseYieldSkimmingIntegrationTest } from "./base/BaseYieldSkimmingIntegrationTest.sol";
-import { LidoTestConfig } from "../config/LidoTestConfig.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { WadRayMath } from "src/utils/libs/Maths/WadRay.sol";
+import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
+import { IYieldSkimmingStrategy } from "src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol";
+import { console } from "forge-std/console.sol";
 
-/// @title Lido Strategy Integration Tests
+/// @title Lido Test
 /// @author Octant
 /// @notice Integration tests for the Lido strategy using a mainnet fork
-contract LidoStrategyTest is BaseYieldSkimmingIntegrationTest {
-    // ========== STATE VARIABLES ==========
+contract LidoStrategyTest is Test {
+    using SafeERC20 for ERC20;
+    using WadRayMath for uint256;
 
-    LidoStrategy public lidoStrategy;
+    // Strategy instance
+    LidoStrategy public strategy;
+    ITokenizedStrategy public vault;
+
+    // Factory for creating strategies
+    YieldSkimmingTokenizedStrategy tokenizedStrategy;
     LidoStrategyFactory public factory;
 
-    // ========== CONFIGURATION OVERRIDES ==========
+    // Strategy parameters
+    address public management;
+    address public keeper;
+    address public emergencyAdmin;
+    address public donationAddress;
+    string public vaultSharesName = "Lido Vault Shares";
+    bytes32 public strategySalt = keccak256("TEST_STRATEGY_SALT");
+    YieldSkimmingTokenizedStrategy public implementation;
 
-    function _asset() internal pure override returns (address) {
-        return LidoTestConfig.WSTETH;
+    // Test user
+    address public user = address(0x1234);
+
+    // Mainnet addresses
+    address public constant WSTETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
+    address public constant TOKENIZED_STRATEGY_ADDRESS = 0x8cf7246a74704bBE59c9dF614ccB5e3d9717d8Ac;
+
+    // Test constants
+    uint256 public constant INITIAL_DEPOSIT = 100000e18; // WSTETH has 18 decimals
+    uint256 public mainnetFork;
+    uint256 public mainnetForkBlock = 22508883 - 6500 * 90; // latest alchemy block - 90 days
+
+    // Events from ITokenizedStrategy
+    event Reported(uint256 profit, uint256 loss);
+
+    // Use struct to avoid stack too deep
+    struct TestState {
+        address user1;
+        address user2;
+        uint256 depositAmount1;
+        uint256 depositAmount2;
+        uint256 initialExchangeRate;
+        uint256 newExchangeRate1;
+        uint256 newExchangeRate2;
+        uint256 donationBalanceBefore1;
+        uint256 donationBalanceAfter1;
+        uint256 donationBalanceBefore2;
+        uint256 donationBalanceAfter2;
+        uint256 user1Shares;
+        uint256 user2Shares;
+        uint256 user1Assets;
+        uint256 user2Assets;
+        uint256 user1Profit;
+        uint256 user2Profit;
+        uint256 user1ProfitPercentage;
+        uint256 user2ProfitPercentage;
     }
 
-    function _strategyName() internal pure override returns (string memory) {
-        return LidoTestConfig.STRATEGY_NAME;
+    // Additional struct for fuzz tests to avoid stack too deep
+    struct FuzzTestState {
+        uint256 initialExchangeRate;
+        uint256 profitRate;
+        uint256 firstLossRate;
+        uint256 secondLossRate;
+        uint256 donationSharesAfterProfit;
+        uint256 donationSharesAfterFirstLoss;
+        uint256 donationSharesAfterSecondLoss;
+        uint256 assetsReceived;
     }
 
-    function _strategySymbol() internal pure override returns (string memory) {
-        return LidoTestConfig.STRATEGY_SYMBOL;
+    // Setup parameters struct to avoid stack too deep
+    struct SetupParams {
+        address management;
+        address keeper;
+        address emergencyAdmin;
+        address donationAddress;
+        string vaultSharesName;
+        bytes32 strategySalt;
+        address implementationAddress;
+        bool enableBurning;
     }
 
-    function _initialDeposit() internal pure override returns (uint256) {
-        return LidoTestConfig.INITIAL_DEPOSIT;
+    /**
+     * @notice Helper function to airdrop tokens to a specified address
+     * @param _asset The ERC20 token to airdrop
+     * @param _to The recipient address
+     * @param _amount The amount of tokens to airdrop
+     */
+    function airdrop(ERC20 _asset, address _to, uint256 _amount) public {
+        uint256 balanceBefore = _asset.balanceOf(_to);
+        deal(address(_asset), _to, balanceBefore + _amount);
     }
 
-    function _strategy() internal view override returns (address) {
-        return address(lidoStrategy);
-    }
+    function setUp() public {
+        // Create a mainnet fork
+        // NOTE: This relies on the RPC URL configured in foundry.toml under [rpc_endpoints]
+        // where mainnet = "${ETHEREUM_NODE_MAINNET}" environment variable
+        mainnetFork = vm.createFork("mainnet");
+        vm.selectFork(mainnetFork);
 
-    function _exchangeRateSelector() internal pure override returns (string memory) {
-        return LidoTestConfig.EXCHANGE_RATE_SELECTOR;
-    }
-
-    // ========== SETUP ==========
-
-    function _etchImplementation() internal override {
+        // Etch YieldSkimmingTokenizedStrategy
         implementation = new YieldSkimmingTokenizedStrategy{ salt: keccak256("OCT_YIELD_SKIMMING_STRATEGY_V1") }();
         bytes memory tokenizedStrategyBytecode = address(implementation).code;
-        vm.etch(LidoTestConfig.TOKENIZED_STRATEGY_ADDRESS, tokenizedStrategyBytecode);
-    }
+        vm.etch(TOKENIZED_STRATEGY_ADDRESS, tokenizedStrategyBytecode);
 
-    function _deployStrategy() internal override returns (address) {
-        _etchImplementation();
+        // Now use that address as our tokenizedStrategy
+        tokenizedStrategy = YieldSkimmingTokenizedStrategy(TOKENIZED_STRATEGY_ADDRESS);
 
+        // Set up addresses
+        management = address(0x1);
+        keeper = address(0x2);
+        emergencyAdmin = address(0x3);
+        donationAddress = address(0x4);
+
+        // Create setup params to avoid stack too deep
+        SetupParams memory params = SetupParams({
+            management: management,
+            keeper: keeper,
+            emergencyAdmin: emergencyAdmin,
+            donationAddress: donationAddress,
+            vaultSharesName: vaultSharesName,
+            strategySalt: strategySalt,
+            implementationAddress: address(implementation),
+            enableBurning: true
+        });
+
+        // Deploy factory
         factory = new LidoStrategyFactory();
 
-        vm.startPrank(management);
+        // Deploy strategy using the factory's createStrategy method
+        vm.startPrank(params.management);
         address strategyAddress = factory.createStrategy(
-            _strategyName(),
-            _strategySymbol(),
-            management,
-            keeper,
-            emergencyAdmin,
-            donationAddress,
-            true, // enableBurning
-            address(implementation)
+            params.vaultSharesName,
+            params.management,
+            params.keeper,
+            params.emergencyAdmin,
+            params.donationAddress,
+            params.enableBurning,
+            params.implementationAddress
         );
         vm.stopPrank();
 
-        lidoStrategy = LidoStrategy(strategyAddress);
-        return strategyAddress;
-    }
+        // Cast the deployed address to our strategy type
+        strategy = LidoStrategy(strategyAddress);
+        vault = ITokenizedStrategy(address(strategy));
 
-    function _labelAddresses() internal override {
-        vm.label(address(lidoStrategy), "Lido");
-        vm.label(address(factory), "LidoStrategyFactory");
-        vm.label(LidoTestConfig.WSTETH, "WSTETH");
-        vm.label(LidoTestConfig.TOKENIZED_STRATEGY_ADDRESS, "TokenizedStrategy");
+        // Label addresses for better trace outputs
+        vm.label(address(strategy), "Lido");
+        vm.label(address(factory), "YieldSkimmingVaultFactory");
+        vm.label(WSTETH, "Lido Yield Vault");
+        vm.label(TOKENIZED_STRATEGY_ADDRESS, "TokenizedStrategy");
         vm.label(management, "Management");
         vm.label(keeper, "Keeper");
         vm.label(emergencyAdmin, "Emergency Admin");
         vm.label(donationAddress, "Donation Address");
         vm.label(user, "Test User");
+
+        // Airdrop WSTETH tokens to test user
+        airdrop(ERC20(WSTETH), user, INITIAL_DEPOSIT);
+
+        // Approve strategy to spend user's tokens
+        vm.startPrank(user);
+        ERC20(WSTETH).approve(address(strategy), type(uint256).max);
+        vm.stopPrank();
     }
 
-    function setUp() public {
-        _baseSetUp();
-    }
-
-    // ========== TESTS - Delegating to base implementations ==========
-
+    /// @notice Test that the strategy is properly initialized
     function testInitializationLido() public view {
-        _testInitialization();
+        assertEq(IERC4626(address(strategy)).asset(), WSTETH, "Yield vault address incorrect");
+        assertEq(vault.management(), management, "Management address incorrect");
+        assertEq(vault.keeper(), keeper, "Keeper address incorrect");
+        assertEq(vault.emergencyAdmin(), emergencyAdmin, "Emergency admin incorrect");
+        assertGt(
+            IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate(),
+            0,
+            "Last reported exchange rate should be initialized"
+        );
     }
 
+    /// @notice Test depositing assets into the strategy
     function testDepositLido() public {
-        _testDeposit(100e18);
+        uint256 depositAmount = 100e18; // 100 WSTETH
+
+        // Initial balances
+        uint256 initialUserBalance = ERC20(WSTETH).balanceOf(user);
+
+        // Deposit assets
+        vm.startPrank(user);
+        // approve the strategy to spend the user's tokens
+        ERC20(WSTETH).approve(address(strategy), depositAmount);
+        uint256 sharesReceived = vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Verify balances after deposit
+        assertEq(
+            ERC20(WSTETH).balanceOf(user),
+            initialUserBalance - depositAmount,
+            "User balance not reduced correctly"
+        );
+
+        assertGt(sharesReceived, 0, "No shares received from deposit");
+        assertGt(strategy.balanceOfAsset(), 0, "Strategy should have deployed assets to yield vault");
     }
 
+    /// @notice Fuzz test depositing assets into the strategy
     function testFuzzDepositLido(uint256 depositAmount) public {
-        _testFuzzDeposit(depositAmount);
+        // Bound the deposit amount to reasonable values (0.01 to 10,000 WSTETH)
+        depositAmount = bound(depositAmount, 0.01e18, 10000e18);
+
+        // Airdrop tokens to user for this test
+        airdrop(ERC20(WSTETH), user, depositAmount);
+
+        // Initial balances
+        uint256 initialUserBalance = ERC20(WSTETH).balanceOf(user);
+
+        // Deposit assets
+        vm.startPrank(user);
+        // approve the strategy to spend the user's tokens
+        ERC20(WSTETH).approve(address(strategy), depositAmount);
+        uint256 sharesReceived = vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Verify balances after deposit
+        assertEq(
+            ERC20(WSTETH).balanceOf(user),
+            initialUserBalance - depositAmount,
+            "User balance not reduced correctly"
+        );
+
+        assertGt(sharesReceived, 0, "No shares received from deposit");
+        assertGt(strategy.balanceOfAsset(), 0, "Strategy should have deployed assets to yield vault");
     }
 
+    /// @notice Fuzz test withdrawing assets from the strategy
     function testFuzzWithdraw(uint256 depositAmount, uint256 withdrawPercentage) public {
-        _testFuzzWithdraw(depositAmount, withdrawPercentage);
+        // Bound inputs to reasonable values
+        depositAmount = bound(depositAmount, 1e18, 10000e18); // 1 to 10,000 WSTETH
+        withdrawPercentage = bound(withdrawPercentage, 1, 100); // 1% to 100% (prevents overflow in percentage calc)
+
+        // Airdrop tokens to user for this test
+        airdrop(ERC20(WSTETH), user, depositAmount);
+
+        // Deposit first
+        vm.startPrank(user);
+        ERC20(WSTETH).approve(address(strategy), depositAmount);
+        vault.deposit(depositAmount, user);
+
+        // Initial balances before withdrawal
+        uint256 initialUserBalance = ERC20(WSTETH).balanceOf(user);
+        uint256 initialShareBalance = vault.balanceOf(user);
+
+        // redeem balance of shares
+        uint256 sharesToBurn = (vault.balanceOf(user) * withdrawPercentage) / 100;
+        uint256 withdrawnAmount = vault.redeem(sharesToBurn, user, user);
+        vm.stopPrank();
+
+        // Verify balances after withdrawal
+        assertEq(
+            ERC20(WSTETH).balanceOf(user),
+            initialUserBalance + withdrawnAmount,
+            "User didn't receive correct assets"
+        );
+        assertEq(vault.balanceOf(user), initialShareBalance - sharesToBurn, "Shares not burned correctly");
     }
 
+    // Additional struct for profit fuzz tests to avoid stack too deep
+    struct ProfitFuzzTestState {
+        uint256 totalAssetsBefore;
+        uint256 initialExchangeRate;
+        uint256 newExchangeRate;
+        uint256 donationAddressBalanceBefore;
+        uint256 donationAddressBalanceAfter;
+        uint256 totalAssetsAfter;
+        uint256 sharesToRedeem;
+        uint256 assetsReceived;
+        uint256 donationAssetsReceived;
+    }
+
+    /// @notice Fuzz test the harvesting functionality with profit
     function testFuzzHarvestWithProfitLido(uint256 depositAmount, uint256 profitPercentage) public {
-        _testFuzzHarvestWithProfit(depositAmount, profitPercentage);
+        // Bound inputs to reasonable values
+        depositAmount = bound(depositAmount, 1e18, 10000e18); // 1 to 10,000 WSTETH
+        profitPercentage = bound(profitPercentage, 1, 99); // 1% to 99% profit (under 100% health check limit)
+
+        ProfitFuzzTestState memory state;
+
+        // Airdrop tokens to user for this test
+        airdrop(ERC20(WSTETH), user, depositAmount);
+
+        // Deposit first
+        vm.startPrank(user);
+        ERC20(WSTETH).approve(address(strategy), depositAmount);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Check initial state
+        state.totalAssetsBefore = vault.totalAssets();
+        state.initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+
+        // Simulate exchange rate increase based on fuzzed percentage
+        state.newExchangeRate = (state.initialExchangeRate * (100 + profitPercentage)) / 100;
+
+        // Mock the actual yield vault's stEthPerToken (convert back to WAD format)
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(state.newExchangeRate));
+
+        state.donationAddressBalanceBefore = ERC20(address(strategy)).balanceOf(donationAddress);
+
+        // Call report
+        vm.startPrank(keeper);
+        (uint256 profit, uint256 loss) = vault.report();
+        vm.stopPrank();
+
+        // Clear mock to avoid interference with other tests
+        vm.clearMockedCalls();
+
+        // Assert profit and loss
+        assertGt(profit, 0, "Profit should be positive");
+        assertEq(loss, 0, "There should be no loss");
+
+        state.donationAddressBalanceAfter = ERC20(address(strategy)).balanceOf(donationAddress);
+
+        // donation address should have received the profit
+        assertGt(
+            state.donationAddressBalanceAfter,
+            state.donationAddressBalanceBefore,
+            "Donation address should have received profit"
+        );
+
+        // Check total assets after harvest
+        state.totalAssetsAfter = vault.totalAssets();
+        assertEq(state.totalAssetsAfter, state.totalAssetsBefore, "Total assets should not change after harvest");
+
+        // Ensure obligations solvency by keeping current rate equal to last reported rate during redemption
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(state.newExchangeRate));
+
+        // withdraw the donation address shares first to ensure obligations solvency
+        vm.startPrank(donationAddress);
+        state.donationAssetsReceived = vault.redeem(vault.balanceOf(donationAddress), donationAddress, donationAddress);
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        // then user withdraws
+        vm.startPrank(user);
+        state.sharesToRedeem = vault.balanceOf(user);
+        state.assetsReceived = vault.redeem(state.sharesToRedeem, user, user);
+        vm.stopPrank();
+
+        assertApproxEqRel(
+            state.donationAssetsReceived,
+            (depositAmount * profitPercentage) / (100 + profitPercentage),
+            0.1e16,
+            "Donation address should have received profit"
+        );
+
+        // Verify user received their original deposit
+        assertApproxEqRel(
+            state.assetsReceived * state.newExchangeRate,
+            depositAmount * state.initialExchangeRate,
+            0.1e16, // 0.1% tolerance for fuzzing
+            "User should receive original deposit"
+        );
     }
 
+    /// @notice Test multiple users with fair profit distribution
     function testMultipleUserProfitDistributionLido() public {
-        _testMultipleUserProfitDistribution();
+        TestState memory state;
+
+        // First user deposits
+        state.user1 = user; // Reuse existing test user
+        state.user2 = address(0x5678);
+        state.depositAmount1 = 1000e18; // 1000 WSTETH
+        state.depositAmount2 = 2000e18; // 2000 WSTETH
+
+        // Get initial exchange rate
+        state.initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+
+        vm.startPrank(state.user1);
+        vault.deposit(state.depositAmount1, state.user1);
+        vm.stopPrank();
+
+        // Generate yield for first user (10% increase in exchange rate)
+        state.newExchangeRate1 = (state.initialExchangeRate * 110) / 100;
+
+        // Check donation address balance before harvest
+        state.donationBalanceBefore1 = ERC20(address(strategy)).balanceOf(donationAddress);
+
+        // Mock the yield vault's stEthPerToken instead of strategy's internal method
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(state.newExchangeRate1));
+
+        // Harvest to realize profit
+        vm.startPrank(keeper);
+        vault.report();
+        vm.stopPrank();
+
+        // Check donation address balance after harvest
+        state.donationBalanceAfter1 = ERC20(address(strategy)).balanceOf(donationAddress);
+
+        // Verify donation address received profit
+        assertGt(
+            state.donationBalanceAfter1,
+            state.donationBalanceBefore1,
+            "Donation address should have received profit after first harvest"
+        );
+
+        // Second user deposits after profit
+        vm.startPrank(address(this));
+        airdrop(ERC20(WSTETH), state.user2, state.depositAmount2);
+        vm.stopPrank();
+
+        vm.startPrank(state.user2);
+        ERC20(WSTETH).approve(address(strategy), type(uint256).max);
+        vault.deposit(state.depositAmount2, state.user2);
+        vm.stopPrank();
+
+        // Clear mock
+        vm.clearMockedCalls();
+
+        // Generate more yield after second user joined (5% increase from last rate)
+        state.newExchangeRate2 = (state.newExchangeRate1 * 105) / 100;
+
+        // Check donation address balance before second harvest
+        state.donationBalanceBefore2 = ERC20(address(strategy)).balanceOf(donationAddress);
+
+        // Mock the yield vault's stEthPerToken
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(state.newExchangeRate2));
+
+        // Harvest again
+        vm.startPrank(keeper);
+        vault.report();
+        vm.stopPrank();
+
+        // Clear mock
+        vm.clearMockedCalls();
+
+        // Check donation address balance after second harvest
+        state.donationBalanceAfter2 = ERC20(address(strategy)).balanceOf(donationAddress);
+
+        // Verify donation address received more profit
+        assertGt(
+            state.donationBalanceAfter2,
+            state.donationBalanceBefore2,
+            "Donation address should have received profit after second harvest"
+        );
+
+        // Keep current exchange rate at last reported during redemptions to ensure obligations solvency
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(state.newExchangeRate2));
+
+        // redeem the shares of the donation address first
+        vm.startPrank(donationAddress);
+        vault.redeem(vault.balanceOf(donationAddress), donationAddress, donationAddress);
+        vm.stopPrank();
+
+        // Then both users withdraw
+        vm.startPrank(state.user1);
+        state.user1Shares = vault.balanceOf(state.user1);
+        state.user1Assets = vault.redeem(vault.balanceOf(state.user1), state.user1, state.user1);
+        vm.stopPrank();
+
+        vm.startPrank(state.user2);
+        state.user2Shares = vault.balanceOf(state.user2);
+        state.user2Assets = vault.redeem(vault.balanceOf(state.user2), state.user2, state.user2);
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+
+        // User 1 deposited before first yield accrual, so should have earned more
+        assertApproxEqRel(
+            state.user1Assets * state.newExchangeRate2,
+            state.depositAmount1 * state.initialExchangeRate,
+            0.000001e18, // 0.0001% tolerance
+            "User 1 should receive deposit adjusted for exchange rate change"
+        );
+
+        // User 2 deposited after first yield accrual but before second
+        assertApproxEqRel(
+            state.user2Assets * state.newExchangeRate2,
+            state.depositAmount2 * state.newExchangeRate1,
+            0.00001e18, // 0.1% tolerance
+            "User 2 should receive deposit adjusted for exchange rate change"
+        );
     }
 
+    /// @notice Test the harvesting functionality
     function testHarvestLido() public {
-        _testHarvest(100e18);
+        uint256 depositAmount = 100e18; // 100 WSTETH
+
+        // Deposit first
+        vm.startPrank(user);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Capture initial state
+        uint256 initialAssets = vault.totalAssets();
+        uint256 initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+
+        // Call report as keeper (which internally calls _harvestAndReport)
+        vm.startPrank(keeper);
+        vault.report();
+        vm.stopPrank();
+
+        // Get new exchange rate and total assets
+        uint256 newExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+        uint256 newTotalAssets = vault.totalAssets();
+
+        // mock stEthPerToken to be 1.1x the initial exchange rate
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode((newExchangeRate * 11) / 10));
+
+        // Verify exchange rate is updated
+        assertEq(newExchangeRate, initialExchangeRate, "Exchange rate should be updated after harvest");
+
+        // Verify total assets after harvest
+        // Note: We don't check for specific increases here as we're using a mainnet fork
+        // and yield calculation can vary, but assets should be >= than before unless there's a loss
+        assertGe(newTotalAssets, initialAssets, "Total assets should not decrease after harvest");
     }
 
+    /// @notice Fuzz test emergency exit functionality
     function testFuzzEmergencyExit(uint256 depositAmount) public {
-        _testFuzzEmergencyExit(depositAmount);
+        // Bound deposit amount to reasonable values
+        depositAmount = bound(depositAmount, 1e18, 10000e18); // 1 to 10,000 WSTETH
+
+        // Airdrop tokens to user for this test
+        airdrop(ERC20(WSTETH), user, depositAmount);
+
+        // User deposits
+        vm.startPrank(user);
+        ERC20(WSTETH).approve(address(strategy), depositAmount);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Trigger emergency shutdown mode - must be called by emergency admin
+        vm.startPrank(emergencyAdmin);
+        vault.shutdownStrategy();
+
+        // Execute emergency withdraw
+        vault.emergencyWithdraw(type(uint256).max);
+        vm.stopPrank();
+
+        // User withdraws their funds
+        vm.startPrank(user);
+        uint256 userShares = vault.balanceOf(user);
+        uint256 assetsReceived = vault.redeem(userShares, user, user);
+        vm.stopPrank();
+
+        // The user should receive approximately their original deposit in value
+        // We allow a small deviation due to potential rounding in the calculations
+        assertApproxEqRel(
+            assetsReceived,
+            depositAmount,
+            0.001e18, // 0.1% tolerance
+            "User should receive approximately original deposit value"
+        );
     }
 
+    /// @notice Fuzz test exchange rate tracking and yield calculation
     function testFuzzExchangeRateTrackingLido(uint256 depositAmount, uint256 exchangeRateIncreasePercentage) public {
-        _testFuzzExchangeRateTracking(depositAmount, exchangeRateIncreasePercentage);
+        // Bound inputs to reasonable values
+        depositAmount = bound(depositAmount, 1e18, 10000e18); // 1 to 10,000 WSTETH
+        exchangeRateIncreasePercentage = bound(exchangeRateIncreasePercentage, 1, 99); // 1% to 50% increase
+
+        // Airdrop tokens to user for this test
+        airdrop(ERC20(WSTETH), user, depositAmount);
+
+        // Deposit first
+        vm.startPrank(user);
+        ERC20(WSTETH).approve(address(strategy), depositAmount);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Get initial exchange rate
+        uint256 initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+
+        // Simulate exchange rate increase based on fuzzed percentage
+        uint256 newExchangeRate = (initialExchangeRate * (100 + exchangeRateIncreasePercentage)) / 100;
+
+        // Mock the yield vault's stEthPerToken
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(newExchangeRate));
+
+        // Report to capture yield
+        vm.startPrank(keeper);
+        (uint256 profit, uint256 loss) = vault.report();
+        vm.stopPrank();
+
+        // Clear mock
+        vm.clearMockedCalls();
+
+        // Verify profit and loss
+        assertGt(profit, 0, "Should have captured profit from exchange rate increase");
+        assertEq(loss, 0, "Should have no loss");
+
+        // Verify exchange rate was updated
+        uint256 updatedExchangeRate = IYieldSkimmingStrategy(address(strategy)).getLastRateRay().rayToWad();
+
+        assertApproxEqRel(
+            updatedExchangeRate,
+            newExchangeRate,
+            0.000001e18,
+            "Exchange rate should be updated after harvest"
+        );
     }
 
+    /// @notice Test getting the last reported exchange rate
     function testgetCurrentExchangeRate() public view {
-        _testGetCurrentExchangeRate();
+        uint256 rate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+        assertGt(rate, 0, "Exchange rate should be initialized and greater than zero");
     }
 
+    /// @notice Test balance of asset and shares
     function testBalanceOfAssetAndShares() public {
-        _testBalanceOfAssetAndShares(100e18);
+        uint256 depositAmount = 100e18;
+        vm.startPrank(user);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        uint256 assetBalance = strategy.balanceOfAsset();
+        uint256 sharesBalance = strategy.balanceOfAsset();
+
+        assertEq(assetBalance, sharesBalance, "Asset and shares balance should match for this strategy");
+        assertGt(assetBalance, 0, "Asset balance should be greater than zero after deposit");
     }
 
+    /// @notice Test health check for profit limit exceeded
     function testHealthCheckProfitLimitExceeded() public {
-        _testHealthCheckProfitLimitExceeded(1000e18);
+        uint256 depositAmount = 1000e18;
+        vm.startPrank(user);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // First report: sets doHealthCheck = true, does NOT check
+        vm.startPrank(keeper);
+        vault.report();
+        vm.stopPrank();
+
+        // Mock a 10x exchange rate
+        uint256 initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+        uint256 newExchangeRate = (initialExchangeRate * 7) / 3; // 233%
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(newExchangeRate));
+
+        // Second report: should revert
+        vm.startPrank(keeper);
+        vm.expectRevert("!profit");
+        vault.report();
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
     }
 
+    // testHealthCheckProfitLimitExceeded when doHealthCheck is false
     function testHealthCheckProfitLimitExceededWhenDoHealthCheckIsFalse() public {
-        _testHealthCheckProfitLimitExceededWhenDoHealthCheckIsFalse();
+        vm.startPrank(management);
+        strategy.setDoHealthCheck(false);
+        vm.stopPrank();
+
+        // check the do health check
+        assertEq(strategy.doHealthCheck(), false);
+
+        // old exchange rate
+        uint256 initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+
+        // make a 10 time profit (should revert when doHealthCheck is true but not when it is false)
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(initialExchangeRate * 10));
+
+        // report
+        vm.startPrank(keeper);
+        vault.report();
+        vm.stopPrank();
+
+        // check the do health check
+        assertEq(strategy.doHealthCheck(), true);
     }
 
+    // test change profit limit ratio
     function testChangeProfitLimitRatio() public {
-        _testChangeProfitLimitRatio();
+        vm.startPrank(management);
+        strategy.setProfitLimitRatio(5000);
+        vm.stopPrank();
+
+        // check the profit limit ratio
+        assertEq(strategy.profitLimitRatio(), 5000);
     }
 
     function testSetDoHealthCheckToFalse() public {
-        _testSetDoHealthCheckToFalse();
+        vm.startPrank(management);
+        strategy.setDoHealthCheck(false);
+        vm.stopPrank();
+
+        // check the do health check
+        assertEq(strategy.doHealthCheck(), false);
     }
 
+    // tendTrigger always returns false
     function testTendTriggerAlwaysFalse() public view {
-        _testTendTriggerAlwaysFalse();
+        (bool trigger, ) = IBaseStrategy(address(strategy)).tendTrigger();
+        assertEq(trigger, false, "Tend trigger should always be false");
     }
 
+    /// @notice Fuzz test basic loss scenario with single user
     function testFuzzHarvestWithLossLido(
         uint256 depositAmount,
         uint256 profitPercentage,
         uint256 lossPercentage
     ) public {
-        _testFuzzHarvestWithLoss(depositAmount, profitPercentage, lossPercentage);
+        // Bound inputs to reasonable values
+        depositAmount = bound(depositAmount, 1e18, 10000e18); // 1 to 10,000 WSTETH
+        profitPercentage = bound(profitPercentage, 5, 50); // 5% to 50% profit first
+        lossPercentage = bound(lossPercentage, 1, 19); // 1% to 19% loss (less than 20% limit)
+
+        // Set loss limit to allow 20% losses
+        vm.startPrank(management);
+        strategy.setLossLimitRatio(2000); // 20%
+        vm.stopPrank();
+
+        // Airdrop tokens to user for this test
+        airdrop(ERC20(WSTETH), user, depositAmount);
+
+        // First deposit to create some donation shares for loss protection
+        vm.startPrank(user);
+        ERC20(WSTETH).approve(address(strategy), depositAmount);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Generate some profit first to create donation shares
+        uint256 initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+        uint256 profitExchangeRate = (initialExchangeRate * (100 + profitPercentage)) / 100;
+
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(profitExchangeRate));
+
+        vm.startPrank(keeper);
+        vault.report(); // This creates donation shares for loss protection
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+
+        // Check donation address has shares for loss protection
+        uint256 donationSharesBefore = vault.balanceOf(donationAddress);
+        assertGt(donationSharesBefore, 0, "Donation address should have shares for loss protection");
+
+        // Check initial state before loss
+        uint256 totalAssetsBefore = vault.totalAssets();
+        uint256 userSharesBefore = vault.balanceOf(user);
+
+        // Simulate exchange rate decrease
+        uint256 lossExchangeRate = (profitExchangeRate * (100 - lossPercentage)) / 100;
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(lossExchangeRate));
+
+        // Call report and capture the returned values
+        vm.startPrank(keeper);
+        (uint256 profit, uint256 loss) = vault.report();
+        vm.stopPrank();
+
+        // Clear mock to avoid interference with other tests
+        vm.clearMockedCalls();
+
+        // Assert loss and profit
+        assertEq(profit, 0, "Profit should be zero");
+        assertGt(loss, 0, "Loss should be positive");
+
+        // Check that donation shares were burned for loss protection
+        uint256 donationSharesAfter = vault.balanceOf(donationAddress);
+        assertLt(donationSharesAfter, donationSharesBefore, "Donation shares should be burned for loss protection");
+
+        // User shares should remain the same (loss protection in effect)
+        uint256 userSharesAfter = vault.balanceOf(user);
+        assertEq(userSharesAfter, userSharesBefore, "User shares should not change due to loss protection");
+
+        // Total assets should not change
+        uint256 totalAssetsAfter = vault.totalAssets();
+        assertEq(totalAssetsAfter, totalAssetsBefore, "Total assets should be the same before and after loss");
     }
 
+    /// @notice Test loss scenario where loss exceeds available donation shares
     function testLossExceedingDonationSharesLido() public {
-        _testLossExceedingDonationShares();
+        // Set loss limit to allow 15% losses
+        vm.startPrank(management);
+        strategy.setLossLimitRatio(1500); // 15%
+        vm.stopPrank();
+
+        uint256 depositAmount = 1000e18; // 1000 WSTETH
+
+        // User deposits
+        vm.startPrank(user);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Generate small profit to create minimal donation shares
+        uint256 initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+        uint256 smallProfitRate = (initialExchangeRate * 1005) / 1000; // 0.5% profit
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(smallProfitRate));
+
+        vm.startPrank(keeper);
+        vault.report(); // Creates small amount of donation shares
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        uint256 donationSharesBefore = vault.balanceOf(donationAddress);
+        uint256 userSharesBefore = vault.balanceOf(user);
+
+        // Generate large loss (10% from initial rate)
+        uint256 largeLossRate = (initialExchangeRate * 90) / 100;
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(largeLossRate));
+
+        vm.startPrank(keeper);
+        (uint256 profit, uint256 loss) = vault.report();
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        // Verify loss was reported
+        assertEq(profit, 0, "Should have no profit");
+        assertGt(loss, 0, "Should have reported loss");
+
+        // All donation shares should be burned (limited by available balance)
+        uint256 donationSharesAfter = vault.balanceOf(donationAddress);
+        assertLt(donationSharesAfter, donationSharesBefore, "Some donation shares should be burned");
+
+        // User shares should remain the same (they don't get burned)
+        assertEq(vault.balanceOf(user), userSharesBefore, "User shares should not be burned");
+
+        // User should still be able to withdraw, but will receive less due to insufficient loss protection
+        vm.startPrank(user);
+        uint256 assetsReceived = vault.redeem(vault.balanceOf(user), user, user);
+        vm.stopPrank();
+
+        // User receives less than original deposit due to insufficient loss protection
+        assertLt(
+            assetsReceived * largeLossRate,
+            depositAmount * initialExchangeRate,
+            "User should receive less due to insufficient loss protection"
+        );
     }
 
+    /// @notice Test consecutive loss scenarios
     function testConsecutiveLossesLido() public {
-        _testConsecutiveLosses();
+        // Set loss limit to allow 15% losses
+        vm.startPrank(management);
+        strategy.setLossLimitRatio(1500); // 15%
+        vm.stopPrank();
+
+        uint256 depositAmount = 1000e18; // 1000 WSTETH
+
+        // User deposits
+        vm.startPrank(user);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Generate profit to create donation shares
+        uint256 initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+        uint256 profitRate = (initialExchangeRate * 120) / 100; // 20% profit
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(profitRate));
+
+        vm.startPrank(keeper);
+        vault.report(); // Creates donation shares
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        uint256 donationSharesAfterProfit = vault.balanceOf(donationAddress);
+        assertGt(donationSharesAfterProfit, 0, "Should have donation shares after profit");
+
+        // First loss (5% from profit rate)
+        uint256 firstLossRate = (profitRate * 95) / 100;
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(firstLossRate));
+
+        vm.startPrank(keeper);
+        (uint256 profit1, uint256 loss1) = vault.report();
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        assertEq(profit1, 0, "Should have no profit in first loss");
+        assertGt(loss1, 0, "Should have loss in first report");
+
+        uint256 donationSharesAfterFirstLoss = vault.balanceOf(donationAddress);
+        assertLt(
+            donationSharesAfterFirstLoss,
+            donationSharesAfterProfit,
+            "Donation shares should decrease after first loss"
+        );
+
+        // Second consecutive loss (another 5% from current rate)
+        uint256 secondLossRate = (firstLossRate * 95) / 100;
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(secondLossRate));
+
+        vm.startPrank(keeper);
+        (uint256 profit2, uint256 loss2) = vault.report();
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        assertEq(profit2, 0, "Should have no profit in second loss");
+        assertGt(loss2, 0, "Should have loss in second report");
+
+        uint256 donationSharesAfterSecondLoss = vault.balanceOf(donationAddress);
+        assertLe(
+            donationSharesAfterSecondLoss,
+            donationSharesAfterFirstLoss,
+            "Donation shares should decrease or stay same after second loss"
+        );
+
+        // User should still be able to withdraw
+        vm.startPrank(user);
+        uint256 assetsReceived = vault.redeem(vault.balanceOf(user), user, user);
+        vm.stopPrank();
+
+        assertGt(assetsReceived, 0, "User should receive some assets");
     }
 
+    /// @notice Test that loss protection works correctly with zero donation shares
     function testLossWithZeroDonationSharesLido() public {
-        _testLossWithZeroDonationShares();
+        // Set loss limit to allow 10% losses
+        vm.startPrank(management);
+        strategy.setLossLimitRatio(1000); // 10%
+        vm.stopPrank();
+
+        uint256 depositAmount = 1000e18; // 1000 WSTETH
+
+        // User deposits without any prior profit generation
+        vm.startPrank(user);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Verify no donation shares exist
+        uint256 donationSharesBefore = vault.balanceOf(donationAddress);
+        assertEq(donationSharesBefore, 0, "Should have no donation shares initially");
+
+        uint256 userSharesBefore = vault.balanceOf(user);
+        uint256 totalAssetsBefore = vault.totalAssets();
+
+        // Generate loss (5% decrease)
+        uint256 initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+        uint256 lossRate = (initialExchangeRate * 95) / 100;
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(lossRate));
+
+        vm.startPrank(keeper);
+        (uint256 profit, uint256 loss) = vault.report();
+        vm.stopPrank();
+        vm.clearMockedCalls();
+
+        // Verify loss was reported
+        assertEq(profit, 0, "Should have no profit");
+        assertGt(loss, 0, "Should have reported loss");
+
+        // Donation shares should remain zero (nothing to burn)
+        uint256 donationSharesAfter = vault.balanceOf(donationAddress);
+        assertEq(donationSharesAfter, 0, "Should still have no donation shares");
+
+        // User shares should remain unchanged
+        assertEq(vault.balanceOf(user), userSharesBefore, "User shares should not change");
+
+        // Total assets should decrease by loss
+        assertEq(vault.totalAssets(), totalAssetsBefore, "Total assets should be the same before and after loss");
+
+        // User withdrawal should work but receive reduced value
+        vm.startPrank(user);
+        uint256 assetsReceived = vault.redeem(vault.balanceOf(user), user, user);
+        vm.stopPrank();
+
+        // User receives less due to no loss protection
+        assertLt(
+            assetsReceived * lossRate,
+            depositAmount * initialExchangeRate,
+            "User should receive less due to no loss protection"
+        );
     }
 
+    /// @notice Fuzz test consecutive loss scenarios
     function testFuzzConsecutiveLossesLido(
         uint256 depositAmount,
         uint256 profitPercentage,
         uint256 firstLossPercentage,
         uint256 secondLossPercentage
     ) public {
-        _testFuzzConsecutiveLosses(depositAmount, profitPercentage, firstLossPercentage, secondLossPercentage);
+        // Bound inputs to reasonable values
+        depositAmount = bound(depositAmount, 1e18, 10000e18); // 1 to 10,000 WSTETH
+        profitPercentage = bound(profitPercentage, 10, 50); // 10% to 50% profit first
+        firstLossPercentage = bound(firstLossPercentage, 1, 10); // 1% to 10% first loss
+        secondLossPercentage = bound(secondLossPercentage, 1, 10); // 1% to 10% second loss
+
+        FuzzTestState memory state;
+
+        // Set loss limit to allow 15% losses
+        vm.startPrank(management);
+        strategy.setLossLimitRatio(2000); // 20%
+        vm.stopPrank();
+
+        // Airdrop tokens to user for this test
+        airdrop(ERC20(WSTETH), user, depositAmount);
+
+        // Get the current exchange rate before deposit
+        state.initialExchangeRate = IYieldSkimmingStrategy(address(strategy)).getCurrentExchangeRate();
+
+        // User deposits
+        vm.startPrank(user);
+        ERC20(WSTETH).approve(address(strategy), depositAmount);
+        vault.deposit(depositAmount, user);
+        vm.stopPrank();
+
+        // Do an initial report to establish the baseline rate
+        vm.prank(keeper);
+        vault.report();
+
+        // Generate profit to create donation shares
+        state.profitRate = (state.initialExchangeRate * (100 + profitPercentage)) / 100;
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(state.profitRate));
+
+        vm.startPrank(keeper);
+        vault.report(); // Creates donation shares
+        vm.stopPrank();
+
+        // make sure donation address received shares
+        assertGt(vault.balanceOf(donationAddress), 0, "Donation address should have received shares");
+
+        // make sure withdrawable underlying value is the same as the deposit amount * initial exchange rate
+        assertApproxEqRel(
+            vault.convertToAssets(vault.balanceOf(user)) * state.profitRate,
+            depositAmount * state.initialExchangeRate,
+            0.01e16, // 0.01% tolerance for loss protection limitations and precision in edge cases
+            "Withdrawable underlying value should be the same as the deposit amount * initial exchange rate"
+        );
+
+        vm.clearMockedCalls();
+
+        state.donationSharesAfterProfit = vault.balanceOf(donationAddress);
+        assertGt(state.donationSharesAfterProfit, 0, "Should have donation shares after profit");
+
+        // First loss
+        state.firstLossRate = (state.profitRate * (100 - firstLossPercentage)) / 100;
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(state.firstLossRate));
+
+        vm.startPrank(keeper);
+        (uint256 profit1, uint256 loss1) = vault.report();
+        vm.stopPrank();
+
+        assertEq(profit1, 0, "Should have no profit in first loss");
+        assertGt(loss1, 0, "Should have loss in first report");
+
+        vm.clearMockedCalls();
+
+        state.donationSharesAfterFirstLoss = vault.balanceOf(donationAddress);
+        assertLt(
+            state.donationSharesAfterFirstLoss,
+            state.donationSharesAfterProfit,
+            "Donation shares should decrease after first loss"
+        );
+
+        // Second consecutive loss
+        state.secondLossRate = (state.firstLossRate * (100 - secondLossPercentage)) / 100;
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(state.secondLossRate));
+
+        vm.startPrank(keeper);
+        (uint256 profit2, uint256 loss2) = vault.report();
+        vm.stopPrank();
+
+        assertEq(profit2, 0, "Should have no profit in second loss");
+        assertGt(loss2, 0, "Should have loss in second report");
+
+        state.donationSharesAfterSecondLoss = vault.balanceOf(donationAddress);
+        assertLe(
+            state.donationSharesAfterSecondLoss,
+            state.donationSharesAfterFirstLoss,
+            "Donation shares should decrease or stay same after second loss"
+        );
+
+        // User should still be able to withdraw
+        vm.startPrank(user);
+        state.assetsReceived = vault.redeem(vault.balanceOf(user), user, user);
+        vm.stopPrank();
+        // Calculate underlying values
+        uint256 initialValue = depositAmount * state.initialExchangeRate;
+        uint256 receivedValue = state.assetsReceived * state.secondLossRate;
+
+        // Check if net rate change is negative (losses > gains)
+        if (state.secondLossRate < state.initialExchangeRate) {
+            // Net loss scenario: user should receive less than initial deposit in underlying terms
+            // This upholds the invariant that users cannot withdraw more than deposited
+            assertLe(
+                receivedValue,
+                initialValue,
+                "User cannot receive more than initial deposit in underlying terms when net loss occurs"
+            );
+        } else {
+            // Net gain scenario: user should receive about the same as their initial deposit
+            assertApproxEqRel(
+                receivedValue,
+                initialValue,
+                3e16, // 3% tolerance for complex yield skimming edge cases with consecutive rate changes
+                "User should receive about the same as deposit when net gain occurs"
+            );
+        }
     }
 
+    // Struct to hold test data and avoid stack too deep
+    struct ProfitLossTestData {
+        address user1;
+        address user2;
+        uint256 depositAmount1;
+        uint256 depositAmount2;
+        uint256 initialRate;
+        uint256 increasedRate;
+        uint256 user1Shares;
+        uint256 user2Shares;
+        uint256 profit1;
+        uint256 loss1;
+        uint256 dragonShares;
+        uint256 user1Assets;
+        uint256 user2Assets;
+        uint256 profit2;
+        uint256 loss2;
+        uint256 dragonSharesAfterLoss;
+    }
+
+    /// @notice Test profit then loss scenario with proper dragon share burning
+    /// @dev Sequence: r1.0, d1, r1.5, d2, report, r1.0, w1, report, r1.5, w2
+    /// Demonstrates that losses are properly handled regardless of rate direction
     function test_profitThenLoss_dragonSharesBurnCorrectly() public {
-        _test_profitThenLoss_dragonSharesBurnCorrectly();
+        ProfitLossTestData memory data;
+
+        data.user1 = makeAddr("user1");
+        data.user2 = makeAddr("user2");
+        data.depositAmount1 = 100e18; // 100 rETH
+        data.depositAmount2 = 150e18; // 150 rETH
+        data.initialRate = 1e18;
+        data.increasedRate = (1e18 * 15) / 10; // 1.5x rate
+
+        // Airdrop rETH to both users
+        airdrop(ERC20(WSTETH), data.user1, data.depositAmount1);
+        airdrop(ERC20(WSTETH), data.user2, data.depositAmount2);
+
+        // Set loss limit to allow for the rate drop from 1.5 to 1.0 (33% loss)
+        vm.startPrank(management);
+        strategy.setLossLimitRatio(5000); // 50% loss limit
+        vm.stopPrank();
+
+        // Step 1-2: r1.0, d1 - set rate to 1.0
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.initialRate));
+
+        vm.startPrank(data.user1);
+        ERC20(WSTETH).approve(address(strategy), data.depositAmount1);
+        data.user1Shares = vault.deposit(data.depositAmount1, data.user1);
+        vm.stopPrank();
+
+        // Expected shares for user1: depositAmount * rate = 100e18 * 1e18 / 1e18 = 100e18
+        // When first depositor, shares = assets
+        assertEq(
+            data.user1Shares,
+            data.depositAmount1,
+            "User1 should receive 100e18 shares for 100e18 rETH at 1:1 rate"
+        );
+
+        // Total assets should increase by deposit amount
+        assertEq(vault.totalAssets(), data.depositAmount1, "Total assets should be 100e18 after user1 deposit");
+
+        vm.clearMockedCalls();
+
+        // Step 3-4: r1.5, d2 - Rate increases to 1.5, User2 deposits 150 rETH
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.increasedRate));
+
+        vm.startPrank(data.user2);
+        ERC20(WSTETH).approve(address(strategy), data.depositAmount2);
+        data.user2Shares = vault.deposit(data.depositAmount2, data.user2);
+        vm.stopPrank();
+
+        // Expected shares for user2:
+        // User2 deposits 150e18 rETH when rate is 1.5
+        // shares = assets * initialRate / currentRate = 150e18 * 1.5 = 225e18
+        assertEq(data.user2Shares, 225e18, "User2 should receive 225e18 shares for 150e18 rETH at 1.5x rate");
+
+        // Total assets should increase by deposit amount
+        assertEq(vault.totalAssets(), 250e18, "Total assets should be 250e18 after both deposits");
+
+        // Step 5: report - First report (should mint dragon shares)
+        vm.startPrank(keeper);
+        (data.profit1, data.loss1) = vault.report();
+        vm.stopPrank();
+        data.dragonShares = vault.balanceOf(donationAddress);
+
+        // Expected profit calculation:
+        // Before report: totalSupply = 100e18 (user1) + 225e18 (user2) = 325e18
+        // Before report: totalAssets = 250e18 rETH
+        // Current rate = 1.5, last reported rate = 1.0
+        //
+        // Dragon shares calculation (excess value method):
+        // 1. Total vault value (in ETH terms) = 250e18 rETH × 1.5 rate = 375e18 ETH
+        // 2. Total user debt (what we owe) = 325e18 shares × 1 ETH/share = 325e18 ETH
+        // 3. Excess value = 375e18 - 325e18 = 50e18 ETH
+        // 4. Dragon shares minted = 50e18 (1 share = 1 ETH value)
+        // 5. Profit reported = 50e18 ETH ÷ 1.5 rate = 33.333e18 rETH
+        assertEq(data.profit1, 33333333333333333333, "Should report 33.333e18 profit");
+        assertEq(data.loss1, 0, "Should report no loss in first report");
+        assertEq(data.dragonShares, 50e18, "Dragon shares should be 50e18");
+
+        // Total supply should increase by dragon shares
+        assertEq(vault.totalSupply(), 375e18, "Total supply should be 325e18 + 50e18 dragon shares");
+
+        // Step 6: r1.0 - Rate drops back to 1.0
+        vm.clearMockedCalls();
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.initialRate));
+
+        // Step 7-8: w1 - User1 withdraws all
+        vm.startPrank(data.user1);
+        data.user1Assets = vault.redeem(vault.balanceOf(data.user1), data.user1, data.user1);
+        vm.stopPrank();
+
+        // User1 has 100e18 shares
+        // So user1 receives: 100 shares / 375 shares  * 250e18 = 66.666e18 rETH
+        assertEq(
+            data.user1Assets,
+            66666666666666666666,
+            "User1 should receive 66.666e18 rETH (100e18 shares at last rate 1.5)"
+        );
+        assertEq(
+            ERC20(WSTETH).balanceOf(data.user1),
+            66666666666666666666,
+            "User1 balance should be 66.666e18 after withdrawal"
+        );
+        assertEq(vault.balanceOf(data.user1), 0, "User1 should have no shares left");
+
+        // Step 9: report - Second report (should burn dragon shares due to loss)
+        vm.startPrank(keeper);
+        (data.profit2, data.loss2) = vault.report();
+        vm.stopPrank();
+        data.dragonSharesAfterLoss = vault.balanceOf(donationAddress);
+
+        // Expected loss calculation using excess value method:
+        // After user1 withdrawal:
+        // - User1 withdrew: 100e18 shares ÷ 1.5 rate = 66.666e18 rETH
+        // - Remaining shares: user2 (225e18) + dragon shares (50e18) = 275e18
+        // - Remaining assets: 250e18 - 66.666e18 = 183.333e18 rETH
+        // - Current rate: 1.0, last reported rate: 1.5
+        //
+        // Loss calculation (excess value method):
+        // 1. Total vault value (in ETH terms) = 183.333e18 rETH × 1.0 rate = 183.333e18 ETH
+        // 2. Total debt owed = 275e18 shares × 1 ETH/share = 275e18 ETH
+        // 3. Deficit (loss) = 183.333e18 - 275e18 = -91.666e18 ETH
+        // 4. Loss reported = 91.666e18 ETH ÷ 1.0 rate = 91.666e18 rETH
+        assertEq(data.profit2, 0, "Should report no profit in second report");
+        assertEq(data.loss2, 91666666666666666666, "Should report 91.666e18 loss");
+
+        // Dragon shares burning to cover loss:
+        // - Loss to cover: 91.666e18 ETH
+        // - Dragon shares available: 50e18
+        // - All 50e18 dragon shares burned (insufficient to cover full loss)
+        // - Uncovered loss: 91.666e18 - 50e18 = 41.666e18 ETH remains as vault deficit
+        assertEq(data.dragonSharesAfterLoss, 0, "All dragon shares should be burned");
+
+        // Log the actual values for debugging
+        console.log("Dragon shares before loss:", data.dragonShares);
+        console.log("Dragon shares after loss:", data.dragonSharesAfterLoss);
+        console.log("Loss reported:", data.loss2);
+
+        // Step 10-11: r1.5, w2 - Rate increases back to 1.5, User2 withdraws all
+        vm.clearMockedCalls();
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.increasedRate));
+
+        vm.startPrank(data.user2);
+        data.user2Assets = vault.redeem(vault.balanceOf(data.user2), data.user2, data.user2);
+
+        vm.stopPrank();
+
+        // check if vault is insolvent
+        assertEq(IYieldSkimmingStrategy(address(vault)).isVaultInsolvent(), false, "Vault should be solvent");
+
+        // User2 has 225e18 shares
+        // At rate 1.5, user2 should receive: 225e18 / 1.5 = 150e18 rETH
+        assertEq(data.user2Assets, 150e18, "User2 should receive 150e18 rETH (225e18 shares at 1.5 rate)");
+        assertEq(ERC20(WSTETH).balanceOf(data.user2), 150e18, "User2 balance should be 150e18 after withdrawal");
+        assertEq(vault.balanceOf(data.user2), 0, "User2 should have no shares left");
+
+        // Final state: vault should be mostly empty
+        // There might be some remaining dragon shares that weren't fully burned
+        // and their value at the current rate
+        uint256 remainingDragonShares = vault.balanceOf(donationAddress);
+        uint256 remainingAssets = vault.totalAssets();
+
+        // Log final state for debugging
+        console.log("Remaining dragon shares:", remainingDragonShares);
+        console.log("Remaining total supply:", vault.totalSupply());
+        console.log("Remaining assets:", remainingAssets);
+
+        // Final state analysis:
+        // In this specific test scenario, we know the outcome:
+        // - remainingDragonShares = 0 (all 50e18 burned to cover loss)
+        // - vault.totalSupply() = 0 (both users withdrew all shares)
+        // - remainingAssets = 33.333e18 rETH (uncovered loss portion)
+
+        assertEq(remainingDragonShares, 0, "All dragon shares should be burned");
+        assertEq(vault.totalSupply(), 0, "All shares should be withdrawn");
+
+        // Final state explanation:
+        // After all operations: 183.333e18 rETH remained after user1 withdrawal
+        // User2 then withdrew: 225e18 shares ÷ 1.5 rate = 150e18 rETH
+        // Remaining assets: 183.333e18 - 150e18 = 33.333e18 rETH
+        //
+        // This 33.333e18 rETH represents the uncovered portion of the 91.666e18 ETH loss
+        // that couldn't be covered by the 50e18 dragon shares that were burned
+        console.log("Expected behavior: Assets remain due to uncovered loss");
+        assertEq(remainingAssets, 33333333333333333334, "Expected 33.333e18 rETH to remain from uncovered loss");
+
+        // lets call report
+        vm.startPrank(keeper);
+        (uint256 profit3, uint256 loss3) = vault.report();
+        vm.stopPrank();
+        console.log("Profit reported:", profit3);
+        console.log("Loss reported:", loss3);
+        console.log("Dragon shares remaining:", vault.balanceOf(donationAddress));
+        console.log("Total assets:", vault.totalAssets());
+
+        // dragon should withdraw remaining assets
+        vm.startPrank(donationAddress);
+        uint256 assets = vault.redeem(vault.balanceOf(donationAddress), donationAddress, donationAddress);
+        console.log("Assets withdrawn:", assets);
+        vm.stopPrank();
+        console.log("Donation address balance:", ERC20(WSTETH).balanceOf(donationAddress));
+        console.log("Donation address total assets:", vault.totalAssets());
+        console.log("Donation address total supply:", vault.totalSupply());
     }
 
+    // Struct to avoid stack too deep for dragon withdrawal tests
+    struct DragonWithdrawalTestData {
+        address user1;
+        uint256 depositAmount;
+        uint256 initialRate;
+        uint256 increasedRate;
+        uint256 decreasedRate;
+        uint256 finalRate;
+        uint256 user1Shares;
+        uint256 dragonSharesAfterProfit;
+        uint256 dragonAssets;
+        uint256 profit1;
+        uint256 loss1;
+        uint256 profit2;
+        uint256 loss2;
+        uint256 profit3;
+        uint256 loss3;
+        uint256 assetsReceived;
+    }
+
+    /// @notice Test dragon router withdrawal followed by rate recovery - user should have no loss
+    /// @dev Sequence: d1 -> r1.5 -> report (mint DR) -> wDR -> r1.0 -> report (cant burn shares) -> r1.5 -> report -> w1 (no loss)
     function test_dragonRouterWithdrawal_rateRecovery_userNoLoss() public {
-        _test_dragonRouterWithdrawal_rateRecovery_userNoLoss();
+        DragonWithdrawalTestData memory data;
+
+        data.user1 = makeAddr("user1");
+        data.depositAmount = 100e18; // 100 rETH
+        data.initialRate = 1e18; // 1.0
+        data.increasedRate = (1e18 * 15) / 10; // 1.5x rate
+        data.decreasedRate = 1e18; // back to 1.0
+
+        // Airdrop rETH to user
+        airdrop(ERC20(WSTETH), data.user1, data.depositAmount);
+
+        // Set loss limit to allow for rate changes
+        vm.startPrank(management);
+        strategy.setLossLimitRatio(5000); // 50% loss limit
+        vm.stopPrank();
+
+        // Step 1: d1 - User deposits at rate 1.0
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.initialRate));
+
+        vm.startPrank(data.user1);
+        ERC20(WSTETH).approve(address(strategy), data.depositAmount);
+        data.user1Shares = vault.deposit(data.depositAmount, data.user1);
+        vm.stopPrank();
+
+        // Expected shares: depositAmount * rate = 100e18 * 1e18 / 1e18 = 100e18
+        assertEq(data.user1Shares, 100e18, "User1 should receive 100e18 shares at 1:1 rate");
+
+        vm.clearMockedCalls();
+
+        // Step 2: r1.5 - Rate increases to 1.5
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.increasedRate));
+
+        // Step 3: report (mint DR) - First report creates dragon shares
+        vm.startPrank(keeper);
+        (data.profit1, data.loss1) = vault.report();
+        vm.stopPrank();
+
+        data.dragonSharesAfterProfit = vault.balanceOf(donationAddress);
+
+        // Expected profit calculation:
+        // Total assets: 100e18 rETH
+        // Current rate: 1.5, last rate: 1.0
+        // Vault value: 100e18 * 1.5 = 150e18 ETH
+        // User debt: 100e18 * 1.0 = 100e18 ETH
+        // Excess value: 150e18 - 100e18 = 50e18 ETH
+        // Dragon shares minted: 50e18
+        // Profit reported: 50e18 / 1.5 = 33.333e18 rETH
+        assertEq(data.profit1, 33333333333333333333, "Should report 33.333e18 profit");
+        assertEq(data.loss1, 0, "Should report no loss");
+        assertEq(data.dragonSharesAfterProfit, 50e18, "Dragon shares should be 50e18");
+
+        // Step 4: wDR - Dragon router withdraws all shares (removes protection buffer)
+        vm.startPrank(donationAddress);
+        data.dragonAssets = vault.redeem(vault.balanceOf(donationAddress), donationAddress, donationAddress);
+        vm.stopPrank();
+
+        // Expected dragon withdrawal:
+        // Dragon shares: 50e18
+        // Total shares: 150e18 (100e18 user + 50e18 dragon)
+        // Total assets: 100e18 rETH
+        // Dragon receives: 50e18 / 150e18 * 100e18 = 33.333e18 rETH
+        assertEq(data.dragonAssets, 33333333333333333333, "Dragon should receive 33.333e18 rETH");
+        assertEq(vault.balanceOf(donationAddress), 0, "Dragon should have no shares after withdrawal");
+
+        vm.clearMockedCalls();
+
+        // Step 5: r1.0 - Rate drops back to 1.0
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.decreasedRate));
+
+        // Step 6: report (cant burn shares) - Report with no dragon shares to burn
+        vm.startPrank(keeper);
+        (data.profit2, data.loss2) = vault.report();
+        vm.stopPrank();
+
+        // Expected loss calculation:
+        // Remaining assets: 100e18 - 33.333e18 = 66.666e18 rETH
+        // Current rate: 1.0, last rate: 1.5
+        // Vault value: 66.666e18 * 1.0 = 66.666e18 ETH
+        // User debt: 100e18 * 1.0 = 100e18 ETH
+        // Deficit: 66.666e18 - 100e18 = -33.333e18 ETH
+        // Loss reported: 33.333e18 ETH / 1.0 = 33.333e18 rETH
+        // No dragon shares to burn, loss remains uncovered
+        assertEq(data.profit2, 0, "Should report no profit");
+        assertEq(data.loss2, 33333333333333333333, "Should report 33.333e18 loss (with rounding)");
+        assertEq(vault.balanceOf(donationAddress), 0, "Still no dragon shares to burn");
+
+        vm.clearMockedCalls();
+
+        // Step 7: r1.5 - Rate recovers to 1.5
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.increasedRate));
+
+        // Step 8: report - Report the recovery
+        vm.startPrank(keeper);
+        (data.profit3, data.loss3) = vault.report();
+        vm.stopPrank();
+
+        // Expected profit from recovery:
+        // Assets: 66.666e18 rETH
+        // Current rate: 1.5, last rate: 1.0
+        // Vault value: 66.666e18 * 1.5 = 100e18 ETH
+        // User debt: 100e18 ETH (unchanged)
+        // No excess value, no profit to report (exactly breaks even)
+        assertEq(data.profit3, 0, "Should report no profit (exactly breaks even)");
+        assertEq(data.loss3, 0, "Should report no loss");
+
+        // Step 9: w1 - User withdraws (should have no loss due to rate recovery)
+        vm.startPrank(data.user1);
+        data.assetsReceived = vault.redeem(vault.balanceOf(data.user1), data.user1, data.user1);
+        vm.stopPrank();
+
+        // Expected withdrawal:
+        // User shares: 100e18
+        // Total shares: 100e18 (only user shares remain)
+        // Total assets: 66.666e18 rETH
+        // At rate 1.5, user receives: 100e18 / 1.5 = 66.666e18 rETH
+        // Value check: 66.666e18 * 1.5 = 100e18 ETH (matches initial deposit value)
+        assertEq(data.assetsReceived, 66666666666666666666, "User should receive 66.666e18 rETH");
+
+        // Verify no loss in ETH value terms
+        // Since rates are in WAD format (1e18), we need to divide by 1e18 after multiplication
+        uint256 depositValue = (data.depositAmount * data.initialRate) / 1e18; // 100e18 ETH
+        uint256 withdrawValue = (data.assetsReceived * data.increasedRate) / 1e18; // 66.666e18 * 1.5 = 100e18 ETH
+        assertApproxEqAbs(
+            withdrawValue,
+            depositValue,
+            1e15,
+            "User should have no loss in ETH value terms (within 0.001 ETH tolerance)"
+        );
     }
 
+    /// @notice Test dragon router withdrawal followed by rate decline - user should experience loss
+    /// @dev Sequence: d1 -> r1.5 -> report (mint DR) -> wDR -> r1.0 -> report (cant burn shares) -> r0.9 -> w1 (loss)
     function test_dragonRouterWithdrawal_rateDecline_userLoss() public {
-        _test_dragonRouterWithdrawal_rateDecline_userLoss();
+        DragonWithdrawalTestData memory data;
+
+        data.user1 = makeAddr("user1");
+        data.depositAmount = 100e18; // 100 rETH
+        data.initialRate = 1e18; // 1.0
+        data.increasedRate = (1e18 * 15) / 10; // 1.5x rate
+        data.decreasedRate = 1e18; // 1.0
+        data.finalRate = (1e18 * 9) / 10; // 0.9x rate
+
+        // Airdrop rETH to user
+        airdrop(ERC20(WSTETH), data.user1, data.depositAmount);
+
+        // Set loss limit to allow for rate changes
+        vm.startPrank(management);
+        strategy.setLossLimitRatio(5000); // 50% loss limit
+        vm.stopPrank();
+
+        // Step 1: d1 - User deposits at rate 1.0
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.initialRate));
+
+        vm.startPrank(data.user1);
+        ERC20(WSTETH).approve(address(strategy), data.depositAmount);
+        data.user1Shares = vault.deposit(data.depositAmount, data.user1);
+        vm.stopPrank();
+
+        // Expected shares: depositAmount * rate = 100e18 * 1e18 / 1e18 = 100e18
+        assertEq(data.user1Shares, 100e18, "User1 should receive 100e18 shares at 1:1 rate");
+
+        vm.clearMockedCalls();
+
+        // Step 2: r1.5 - Rate increases to 1.5
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.increasedRate));
+
+        // Step 3: report (mint DR) - First report creates dragon shares
+        vm.startPrank(keeper);
+        (data.profit1, data.loss1) = vault.report();
+        vm.stopPrank();
+
+        data.dragonSharesAfterProfit = vault.balanceOf(donationAddress);
+
+        // Expected profit calculation (same as first test):
+        // Total assets: 100e18 rETH
+        // Current rate: 1.5, last rate: 1.0
+        // Vault value: 100e18 * 1.5 = 150e18 ETH
+        // User debt: 100e18 * 1.0 = 100e18 ETH
+        // Excess value: 150e18 - 100e18 = 50e18 ETH
+        // Dragon shares minted: 50e18
+        // Profit reported: 50e18 / 1.5 = 33.333e18 rETH
+        assertEq(data.profit1, 33333333333333333333, "Should report 33.333e18 profit");
+        assertEq(data.loss1, 0, "Should report no loss");
+        assertEq(data.dragonSharesAfterProfit, 50e18, "Dragon shares should be 50e18");
+
+        // Step 4: wDR - Dragon router withdraws all shares (removes protection buffer)
+        vm.startPrank(donationAddress);
+        data.dragonAssets = vault.redeem(vault.balanceOf(donationAddress), donationAddress, donationAddress);
+        vm.stopPrank();
+
+        // Expected dragon withdrawal:
+        // Dragon shares: 50e18
+        // Total shares: 150e18 (100e18 user + 50e18 dragon)
+        // Total assets: 100e18 rETH
+        // Dragon receives: 50e18 / 150e18 * 100e18 = 33.333e18 rETH
+        assertEq(data.dragonAssets, 33333333333333333333, "Dragon should receive 33.333e18 rETH");
+        assertEq(vault.balanceOf(donationAddress), 0, "Dragon should have no shares after withdrawal");
+
+        vm.clearMockedCalls();
+
+        // Step 5: r1.0 - Rate drops back to 1.0
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.decreasedRate));
+
+        // Step 6: report (cant burn shares) - Report with no dragon shares to burn
+        vm.startPrank(keeper);
+        (data.profit2, data.loss2) = vault.report();
+        vm.stopPrank();
+
+        // Expected loss calculation:
+        // Remaining assets: 100e18 - 33.333e18 = 66.666e18 rETH
+        // Current rate: 1.0, last rate: 1.5
+        // Vault value: 66.666e18 * 1.0 = 66.666e18 ETH
+        // User debt: 100e18 * 1.0 = 100e18 ETH
+        // Deficit: 66.666e18 - 100e18 = -33.333e18 ETH
+        // Loss reported: 33.333e18 ETH / 1.0 = 33.333e18 rETH
+        // No dragon shares to burn, loss remains uncovered
+        assertEq(data.profit2, 0, "Should report no profit");
+        assertEq(data.loss2, 33333333333333333333, "Should report 33.333e18 loss (with rounding)");
+        assertEq(vault.balanceOf(donationAddress), 0, "Still no dragon shares to burn");
+
+        vm.clearMockedCalls();
+
+        // Step 7: r0.9 - Rate declines further to 0.9 (below deposit rate)
+        vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.finalRate));
+
+        // Step 8: w1 - User withdraws (should experience loss due to rate below deposit rate and no dragon protection)
+        vm.startPrank(data.user1);
+        data.assetsReceived = vault.redeem(vault.balanceOf(data.user1), data.user1, data.user1);
+        vm.stopPrank();
+
+        // Expected withdrawal with loss:
+        // User shares: 100e18
+        // Total shares: 100e18 (only user shares remain)
+        // Total assets: 66.666e18 rETH
+        // Since vault is insolvent (lastReportedRate=1.0, currentRate=0.9):
+        //   Vault value: 66.666e18 * 0.9 = 60e18 ETH
+        //   User debt: 100e18 ETH
+        //   Deficit: 60e18 - 100e18 = -40e18 ETH (vault is insolvent)
+        // In insolvency, user receives proportional share of assets:
+        //   User receives: 100e18 shares / 100e18 total shares * 66.666e18 assets = 66.666e18 rETH
+        assertEq(data.assetsReceived, 66666666666666666667, "User should receive 66.666e18 rETH");
+
+        // Calculate the loss in ETH value terms
+        // Since rates are in WAD format (1e18), we need to divide by 1e18 after multiplication
+        uint256 depositValue = (data.depositAmount * data.initialRate) / 1e18; // 100e18 ETH
+        uint256 withdrawValue = (data.assetsReceived * data.finalRate) / 1e18; // 66.666e18 * 0.9 = 60e18 ETH
+
+        // User should receive less than their deposit due to loss and no dragon protection
+        assertLt(withdrawValue, depositValue, "User should receive less ETH value than deposited");
+
+        // Expected loss: 100e18 - 60e18 = 40e18 ETH (40% loss)
+        uint256 actualLoss = depositValue - withdrawValue;
+        assertApproxEqAbs(actualLoss, 40e18, 1e15, "User should experience ~40e18 ETH loss (40%)");
+
+        // Verify the user experienced significant loss (40%)
+        uint256 lossPercentage = (actualLoss * 100) / depositValue;
+        assertEq(lossPercentage, 40, "User should experience exactly 40% loss");
     }
 }

--- a/test/integration/strategies/YieldSkimming/base/BaseYieldSkimmingIntegrationTest.sol
+++ b/test/integration/strategies/YieldSkimming/base/BaseYieldSkimmingIntegrationTest.sol
@@ -746,7 +746,6 @@ abstract contract BaseYieldSkimmingIntegrationTest is BaseIntegrationTest {
         vm.startPrank(keeper);
         vault.report();
         vm.stopPrank();
-        _clearMocks();
 
         assertApproxEqRel(
             vault.convertToAssets(vault.balanceOf(user)) * state.profitRate,
@@ -757,6 +756,8 @@ abstract contract BaseYieldSkimmingIntegrationTest is BaseIntegrationTest {
 
         state.donationSharesAfterProfit = vault.balanceOf(donationAddress);
         assertGt(state.donationSharesAfterProfit, 0, "Should have donation shares after profit");
+
+        _clearMocks();
 
         state.firstLossRate = (state.profitRate * (100 - firstLossPercentage)) / 100;
         _mockExchangeRate(state.firstLossRate);

--- a/test/integration/strategies/YieldSkimming/base/BaseYieldSkimmingIntegrationTest.sol
+++ b/test/integration/strategies/YieldSkimming/base/BaseYieldSkimmingIntegrationTest.sol
@@ -783,7 +783,6 @@ abstract contract BaseYieldSkimmingIntegrationTest is BaseIntegrationTest {
         vm.startPrank(keeper);
         (uint256 profit2, uint256 loss2) = vault.report();
         vm.stopPrank();
-        _clearMocks();
 
         assertEq(profit2, 0, "Should have no profit in second loss");
         assertGt(loss2, 0, "Should have loss in second report");
@@ -798,6 +797,7 @@ abstract contract BaseYieldSkimmingIntegrationTest is BaseIntegrationTest {
         vm.startPrank(user);
         state.assetsReceived = vault.redeem(vault.balanceOf(user), user, user);
         vm.stopPrank();
+        _clearMocks();
 
         uint256 initialValue = depositAmount * state.initialExchangeRate;
         uint256 receivedValue = state.assetsReceived * state.secondLossRate;

--- a/test/regen/RegenStakerGovernanceProtection.t.sol
+++ b/test/regen/RegenStakerGovernanceProtection.t.sol
@@ -12,15 +12,8 @@ import { AddressSet } from "src/utils/AddressSet.sol";
 import { IAddressSet } from "src/utils/IAddressSet.sol";
 import { Staker } from "staker/Staker.sol";
 
-/**
- * @title RegenStakerGovernanceProtectionTest
- * @dev Tests governance protection mechanisms for admin functions
- *
- * COVERAGE:
- * - REG-006 fix: setMaxBumpTip protection during active rewards
- * - Consistency: setMinimumStakeAmount protection verification
- * - Governance asymmetry resolution
- */
+/// @title RegenStakerGovernanceProtectionTest
+/// @dev Tests setEarningPowerCalculator governance protection during active reward periods
 contract RegenStakerGovernanceProtectionTest is Test {
     RegenStaker public regenStaker;
     RegenEarningPowerCalculator public earningPowerCalculator;
@@ -34,13 +27,10 @@ contract RegenStakerGovernanceProtectionTest is Test {
     address public user = makeAddr("user");
 
     uint256 public constant INITIAL_REWARD_AMOUNT = 100 ether;
-    uint256 public constant USER_STAKE_AMOUNT = 10 ether;
     uint256 public constant REWARD_DURATION = 30 days;
-    uint256 public constant INITIAL_MAX_BUMP_TIP = 1000;
-    uint128 public constant INITIAL_MIN_STAKE = 100;
+    uint256 public constant INITIAL_MIN_STAKE = 1 ether;
 
     function setUp() public {
-        // Deploy tokens
         rewardToken = new MockERC20(18);
         stakeToken = new MockERC20Staking(18);
 
@@ -60,245 +50,129 @@ contract RegenStakerGovernanceProtectionTest is Test {
             rewardToken,
             stakeToken,
             earningPowerCalculator,
-            INITIAL_MAX_BUMP_TIP,
+            1000,
             admin,
             uint128(REWARD_DURATION),
-            INITIAL_MIN_STAKE,
+            uint128(INITIAL_MIN_STAKE),
             allowset,
             IAddressSet(address(0)),
             AccessMode.NONE,
             allocationAllowset
         );
-
-        // Setup permissions
         regenStaker.setRewardNotifier(rewardNotifier, true);
         allowset.add(user);
         vm.stopPrank();
 
-        // Fund users
         rewardToken.mint(rewardNotifier, INITIAL_REWARD_AMOUNT);
-        stakeToken.mint(user, USER_STAKE_AMOUNT);
+        stakeToken.mint(user, 10 ether);
 
-        // User stakes
         vm.startPrank(user);
-        stakeToken.approve(address(regenStaker), USER_STAKE_AMOUNT);
-        regenStaker.stake(USER_STAKE_AMOUNT, user);
+        stakeToken.approve(address(regenStaker), 10 ether);
+        regenStaker.stake(10 ether, user);
         vm.stopPrank();
     }
 
-    /**
-     * @dev Test REG-006 fix: setMaxBumpTip reverts during active reward period
-     */
-    function test_setMaxBumpTip_revertsDuringActiveReward() public {
-        // Start reward period
+    function _deployNewCalculator() internal returns (RegenEarningPowerCalculator) {
+        return new RegenEarningPowerCalculator(
+            admin,
+            allowset,
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
+    }
+
+    function _startRewards() internal {
         vm.startPrank(rewardNotifier);
         rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT);
         regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT);
         vm.stopPrank();
-
-        // Verify we're in active reward period
-        assertGt(regenStaker.rewardEndTime(), block.timestamp, "Should be in active reward period");
-
-        // Try to INCREASE during active rewards - should revert
-        vm.prank(admin);
-        vm.expectRevert(RegenStakerBase.CannotRaiseMaxBumpTipDuringActiveReward.selector);
-        regenStaker.setMaxBumpTip(type(uint256).max);
-
-        // Try to DECREASE during active rewards - should succeed
-        vm.prank(admin);
-        regenStaker.setMaxBumpTip(INITIAL_MAX_BUMP_TIP - 1);
-
-        // Verify maxBumpTip was decreased (decreases are allowed during active rewards)
-        assertEq(regenStaker.maxBumpTip(), INITIAL_MAX_BUMP_TIP - 1, "MaxBumpTip should be decreased");
     }
 
-    /**
-     * @dev Test setMaxBumpTip succeeds after reward period ends
-     */
-    function test_setMaxBumpTip_succeedsAfterRewardPeriod() public {
-        // Start reward period
-        vm.startPrank(rewardNotifier);
-        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT);
-        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT);
-        vm.stopPrank();
+    function test_RevertWhen_SetEarningPowerCalculatorDuringActiveReward() public {
+        RegenEarningPowerCalculator newCalculator = _deployNewCalculator();
+        _startRewards();
 
-        // Fast forward past reward end time
+        vm.prank(admin);
+        vm.expectRevert(RegenStakerBase.CannotChangeEarningPowerCalculatorDuringActiveReward.selector);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+    }
+
+    function test_SetEarningPowerCalculatorAfterRewardPeriod() public {
+        RegenEarningPowerCalculator newCalculator = _deployNewCalculator();
+        _startRewards();
         vm.warp(regenStaker.rewardEndTime() + 1);
 
-        // Now setMaxBumpTip should succeed
-        uint256 newMaxBumpTip = 5000;
         vm.prank(admin);
-        regenStaker.setMaxBumpTip(newMaxBumpTip);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
 
-        // Verify change was applied
-        assertEq(regenStaker.maxBumpTip(), newMaxBumpTip, "MaxBumpTip should be updated");
+        assertEq(address(regenStaker.earningPowerCalculator()), address(newCalculator));
     }
 
-    /**
-     * @dev Test setMaxBumpTip works before any rewards are notified
-     */
-    function test_setMaxBumpTip_worksBeforeFirstReward() public {
-        // No rewards notified yet, rewardEndTime should be 0
-        assertEq(regenStaker.rewardEndTime(), 0, "No active reward period");
+    function test_SetEarningPowerCalculatorBeforeFirstReward() public {
+        RegenEarningPowerCalculator newCalculator = _deployNewCalculator();
 
-        // setMaxBumpTip should work
-        uint256 newMaxBumpTip = 2000;
         vm.prank(admin);
-        regenStaker.setMaxBumpTip(newMaxBumpTip);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
 
-        assertEq(regenStaker.maxBumpTip(), newMaxBumpTip, "MaxBumpTip should be updated");
+        assertEq(address(regenStaker.earningPowerCalculator()), address(newCalculator));
     }
 
-    /**
-     * @dev Test setMinimumStakeAmount protection is still working (regression test)
-     */
-    function test_setMinimumStakeAmount_protectionStillWorks() public {
-        // Start reward period
-        vm.startPrank(rewardNotifier);
-        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT);
-        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT);
-        vm.stopPrank();
+    function test_RevertWhen_NonAdminSetsEarningPowerCalculator() public {
+        RegenEarningPowerCalculator newCalculator = _deployNewCalculator();
 
-        // Try to raise minimum stake during active rewards - should revert
-        vm.prank(admin);
-        vm.expectRevert(RegenStakerBase.CannotRaiseMinimumStakeAmountDuringActiveReward.selector);
-        regenStaker.setMinimumStakeAmount(1 ether);
-
-        // Lowering should still work
-        vm.prank(admin);
-        regenStaker.setMinimumStakeAmount(50);
-        assertEq(regenStaker.minimumStakeAmount(), 50, "Should allow lowering minimum");
-    }
-
-    /**
-     * @dev Test governance protection consistency between setMaxBumpTip and setMinimumStakeAmount
-     */
-    function test_governanceProtectionConsistency() public {
-        // Start reward period
-        vm.startPrank(rewardNotifier);
-        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT);
-        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT);
-        vm.stopPrank();
-
-        uint256 rewardEndTime = regenStaker.rewardEndTime();
-        assertGt(rewardEndTime, block.timestamp, "Should be in active reward period");
-
-        // Both functions should be protected during active rewards
-        vm.startPrank(admin);
-
-        // setMaxBumpTip protection (increases revert)
-        vm.expectRevert(RegenStakerBase.CannotRaiseMaxBumpTipDuringActiveReward.selector);
-        regenStaker.setMaxBumpTip(INITIAL_MAX_BUMP_TIP + 1);
-        // decreases allowed
-        regenStaker.setMaxBumpTip(INITIAL_MAX_BUMP_TIP - 1);
-
-        // setMinimumStakeAmount protection (raising)
-        vm.expectRevert(RegenStakerBase.CannotRaiseMinimumStakeAmountDuringActiveReward.selector);
-        regenStaker.setMinimumStakeAmount(1 ether);
-
-        vm.stopPrank();
-
-        // Fast forward past reward period
-        vm.warp(rewardEndTime + 1);
-
-        // Both should work after reward period
-        vm.startPrank(admin);
-
-        regenStaker.setMaxBumpTip(10000);
-        assertEq(regenStaker.maxBumpTip(), 10000, "MaxBumpTip should update after reward period");
-
-        regenStaker.setMinimumStakeAmount(1 ether);
-        assertEq(regenStaker.minimumStakeAmount(), 1 ether, "MinimumStake should update after reward period");
-
-        vm.stopPrank();
-    }
-
-    /**
-     * @dev Test only admin can call setMaxBumpTip (existing access control still works)
-     */
-    function test_setMaxBumpTip_onlyAdmin() public {
-        // Fast forward past any potential reward period
-        vm.warp(block.timestamp + REWARD_DURATION + 1);
-
-        // Non-admin should fail
         vm.prank(user);
         vm.expectRevert(abi.encodeWithSelector(Staker.Staker__Unauthorized.selector, bytes32("not admin"), user));
-        regenStaker.setMaxBumpTip(5000);
-
-        // Admin should succeed
-        vm.prank(admin);
-        regenStaker.setMaxBumpTip(5000);
-        assertEq(regenStaker.maxBumpTip(), 5000, "Admin should be able to set maxBumpTip");
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
     }
 
-    /**
-     * @dev Fuzz test: setMaxBumpTip protection across various time points during reward period
-     */
-    function testFuzz_setMaxBumpTip_protectionTiming(uint256 timeOffset) public {
-        // Start reward period
-        vm.startPrank(rewardNotifier);
-        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT);
-        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT);
-        vm.stopPrank();
-
+    function test_RevertWhen_SetEarningPowerCalculatorExactlyAtRewardEndTime() public {
+        RegenEarningPowerCalculator newCalculator = _deployNewCalculator();
+        _startRewards();
         uint256 rewardEndTime = regenStaker.rewardEndTime();
 
-        // Bound time offset to be within or after reward period
+        vm.warp(rewardEndTime);
+        vm.prank(admin);
+        vm.expectRevert(RegenStakerBase.CannotChangeEarningPowerCalculatorDuringActiveReward.selector);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+
+        vm.warp(rewardEndTime + 1);
+        vm.prank(admin);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+        assertEq(address(regenStaker.earningPowerCalculator()), address(newCalculator));
+    }
+
+    function testFuzz_SetEarningPowerCalculatorProtectionTiming(uint256 timeOffset) public {
+        RegenEarningPowerCalculator newCalculator = _deployNewCalculator();
+        _startRewards();
+        uint256 rewardEndTime = regenStaker.rewardEndTime();
         timeOffset = bound(timeOffset, 0, REWARD_DURATION + 1 days);
         vm.warp(block.timestamp + timeOffset);
 
         vm.prank(admin);
         if (block.timestamp <= rewardEndTime) {
-            // During reward period - should revert
-            vm.expectRevert(RegenStakerBase.CannotRaiseMaxBumpTipDuringActiveReward.selector);
-            regenStaker.setMaxBumpTip(9999);
+            vm.expectRevert(RegenStakerBase.CannotChangeEarningPowerCalculatorDuringActiveReward.selector);
+            regenStaker.setEarningPowerCalculator(address(newCalculator));
         } else {
-            // After reward period - should succeed
-            regenStaker.setMaxBumpTip(9999);
-            assertEq(regenStaker.maxBumpTip(), 9999, "Should update after reward period");
+            regenStaker.setEarningPowerCalculator(address(newCalculator));
+            assertEq(address(regenStaker.earningPowerCalculator()), address(newCalculator));
         }
     }
 
-    /**
-     * @dev Test multiple reward cycles with setMaxBumpTip protection
-     */
-    function test_setMaxBumpTip_multipleRewardCycles() public {
-        // First reward cycle
-        vm.startPrank(rewardNotifier);
-        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT / 2);
-        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT / 2);
+    function test_AdminCanAssignRewardNotifierToArbitraryAddress() public {
+        address newNotifier = makeAddr("newNotifier");
+        uint256 rewardAmount = 50 ether;
+        rewardToken.mint(newNotifier, rewardAmount);
+
+        vm.prank(admin);
+        regenStaker.setRewardNotifier(newNotifier, true);
+
+        assertTrue(regenStaker.isRewardNotifier(newNotifier));
+
+        vm.startPrank(newNotifier);
+        rewardToken.transfer(address(regenStaker), rewardAmount);
+        regenStaker.notifyRewardAmount(rewardAmount);
         vm.stopPrank();
 
-        // Cannot change during first cycle
-        vm.prank(admin);
-        vm.expectRevert(RegenStakerBase.CannotRaiseMaxBumpTipDuringActiveReward.selector);
-        regenStaker.setMaxBumpTip(INITIAL_MAX_BUMP_TIP + 1000);
-
-        // Fast forward to between cycles
-        vm.warp(regenStaker.rewardEndTime() + 1);
-
-        // Can change between cycles
-        vm.prank(admin);
-        regenStaker.setMaxBumpTip(2000);
-        assertEq(regenStaker.maxBumpTip(), 2000, "Should update between cycles");
-
-        // Second reward cycle
-        vm.startPrank(rewardNotifier);
-        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT / 2);
-        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT / 2);
-        vm.stopPrank();
-
-        // Cannot change during second cycle
-        vm.prank(admin);
-        vm.expectRevert(RegenStakerBase.CannotRaiseMaxBumpTipDuringActiveReward.selector);
-        regenStaker.setMaxBumpTip(3000);
-
-        // Fast forward past second cycle
-        vm.warp(regenStaker.rewardEndTime() + 1);
-
-        // Can change after all cycles
-        vm.prank(admin);
-        regenStaker.setMaxBumpTip(3000);
-        assertEq(regenStaker.maxBumpTip(), 3000, "Should update after all cycles");
+        assertGt(regenStaker.rewardEndTime(), block.timestamp);
     }
 }

--- a/test/regen/RegenStakerGovernanceProtection.t.sol
+++ b/test/regen/RegenStakerGovernanceProtection.t.sol
@@ -73,12 +73,7 @@ contract RegenStakerGovernanceProtectionTest is Test {
     }
 
     function _deployNewCalculator() internal returns (RegenEarningPowerCalculator) {
-        return new RegenEarningPowerCalculator(
-            admin,
-            allowset,
-            IAddressSet(address(0)),
-            AccessMode.ALLOWSET
-        );
+        return new RegenEarningPowerCalculator(admin, allowset, IAddressSet(address(0)), AccessMode.ALLOWSET);
     }
 
     function _startRewards() internal {

--- a/test/unit/core/multistrategyvault/LockedVaultTest.t.sol
+++ b/test/unit/core/multistrategyvault/LockedVaultTest.t.sol
@@ -510,4 +510,25 @@ contract LockedVaultTest is Test {
         assertEq(withdrawnAmount, remainingAmount, "Should redeem remaining amount");
         vm.stopPrank();
     }
+
+    function test_RegenGovernanceTransfer() public {
+        address newGovernance = address(0x999);
+        
+        // Only current regen governance can transfer
+        vm.expectRevert(IMultistrategyLockedVault.NotRegenGovernance.selector);
+        vault.setRegenGovernance(newGovernance);
+        
+        vm.prank(gov);
+        vault.setRegenGovernance(newGovernance);
+        
+        assertEq(vault.regenGovernance(), newGovernance, "governance should update immediately");
+    }
+
+    function test_RegenGovernanceRejectsInvalidAddresses() public {
+        vm.startPrank(gov);
+        vm.expectRevert(IMultistrategyLockedVault.InvalidGovernanceAddress.selector);
+        vault.setRegenGovernance(address(0));
+        vault.setRegenGovernance(gov);
+        vm.stopPrank();
+    }
 }

--- a/test/unit/core/multistrategyvault/LockedVaultTest.t.sol
+++ b/test/unit/core/multistrategyvault/LockedVaultTest.t.sol
@@ -510,25 +510,4 @@ contract LockedVaultTest is Test {
         assertEq(withdrawnAmount, remainingAmount, "Should redeem remaining amount");
         vm.stopPrank();
     }
-
-    function test_RegenGovernanceTransfer() public {
-        address newGovernance = address(0x999);
-        
-        // Only current regen governance can transfer
-        vm.expectRevert(IMultistrategyLockedVault.NotRegenGovernance.selector);
-        vault.setRegenGovernance(newGovernance);
-        
-        vm.prank(gov);
-        vault.setRegenGovernance(newGovernance);
-        
-        assertEq(vault.regenGovernance(), newGovernance, "governance should update immediately");
-    }
-
-    function test_RegenGovernanceRejectsInvalidAddresses() public {
-        vm.startPrank(gov);
-        vm.expectRevert(IMultistrategyLockedVault.InvalidGovernanceAddress.selector);
-        vault.setRegenGovernance(address(0));
-        vault.setRegenGovernance(gov);
-        vm.stopPrank();
-    }
 }

--- a/test/unit/strategies/yieldSkimming/AccessControl.t.sol
+++ b/test/unit/strategies/yieldSkimming/AccessControl.t.sol
@@ -292,11 +292,15 @@ contract AccessControlTest is Setup {
         vm.prank(management);
         strategy.setDragonRouter(newRouter);
 
-        // Arrange: crash to insolvency
+        // Arrange: crash to insolvency (with burning disabled so dragon keeps shares)
         MockStrategySkimming(address(strategy)).updateExchangeRate(6e17);
         vm.prank(keeper);
         strategy.report();
         assertTrue(IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(), "vault should be insolvent");
+
+        // Enable burning after insolvency so dragon solvency checks are active
+        vm.prank(management);
+        strategy.setEnableBurning(true);
 
         // Act + Assert: finalize should revert during insolvency
         skip(14 days);

--- a/test/unit/strategies/yieldSkimming/AccessControl.t.sol
+++ b/test/unit/strategies/yieldSkimming/AccessControl.t.sol
@@ -608,6 +608,49 @@ contract AccessControlTest is Setup {
         assertEq(strategy.dragonRouter(), donationAddress);
     }
 
+    /**
+     * @notice Test that enableBurning=false bypasses dragon solvency protection during finalization
+     * @dev Documents the !enableBurning early-return path in _requireDragonSolvency.
+     *      When enableBurning=false, dragon operations are unrestricted regardless of vault solvency.
+     *      Contrast with test_finalizeDragonRouterChange_revertsWhenInsolventWithOldDragonShares
+     *      which shows that enableBurning=true DOES block finalization during insolvency.
+     */
+    function test_finalizeDragonRouterChange_enableBurningFalse_duringInsolvency() public {
+        address alice = makeAddr("alice");
+        address newRouter = address(0x123);
+        uint256 depositAmount = 100e18;
+
+        // 1. Set enableBurning=false (already default, but be explicit)
+        vm.prank(management);
+        strategy.setEnableBurning(false);
+
+        // Setup: user deposit and profit so dragon holds shares
+        mintAndDepositIntoStrategy(strategy, alice, depositAmount);
+        MockStrategySkimming(address(strategy)).updateExchangeRate(15e17);
+        vm.prank(keeper);
+        strategy.report();
+        uint256 dragonShares = strategy.balanceOf(donationAddress);
+        assertGt(dragonShares, 0, "dragon should have shares");
+
+        // 2. Create insolvency (crash rate below user debt coverage)
+        MockStrategySkimming(address(strategy)).updateExchangeRate(6e17);
+        vm.prank(keeper);
+        strategy.report();
+        assertTrue(IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(), "vault should be insolvent");
+
+        // 3. Initiate and finalize dragon router change
+        vm.prank(management);
+        strategy.setDragonRouter(newRouter);
+        skip(14 days);
+
+        // 4. Verify it succeeds — enableBurning=false bypasses _requireDragonSolvency early-return
+        strategy.finalizeDragonRouterChange();
+        assertEq(strategy.dragonRouter(), newRouter, "dragon router should be updated");
+
+        // 5. Verify the complementary case: enabling burning WOULD block finalization.
+        //    (Already covered by test_finalizeDragonRouterChange_revertsWhenInsolventWithOldDragonShares)
+    }
+
     function test_cooldownPeriodConstant() public pure {
         // Verify cooldown period is 14 days (604800 seconds)
         uint256 EXPECTED_COOLDOWN = 14 days;

--- a/test/unit/strategies/yieldSkimming/Accounting.t.sol
+++ b/test/unit/strategies/yieldSkimming/Accounting.t.sol
@@ -1107,7 +1107,8 @@ contract AccountingTest is Setup {
         strategy.report();
 
         // Track total debt before transfers
-        uint256 totalDebtBefore = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()) +
+        uint256 totalDebtBefore = strategy.totalSupply() -
+            strategy.balanceOf(strategy.dragonRouter()) +
             strategy.balanceOf(strategy.dragonRouter());
 
         // Perform random transfers
@@ -1137,7 +1138,8 @@ contract AccountingTest is Setup {
         }
 
         // Verify total debt is conserved
-        uint256 totalDebtAfter = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()) +
+        uint256 totalDebtAfter = strategy.totalSupply() -
+            strategy.balanceOf(strategy.dragonRouter()) +
             strategy.balanceOf(strategy.dragonRouter());
 
         assertEq(totalDebtAfter, totalDebtBefore, "Total debt should be conserved across transfers");
@@ -1486,8 +1488,7 @@ contract AccountingTest is Setup {
         console2.log("Current vault value:", (strategy.totalAssets() * 1e18) / 1e18); // Rate is 1.0
         console2.log(
             "Total debt needed:",
-            strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()) +
-                strategy.balanceOf(donationAddress)
+            strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()) + strategy.balanceOf(donationAddress)
         );
 
         // Skip the deposit since vault is insolvent - this shows the protection working
@@ -1533,10 +1534,7 @@ contract AccountingTest is Setup {
         console2.log("Final dragon shares:", strategy.balanceOf(donationAddress));
         console2.log("Final total assets:", strategy.totalAssets());
         console2.log("Final total supply:", strategy.totalSupply());
-        console2.log(
-            "Final total value debt:",
-            strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter())
-        );
+        console2.log("Final total value debt:", strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()));
 
         // Verify that without the rate check, losses are properly handled
         assertEq(profit2, 0, "Should report no profit in second report");

--- a/test/unit/strategies/yieldSkimming/Accounting.t.sol
+++ b/test/unit/strategies/yieldSkimming/Accounting.t.sol
@@ -1107,9 +1107,8 @@ contract AccountingTest is Setup {
         strategy.report();
 
         // Track total debt before transfers
-        uint256 totalDebtBefore = strategy.totalSupply() -
-            strategy.balanceOf(strategy.dragonRouter()) +
-            strategy.balanceOf(strategy.dragonRouter());
+        uint256 totalDebtBefore = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue() +
+            IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
 
         // Perform random transfers
         for (uint256 i = 0; i < numTransfers; i++) {
@@ -1138,9 +1137,8 @@ contract AccountingTest is Setup {
         }
 
         // Verify total debt is conserved
-        uint256 totalDebtAfter = strategy.totalSupply() -
-            strategy.balanceOf(strategy.dragonRouter()) +
-            strategy.balanceOf(strategy.dragonRouter());
+        uint256 totalDebtAfter = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue() +
+            IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
 
         assertEq(totalDebtAfter, totalDebtBefore, "Total debt should be conserved across transfers");
     }
@@ -1553,6 +1551,134 @@ contract AccountingTest is Setup {
         uint256 userDebtAfter;
         uint256 dragonDebtAfter;
         uint256 totalDebtAfter;
+    }
+
+    function test_isVaultInsolvent_excludesDragonDebt() public {
+        address alice = makeAddr("alice");
+        uint256 depositAmount = 100e18;
+
+        // 1. User deposits (creates user debt)
+        mintAndDepositIntoStrategy(strategy, alice, depositAmount);
+
+        // 2. Create profit (mints dragon shares, creates dragon debt)
+        MockStrategySkimming(address(strategy)).updateExchangeRate(15e17); // 1.5
+        vm.prank(keeper);
+        strategy.report();
+        uint256 dragonDebt = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        assertGt(dragonDebt, 0, "dragon should have debt");
+
+        // 3. Drop exchange rate so vault_value is between user_debt and user_debt + dragon_debt
+        //    user_debt = 100e18, dragon_debt ~50e18, total_debt ~150e18
+        //    At rate 1.2: vault_value = 100 * 1.2 = 120e18
+        //    120e18 > 100e18 (user_debt) but 120e18 < 150e18 (total_debt)
+        MockStrategySkimming(address(strategy)).updateExchangeRate(12e17);
+
+        // 4. Assert isVaultInsolvent() == false (dragon debt excluded from insolvency check)
+        assertFalse(
+            IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(),
+            "vault should NOT be insolvent when it can cover user debt but not dragon debt"
+        );
+
+        // 5. Drop rate further below user_debt
+        //    At rate 0.9: vault_value = 100 * 0.9 = 90e18 < 100e18 (user_debt)
+        MockStrategySkimming(address(strategy)).updateExchangeRate(9e17);
+
+        // 6. Assert isVaultInsolvent() == true
+        assertTrue(
+            IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(),
+            "vault should be insolvent when it cannot cover user debt"
+        );
+    }
+
+    function test_maxDeposit_maxMint_return_zero_when_rate_zero() public {
+        address alice = makeAddr("alice");
+        uint256 depositAmount = 100e18;
+
+        // Setup: user deposits first (so strategy has state)
+        mintAndDepositIntoStrategy(strategy, alice, depositAmount);
+
+        // 1. Set exchange rate to 0
+        MockStrategySkimming(address(strategy)).updateExchangeRate(0);
+
+        // 2. Assert maxDeposit returns 0
+        assertEq(strategy.maxDeposit(alice), 0, "maxDeposit should return 0 when rate is 0");
+
+        // 3. Assert maxMint returns 0
+        assertEq(strategy.maxMint(alice), 0, "maxMint should return 0 when rate is 0");
+
+        // 4. Verify deposit reverts (vault is insolvent: value debt > 0 but vault value = 0)
+        yieldSource.mint(alice, 1e18);
+        vm.prank(alice);
+        yieldSource.approve(address(strategy), 1e18);
+        vm.expectRevert("Cannot operate when vault is insolvent");
+        vm.prank(alice);
+        strategy.deposit(1e18, alice);
+
+        // 5. Verify mint reverts (same insolvency guard)
+        vm.expectRevert("Cannot operate when vault is insolvent");
+        vm.prank(alice);
+        strategy.mint(1e18, alice);
+    }
+
+    /// @notice Dragon router migration cannot desync balance vs debt to cause revert in report()
+    /// @dev Edge case: new dragon has pre-existing shares (transferred before finalization).
+    ///      finalizeDragonRouterChange() adds newDragonBalance to dragonRouterDebtInAssetValue,
+    ///      so debt >= balance is preserved. Then dragonBurn <= balance <= debt, and the subtraction is safe.
+    function test_dragonDebtSubtractionSafeAfterMigration() public {
+        address alice = makeAddr("alice");
+        address newRouter = makeAddr("newDragonRouter");
+        uint256 depositAmount = 100e18;
+
+        // 1. Setup: deposit, create dragon shares via profit
+        mintAndDepositIntoStrategy(strategy, alice, depositAmount);
+
+        vm.prank(management);
+        strategy.setEnableBurning(true);
+
+        MockStrategySkimming(address(strategy)).updateExchangeRate(15e17); // 1.5
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 dragonBalance = strategy.balanceOf(donationAddress);
+        uint256 dragonDebt = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        assertGt(dragonBalance, 0, "dragon should have shares");
+        assertEq(dragonBalance, dragonDebt, "balance and debt should match before migration");
+
+        // 2. Transfer shares TO newRouter BEFORE finalization (user→user transfer, no debt rebalancing).
+        //    This gives newRouter a pre-existing balance without corresponding dragon debt.
+        uint256 extraDeposit = 20e18;
+        mintAndDepositIntoStrategy(strategy, alice, extraDeposit);
+        uint256 aliceShares = strategy.balanceOf(alice);
+        uint256 sharesToTransfer = aliceShares / 4;
+        vm.prank(alice);
+        strategy.transfer(newRouter, sharesToTransfer);
+
+        uint256 newRouterBalance = strategy.balanceOf(newRouter);
+        assertGt(newRouterBalance, 0, "newRouter should have shares before finalization");
+
+        // 3. Finalize: migration adds newDragonBalance to dragonRouterDebtInAssetValue
+        vm.prank(management);
+        strategy.setDragonRouter(newRouter);
+        skip(14 days);
+        strategy.finalizeDragonRouterChange();
+
+        // Verify: debt covers new dragon's balance (finalization migrates debt correctly)
+        uint256 dragonDebtAfterMigration = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        assertGe(dragonDebtAfterMigration, newRouterBalance, "dragon debt should cover new router balance");
+
+        // 4. Trigger loss — exercises the subtraction path in _handleDragonLossProtection
+        MockStrategySkimming(address(strategy)).updateExchangeRate(8e17); // loss
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = strategy.report();
+
+        assertEq(profit, 0, "no profit expected");
+        assertGt(loss, 0, "loss expected");
+
+        // 5. Verify the burn path was actually exercised (dragonBurn > 0).
+        //    After finalization, new dragon has shares and burning is enabled,
+        //    so _handleDragonLossProtection burns shares (does NOT short-circuit on 0 balance).
+        uint256 newDragonBalanceAfterLoss = strategy.balanceOf(newRouter);
+        assertLt(newDragonBalanceAfterLoss, newRouterBalance, "dragon shares should have been burned");
     }
 
     /**

--- a/test/unit/strategies/yieldSkimming/Accounting.t.sol
+++ b/test/unit/strategies/yieldSkimming/Accounting.t.sol
@@ -599,22 +599,6 @@ contract AccountingTest is Setup {
         assertEq(strategy.balanceOf(donationAddress), 0, "Donation address should have no shares");
     }
 
-    function test_maxDeposit_maxMint_return_zero_when_rate_zero() public {
-        address alice = makeAddr("alice");
-        MockStrategySkimming(address(strategy)).updateExchangeRate(0);
-
-        assertEq(strategy.maxDeposit(alice), 0, "maxDeposit should be zero at rate 0");
-        assertEq(strategy.maxMint(alice), 0, "maxMint should be zero at rate 0");
-
-        vm.prank(alice);
-        vm.expectRevert();
-        strategy.deposit(1e18, alice);
-
-        vm.prank(alice);
-        vm.expectRevert();
-        strategy.mint(1e18, alice);
-    }
-
     // ===== DEFICIT ADJUSTMENT TESTS =====
     /**
      * @notice Test invariant: Depositors during loss period cannot withdraw more underlying value than deposited
@@ -648,7 +632,7 @@ contract AccountingTest is Setup {
         vm.stopPrank();
 
         // Check if debt tracking is working properly
-        uint256 totalValueDebt = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
+        uint256 totalValueDebt = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter());
 
         // For yield skimming strategies, deposits after losses are typically blocked
         // by insolvency protection when totalValueDebt > 0 and current value < debt.
@@ -973,7 +957,7 @@ contract AccountingTest is Setup {
 
     /**
      * @notice Test debt tracking when user transfers shares to dragon router
-     * @dev Verifies that totalDebtOwedToUserInAssetValue decreases and dragonRouterDebtInAssetValue increases
+     * @dev Verifies that totalUserDebtInAssetValue decreases and dragonRouterDebtInAssetValue increases
      */
     function test_transferToDragon_updatesDebtTracking(uint256 depositAmount, uint256 transferAmount) public {
         depositAmount = bound(depositAmount, minFuzzAmount, 1e27); // Limit to prevent overflow
@@ -986,8 +970,8 @@ contract AccountingTest is Setup {
         transferAmount = bound(transferAmount, 1, userShares);
 
         // Check initial debt tracking
-        uint256 initialUserDebt = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
-        uint256 initialDragonDebt = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        uint256 initialUserDebt = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter());
+        uint256 initialDragonDebt = strategy.balanceOf(strategy.dragonRouter());
 
         assertEq(initialUserDebt, depositAmount, "Initial user debt should equal deposit");
         assertEq(initialDragonDebt, 0, "Initial dragon debt should be 0");
@@ -998,8 +982,8 @@ contract AccountingTest is Setup {
         vm.stopPrank();
 
         // Check updated debt tracking
-        uint256 finalUserDebt = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
-        uint256 finalDragonDebt = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        uint256 finalUserDebt = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter());
+        uint256 finalDragonDebt = strategy.balanceOf(strategy.dragonRouter());
 
         assertEq(finalUserDebt, initialUserDebt - transferAmount, "User debt should decrease by transfer amount");
         assertEq(finalDragonDebt, initialDragonDebt + transferAmount, "Dragon debt should increase by transfer amount");
@@ -1009,7 +993,7 @@ contract AccountingTest is Setup {
 
     /**
      * @notice Test debt tracking when dragon router transfers shares to user
-     * @dev Verifies that dragonRouterDebtInAssetValue decreases and totalDebtOwedToUserInAssetValue increases
+     * @dev Verifies that dragonRouterDebtInAssetValue decreases and totalUserDebtInAssetValue increases
      */
     function test_transferFromDragon_updatesDebtTracking(
         uint256 depositAmount,
@@ -1038,8 +1022,8 @@ contract AccountingTest is Setup {
         transferAmount = bound(transferAmount, 1, dragonShares);
 
         // Check debt before transfer
-        uint256 initialUserDebt = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
-        uint256 initialDragonDebt = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        uint256 initialUserDebt = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter());
+        uint256 initialDragonDebt = strategy.balanceOf(strategy.dragonRouter());
 
         // Dragon transfers shares to user2
         vm.startPrank(strategy.dragonRouter());
@@ -1047,8 +1031,8 @@ contract AccountingTest is Setup {
         vm.stopPrank();
 
         // Check updated debt tracking
-        uint256 finalUserDebt = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
-        uint256 finalDragonDebt = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        uint256 finalUserDebt = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter());
+        uint256 finalDragonDebt = strategy.balanceOf(strategy.dragonRouter());
 
         assertEq(finalUserDebt, initialUserDebt + transferAmount, "User debt should increase by transfer amount");
         assertEq(finalDragonDebt, initialDragonDebt - transferAmount, "Dragon debt should decrease by transfer amount");
@@ -1080,8 +1064,8 @@ contract AccountingTest is Setup {
         vm.stopPrank();
 
         // Check initial debt
-        uint256 initialUserDebt = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
-        uint256 initialDragonDebt = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        uint256 initialUserDebt = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter());
+        uint256 initialDragonDebt = strategy.balanceOf(strategy.dragonRouter());
 
         // User2 transfers from user1 to dragon router
         vm.startPrank(user2);
@@ -1089,8 +1073,8 @@ contract AccountingTest is Setup {
         vm.stopPrank();
 
         // Check updated debt tracking
-        uint256 finalUserDebt = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
-        uint256 finalDragonDebt = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        uint256 finalUserDebt = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter());
+        uint256 finalDragonDebt = strategy.balanceOf(strategy.dragonRouter());
 
         assertEq(finalUserDebt, initialUserDebt - transferAmount, "User debt should decrease");
         assertEq(finalDragonDebt, initialDragonDebt + transferAmount, "Dragon debt should increase");
@@ -1123,8 +1107,8 @@ contract AccountingTest is Setup {
         strategy.report();
 
         // Track total debt before transfers
-        uint256 totalDebtBefore = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue() +
-            IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        uint256 totalDebtBefore = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()) +
+            strategy.balanceOf(strategy.dragonRouter());
 
         // Perform random transfers
         for (uint256 i = 0; i < numTransfers; i++) {
@@ -1153,8 +1137,8 @@ contract AccountingTest is Setup {
         }
 
         // Verify total debt is conserved
-        uint256 totalDebtAfter = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue() +
-            IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        uint256 totalDebtAfter = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()) +
+            strategy.balanceOf(strategy.dragonRouter());
 
         assertEq(totalDebtAfter, totalDebtBefore, "Total debt should be conserved across transfers");
     }
@@ -1187,7 +1171,7 @@ contract AccountingTest is Setup {
         vm.stopPrank();
 
         // Dragon now has dragonRouterDebtInAssetValue from user transfer + profit
-        uint256 dragonDebt = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        uint256 dragonDebt = strategy.balanceOf(strategy.dragonRouter());
         dragonShares = strategy.balanceOf(strategy.dragonRouter());
 
         // Ensure dragon has enough shares to test the debt limitation
@@ -1312,10 +1296,14 @@ contract AccountingTest is Setup {
         bool isInsolvent = IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent();
 
         if (isInsolvent) {
+            vm.startPrank(management);
+            strategy.setEnableBurning(true);
+            vm.stopPrank();
+
             // Dragon transfers should be blocked during insolvency
             vm.startPrank(strategy.dragonRouter());
-            vm.expectRevert("Dragon cannot operate during insolvency");
-            strategy.transfer(user1, 1);
+            vm.expectRevert("Transfer would cause vault insolvency");
+            strategy.transfer(user1, dragonShares);
             vm.stopPrank();
         }
     }
@@ -1467,10 +1455,7 @@ contract AccountingTest is Setup {
         console2.log("Step 2: d1 - User1 deposits 100");
         mintAndDepositIntoStrategy(strategy, user1, 100e18);
         console2.log("User1 shares:", strategy.balanceOf(user1));
-        console2.log(
-            "Total value debt:",
-            IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue()
-        );
+        console2.log("Total value debt:", strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()));
 
         // r1.5: Rate increases to 1.5
         console2.log("\nStep 3: r1.5 - Rate increases to 1.5");
@@ -1480,10 +1465,7 @@ contract AccountingTest is Setup {
         console2.log("Step 4: d2 - User2 deposits 150");
         mintAndDepositIntoStrategy(strategy, user2, 150e18);
         console2.log("User2 shares:", strategy.balanceOf(user2));
-        console2.log(
-            "Total value debt:",
-            IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue()
-        );
+        console2.log("Total value debt:", strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()));
         console2.log("Total assets:", strategy.totalAssets());
 
         // report: Should create profit and mint to dragon
@@ -1504,7 +1486,7 @@ contract AccountingTest is Setup {
         console2.log("Current vault value:", (strategy.totalAssets() * 1e18) / 1e18); // Rate is 1.0
         console2.log(
             "Total debt needed:",
-            IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue() +
+            strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()) +
                 strategy.balanceOf(donationAddress)
         );
 
@@ -1520,7 +1502,7 @@ contract AccountingTest is Setup {
         console2.log("User1 withdrawn, remaining total assets:", strategy.totalAssets());
         console2.log(
             "Remaining total value debt:",
-            IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue()
+            strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter())
         );
 
         // report: Should show loss and burn dragon shares
@@ -1553,7 +1535,7 @@ contract AccountingTest is Setup {
         console2.log("Final total supply:", strategy.totalSupply());
         console2.log(
             "Final total value debt:",
-            IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue()
+            strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter())
         );
 
         // Verify that without the rate check, losses are properly handled
@@ -1622,8 +1604,8 @@ contract AccountingTest is Setup {
         vars.newDragonBalance = strategy.balanceOf(vars.newDragonRouter);
 
         // Record debt state before change
-        vars.userDebtBefore = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
-        vars.dragonDebtBefore = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        vars.userDebtBefore = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter());
+        vars.dragonDebtBefore = strategy.balanceOf(strategy.dragonRouter());
         vars.totalDebtBefore = vars.userDebtBefore + vars.dragonDebtBefore;
 
         // Initiate dragon router change
@@ -1640,8 +1622,8 @@ contract AccountingTest is Setup {
         assertEq(strategy.dragonRouter(), vars.newDragonRouter, "New dragon router should be set");
 
         // Record debt state after change
-        vars.userDebtAfter = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
-        vars.dragonDebtAfter = IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue();
+        vars.userDebtAfter = strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter());
+        vars.dragonDebtAfter = strategy.balanceOf(strategy.dragonRouter());
         vars.totalDebtAfter = vars.userDebtAfter + vars.dragonDebtAfter;
 
         // Most importantly: total debt should be conserved

--- a/test/unit/strategies/yieldSkimming/DragonTransferBypass.t.sol
+++ b/test/unit/strategies/yieldSkimming/DragonTransferBypass.t.sol
@@ -46,9 +46,14 @@ contract DragonTransferBypassTest is Setup {
         //    Since 1,200,000 < 1,500,000, vault is insolvent
         MockStrategySkimming(address(strategy)).updateExchangeRate(12e17); // 1.2 * 1e18
 
+        // Enable burning to activate dragon restrictions
+        vm.prank(management);
+        strategy.setEnableBurning(true);
+        vm.stopPrank();
+
         // 4) Dragon transfer should be blocked during insolvency
         vm.prank(dragon);
-        vm.expectRevert("Dragon cannot operate during insolvency");
+        vm.expectRevert("Transfer would cause vault insolvency");
         IMockStrategy(address(strategy)).transfer(ally, dragonShares);
 
         // 5) Verify dragon still has all shares (transfer was blocked)

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingDragonRestrictions.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingDragonRestrictions.t.sol
@@ -1,0 +1,519 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { ERC1967Proxy } from "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
+import { WadRayMath } from "src/utils/libs/Maths/WadRay.sol";
+
+// Mock strategy that implements the required interface for YieldSkimmingTokenizedStrategy
+contract MockYieldSkimmingStrategy is YieldSkimmingTokenizedStrategy {
+    using WadRayMath for uint256;
+
+    uint256 private _exchangeRate = 1e18; // Start at 1.0 in wad format
+    uint256 private _decimals = 18;
+
+    function setExchangeRate(uint256 newRate) external {
+        _exchangeRate = newRate;
+    }
+
+    function setExchangeRateDecimals(uint256 newDecimals) external {
+        _decimals = newDecimals;
+    }
+
+    function getCurrentExchangeRate() external view returns (uint256) {
+        return _exchangeRate;
+    }
+
+    function decimalsOfExchangeRate() external view returns (uint256) {
+        return _decimals;
+    }
+
+    function harvestAndReport() external view returns (uint256) {
+        // Simple implementation - return current total assets
+        return _strategyStorage().totalAssets;
+    }
+
+    function deployFunds(uint256) external {
+        // No-op for testing
+    }
+
+    function availableDepositLimit(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function availableWithdrawLimit(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+}
+
+contract YieldSkimmingDragonRestrictionsTest is Test {
+    using Math for uint256;
+    using WadRayMath for uint256;
+
+    MockYieldSkimmingStrategy public strategy;
+    MockYieldSkimmingStrategy public implementation;
+    ERC20Mock public asset;
+
+    // Test addresses
+    address public management = address(0x1);
+    address public keeper = address(0x2);
+    address public emergencyAdmin = address(0x3);
+    address public dragonRouter = address(0x4);
+    address public user1 = address(0x5);
+    address public user2 = address(0x6);
+
+    // Constants
+    uint256 public constant WAD = 1e18;
+    uint256 public constant RAY = 1e27;
+    uint256 public constant INITIAL_RATE = 1e18; // 1.0 in wad
+
+    function setUp() public {
+        // Deploy mock asset
+        asset = new ERC20Mock();
+
+        // Deploy implementation
+        implementation = new MockYieldSkimmingStrategy();
+
+        // Deploy proxy
+        strategy = MockYieldSkimmingStrategy(address(new ERC1967Proxy(address(implementation), "")));
+
+        // Initialize strategy
+        strategy.initialize(
+            address(asset),
+            "Test Yield Skimming Strategy",
+            management,
+            keeper,
+            emergencyAdmin,
+            dragonRouter,
+            true // enableBurning
+        );
+
+        // Set initial exchange rate
+        strategy.setExchangeRate(INITIAL_RATE);
+    }
+
+    function _depositUser(address user, uint256 amount) internal {
+        asset.mint(user, amount);
+        vm.prank(user);
+        asset.approve(address(strategy), amount);
+        vm.prank(user);
+        strategy.deposit(amount, user);
+    }
+
+    function _createProfit(uint256 profitAmount) internal {
+        // Increase exchange rate to create profit
+        uint256 currentRate = strategy.getCurrentExchangeRate();
+        uint256 currentAssets = strategy.totalAssets();
+
+        // Calculate new rate that would generate the desired profit
+        uint256 currentValue = currentAssets.mulDiv(currentRate, WAD);
+        uint256 newValue = currentValue + profitAmount;
+        uint256 newRate = newValue.mulDiv(WAD, currentAssets);
+
+        strategy.setExchangeRate(newRate);
+
+        vm.prank(keeper);
+        strategy.report();
+    }
+
+    function _createLoss(uint256 lossAmount) internal {
+        // Decrease exchange rate to create loss
+        uint256 currentRate = strategy.getCurrentExchangeRate();
+        uint256 currentAssets = strategy.totalAssets();
+
+        // Calculate new rate that would generate the desired loss
+        uint256 currentValue = currentAssets.mulDiv(currentRate, WAD);
+        uint256 newValue = currentValue > lossAmount ? currentValue - lossAmount : 0;
+        uint256 newRate = currentAssets > 0 ? newValue.mulDiv(WAD, currentAssets) : 0;
+
+        strategy.setExchangeRate(newRate);
+
+        vm.prank(keeper);
+        strategy.report();
+    }
+
+    /**
+     * Test maxWithdraw/maxRedeem for dragon router in normal conditions
+     */
+    function test_dragonMaxWithdrawRedeem_normal() public {
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 20 ether;
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        uint256 dragonBalance = strategy.balanceOf(dragonRouter);
+        assertGt(dragonBalance, 0, "Dragon should have shares from profit");
+
+        // Dragon should be able to withdraw/redeem up to its balance in normal conditions
+        uint256 maxWithdraw = strategy.maxWithdraw(dragonRouter);
+        uint256 maxRedeem = strategy.maxRedeem(dragonRouter);
+
+        assertGt(maxWithdraw, 0, "Dragon should be able to withdraw");
+        assertGt(maxRedeem, 0, "Dragon should be able to redeem");
+        assertEq(maxRedeem, dragonBalance, "Dragon max redeem should equal balance");
+    }
+
+    /**
+     * Test maxWithdraw/maxRedeem for dragon router during insolvency
+     */
+    function test_dragonMaxWithdrawRedeem_insolvency() public {
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 20 ether;
+        uint256 lossAmount = 25 ether; // Reasonable loss that makes vault insolvent
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        uint256 dragonBalanceBefore = strategy.balanceOf(dragonRouter);
+        assertGt(dragonBalanceBefore, 0, "Dragon should have shares");
+
+        // Create loss that makes vault insolvent (vault value < user debt)
+        _createLoss(lossAmount);
+
+        // Dragon should not be able to withdraw/redeem during insolvency
+        uint256 maxWithdraw = strategy.maxWithdraw(dragonRouter);
+        uint256 maxRedeem = strategy.maxRedeem(dragonRouter);
+
+        assertEq(maxWithdraw, 0, "Dragon should not be able to withdraw during insolvency");
+        assertEq(maxRedeem, 0, "Dragon should not be able to redeem during insolvency");
+    }
+
+    /**
+     * Test maxWithdraw/maxRedeem for dragon router when burning is disabled
+     */
+    function test_dragonMaxWithdrawRedeem_burningDisabled() public {
+        // Disable burning
+        vm.prank(management);
+        strategy.setEnableBurning(false);
+
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 20 ether;
+        uint256 lossAmount = 25 ether; // Reasonable loss
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        uint256 dragonBalance = strategy.balanceOf(dragonRouter);
+
+        // Create loss
+        _createLoss(lossAmount);
+
+        // When burning is disabled, dragon should be able to withdraw full balance even during insolvency
+        uint256 maxWithdraw = strategy.maxWithdraw(dragonRouter);
+        uint256 maxRedeem = strategy.maxRedeem(dragonRouter);
+
+        assertEq(maxRedeem, dragonBalance, "Dragon should be able to redeem full balance when burning disabled");
+        assertGt(maxWithdraw, 0, "Dragon should be able to withdraw when burning disabled");
+    }
+
+    /**
+     * Test that dragon cannot withdraw profit shares before report() when there's potential loss
+     * This is the key test: dragon should be restricted BEFORE burning occurs
+     */
+    function test_dragonCannotWithdrawProfitBeforeReport() public {
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 20 ether;
+
+        // User deposits at rate 1.0
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon (rate goes to 1.2)
+        _createProfit(profitAmount);
+
+        uint256 dragonBalance = strategy.balanceOf(dragonRouter);
+        // Dragon should have profit shares (exact amount depends on conversion logic)
+        assertGt(dragonBalance, 0, "Dragon should have profit shares from 20 ether profit");
+
+        // Dragon can withdraw in healthy state
+        uint256 maxRedeemHealthy = strategy.maxRedeem(dragonRouter);
+        assertEq(maxRedeemHealthy, dragonBalance, "Dragon should be able to redeem all shares when healthy");
+
+        // Now exchange rate drops slightly (indicating 5 ether loss from peak)
+        // This would leave vault value at 115 ether vs total debt of 120 ether (100 user + 20 dragon)
+        // Vault is still above user debt (100) but below total debt, restricting dragon
+        uint256 currentAssets = strategy.totalAssets();
+        uint256 targetValue = userDeposit + 15 ether; // 115 ether total value - still above user debt
+        uint256 newRate = targetValue.mulDiv(WAD, currentAssets);
+        strategy.setExchangeRate(newRate);
+
+        // BEFORE calling report(), dragon should be restricted
+        uint256 maxRedeemBeforeReport = strategy.maxRedeem(dragonRouter);
+        assertLt(maxRedeemBeforeReport, dragonBalance, "Dragon should be restricted before report()");
+
+        // Dragon cannot withdraw their full balance due to restrictions
+        vm.prank(dragonRouter);
+        vm.expectRevert("Dragon cannot operate during insolvency");
+        strategy.redeem(dragonBalance, dragonRouter, dragonRouter);
+
+        // But dragon can still withdraw the allowed amount
+        if (maxRedeemBeforeReport > 0) {
+            vm.prank(dragonRouter);
+            strategy.redeem(maxRedeemBeforeReport, dragonRouter, dragonRouter);
+        }
+    }
+
+    /**
+     * Test that dragon cannot redeem more than maxRedeem
+     */
+    function test_dragonCannotRedeemMoreThanMax() public {
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 20 ether;
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        uint256 maxRedeem = strategy.maxRedeem(dragonRouter);
+
+        // Try to redeem more than max should fail
+        vm.prank(dragonRouter);
+        vm.expectRevert("ERC4626: redeem more than max");
+        strategy.redeem(maxRedeem + 1, dragonRouter, dragonRouter);
+    }
+
+    /**
+     * Test that dragon cannot withdraw more than maxWithdraw
+     */
+    function test_dragonCannotWithdrawMoreThanMax() public {
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 20 ether;
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        uint256 maxWithdraw = strategy.maxWithdraw(dragonRouter);
+
+        // Try to withdraw more than max should fail
+        vm.prank(dragonRouter);
+        vm.expectRevert("ERC4626: withdraw more than max");
+        strategy.withdraw(maxWithdraw + 1, dragonRouter, dragonRouter);
+    }
+
+    /**
+     * Test transfer respects maxRedeem limits
+     */
+    function test_transferRespectsMaxRedeem() public {
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 50 ether;
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        uint256 dragonBalance = strategy.balanceOf(dragonRouter);
+
+        // Create partial loss to limit dragon's redeemable amount
+        _createLoss(15 ether); // Reasonable loss amount
+
+        uint256 maxRedeem = strategy.maxRedeem(dragonRouter);
+        assertLt(maxRedeem, dragonBalance, "Max redeem should be less than balance after loss");
+
+        // Dragon should be able to transfer up to maxRedeem
+        vm.prank(dragonRouter);
+        strategy.transfer(user2, maxRedeem);
+
+        // But trying to transfer more than maxRedeem should fail
+        uint256 remainingBalance = strategy.balanceOf(dragonRouter);
+        if (remainingBalance > 0) {
+            vm.prank(dragonRouter);
+            vm.expectRevert("Dragon cannot operate during insolvency");
+            strategy.transfer(user2, 1);
+        }
+    }
+
+    /**
+     * Test transferFrom respects maxRedeem limits
+     */
+    function test_transferFromRespectsMaxRedeem() public {
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 50 ether;
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        // Dragon approves user2 to spend their shares
+        vm.prank(dragonRouter);
+        strategy.approve(user2, type(uint256).max);
+
+        // Create partial loss to limit dragon's redeemable amount
+        _createLoss(15 ether); // Reasonable loss amount
+
+        uint256 maxRedeem = strategy.maxRedeem(dragonRouter);
+
+        // User2 should be able to transfer up to maxRedeem on behalf of dragon
+        vm.prank(user2);
+        strategy.transferFrom(dragonRouter, user2, maxRedeem);
+
+        // But trying to transfer more should fail if it would violate solvency
+        uint256 remainingBalance = strategy.balanceOf(dragonRouter);
+        if (remainingBalance > 0) {
+            vm.prank(user2);
+            vm.expectRevert("Dragon cannot operate during insolvency");
+            strategy.transferFrom(dragonRouter, user2, 1);
+        }
+    }
+
+    /**
+     * Test dragon restrictions change as losses accumulate
+     */
+    function test_dragonRestrictionsChangeWithLosses() public {
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 50 ether;
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        uint256 initialMaxRedeem = strategy.maxRedeem(dragonRouter);
+        assertGt(initialMaxRedeem, 0, "Dragon should initially be able to redeem");
+
+        // Create small loss
+        _createLoss(10 ether);
+        uint256 maxRedeemAfterSmallLoss = strategy.maxRedeem(dragonRouter);
+        assertLt(maxRedeemAfterSmallLoss, initialMaxRedeem, "Max redeem should decrease after loss");
+
+        // Create larger loss
+        _createLoss(30 ether);
+        uint256 maxRedeemAfterLargeLoss = strategy.maxRedeem(dragonRouter);
+        assertLt(maxRedeemAfterLargeLoss, maxRedeemAfterSmallLoss, "Max redeem should decrease further");
+
+        // Create loss that makes vault insolvent
+        _createLoss(50 ether);
+        uint256 maxRedeemAfterInsolvency = strategy.maxRedeem(dragonRouter);
+        assertEq(maxRedeemAfterInsolvency, 0, "Dragon should not be able to redeem during insolvency");
+    }
+
+    /**
+     * Test normal users are not affected by dragon restrictions
+     */
+    function test_normalUsersUnaffectedByDragonRestrictions() public {
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 30 ether;
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        uint256 dragonBalanceAfterProfit = strategy.balanceOf(dragonRouter);
+        assertGt(dragonBalanceAfterProfit, 0, "Dragon should have shares after profit");
+
+        // Create a loss that leaves vault value close to user debt
+        // This should restrict dragon without making vault insolvent
+        _createLoss(25 ether);
+
+        uint256 dragonMaxRedeem = strategy.maxRedeem(dragonRouter);
+
+        // Debug info to understand the situation
+        uint256 userDebt = strategy.gettotalDebtOwedToUserInAssetValue();
+        uint256 dragonDebt = strategy.getDragonRouterDebtInAssetValue();
+        uint256 totalAssets = strategy.totalAssets();
+        uint256 currentRate = strategy.getCurrentExchangeRate();
+        uint256 vaultValue = (totalAssets * currentRate) / WAD;
+
+        // The test validates that dragons restrictions work correctly
+        // In some scenarios dragon may not be restricted if there's sufficient excess value
+        if (vaultValue > userDebt && dragonDebt > 0) {
+            uint256 excessValue = vaultValue - userDebt;
+            uint256 expectedMaxRedeem = Math.min(dragonDebt, excessValue);
+            assertEq(dragonMaxRedeem, expectedMaxRedeem, "Dragon max redeem should match expected calculation");
+        }
+
+        // But normal user should not be restricted
+        uint256 userMaxRedeem = strategy.maxRedeem(user1);
+        uint256 userBalance = strategy.balanceOf(user1);
+        assertEq(userMaxRedeem, userBalance, "Normal user should not be restricted");
+
+        // User should be able to redeem their full balance
+        vm.prank(user1);
+        strategy.redeem(userBalance, user1, user1);
+        assertEq(strategy.balanceOf(user1), 0, "User should have redeemed all shares");
+    }
+
+    /**
+     * Test edge case: dragon with exactly enough excess value
+     */
+    function test_dragonExactExcessValue() public {
+        uint256 userDeposit = 100 ether;
+        uint256 profitAmount = 30 ether;
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        uint256 dragonBalance = strategy.balanceOf(dragonRouter);
+
+        // Create loss that leaves exactly the dragon's debt as excess
+        // Dragon should be able to redeem exactly its debt amount
+        uint256 maxRedeem = strategy.maxRedeem(dragonRouter);
+        assertEq(maxRedeem, dragonBalance, "Dragon should be able to redeem all shares when excess equals debt");
+    }
+
+    /**
+     * Test fuzz: dragon restrictions work across various scenarios
+     */
+    function testFuzz_dragonRestrictions(uint256 userDeposit, uint256 profitAmount, uint256 lossAmount) public {
+        userDeposit = bound(userDeposit, 10 ether, 1000 ether);
+        profitAmount = bound(profitAmount, 1 ether, userDeposit);
+        lossAmount = bound(lossAmount, 0, profitAmount + userDeposit);
+
+        // User deposits
+        _depositUser(user1, userDeposit);
+
+        // Create profit for dragon
+        _createProfit(profitAmount);
+
+        uint256 dragonBalanceAfterProfit = strategy.balanceOf(dragonRouter);
+        assertGt(dragonBalanceAfterProfit, 0, "Dragon should have shares after profit");
+
+        // Create loss
+        _createLoss(lossAmount);
+
+        uint256 maxRedeem = strategy.maxRedeem(dragonRouter);
+        uint256 maxWithdraw = strategy.maxWithdraw(dragonRouter);
+        uint256 dragonBalance = strategy.balanceOf(dragonRouter);
+
+        // Max redeem should never exceed dragon balance
+        assertLe(maxRedeem, dragonBalance, "Max redeem should not exceed dragon balance");
+
+        // If vault is insolvent, dragon should not be able to withdraw
+        if (strategy.isVaultInsolvent()) {
+            assertEq(maxRedeem, 0, "Dragon should not redeem during insolvency");
+            assertEq(maxWithdraw, 0, "Dragon should not withdraw during insolvency");
+        }
+
+        // Try to redeem up to max - should succeed
+        if (maxRedeem > 0) {
+            vm.prank(dragonRouter);
+            strategy.redeem(maxRedeem, dragonRouter, dragonRouter);
+        }
+    }
+}

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingDragonRestrictions.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingDragonRestrictions.t.sol
@@ -84,6 +84,7 @@ contract YieldSkimmingDragonRestrictionsTest is Test {
         strategy.initialize(
             address(asset),
             "Test Yield Skimming Strategy",
+            "tYSS",
             management,
             keeper,
             emergencyAdmin,

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingDragonRestrictions.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingDragonRestrictions.t.sol
@@ -255,7 +255,7 @@ contract YieldSkimmingDragonRestrictionsTest is Test {
 
         // Dragon cannot withdraw their full balance due to restrictions
         vm.prank(dragonRouter);
-        vm.expectRevert("Dragon cannot operate during insolvency");
+        vm.expectRevert("Transfer would cause vault insolvency");
         strategy.redeem(dragonBalance, dragonRouter, dragonRouter);
 
         // But dragon can still withdraw the allowed amount
@@ -431,8 +431,8 @@ contract YieldSkimmingDragonRestrictionsTest is Test {
         uint256 dragonMaxRedeem = strategy.maxRedeem(dragonRouter);
 
         // Debug info to understand the situation
-        uint256 userDebt = strategy.gettotalDebtOwedToUserInAssetValue();
-        uint256 dragonDebt = strategy.getDragonRouterDebtInAssetValue();
+        uint256 userDebt = strategy.totalSupply() - strategy.balanceOf(dragonRouter);
+        uint256 dragonDebt = strategy.balanceOf(dragonRouter);
         uint256 totalAssets = strategy.totalAssets();
         uint256 currentRate = strategy.getCurrentExchangeRate();
         uint256 vaultValue = (totalAssets * currentRate) / WAD;


### PR DESCRIPTION
# Rebase audit fixes onto develop

Rebases `feature/osu-1347-rewritten` (originally based on `master`) onto `develop`.

## Commits

- **feat: block setEarningPowerCalculator during active reward periods** — Prevents changing the earning power calculator while a reward period is active in RegenStaker
- **fix: m-18 update _isVaultInsolvent** — Excludes dragon debt from vault insolvency calculation
- **feat: add maxWithdraw/maxRedeem overrides with custody support** — Adds custody-aware withdrawal limits to MultistrategyLockedVault
- **fix: r-33 remove duplicate functions** — Removes duplicate wrapper functions from YieldSkimmingTokenizedStrategy
- **fix: improve transfer solvency checks** — Adds `_requireDragonSolvencyAfterOperation` checks to share transfers and redemptions
- **fix: l23 add _requireDragonSolvency to finalizeDragonRouterChange** — Validates dragon solvency against the old router before finalizing a router change
- **refactor: add governance controls and remove TRST-L-23 comment** — Adds governance protection with timelock to LockedVault configuration setters
- **refactor: remove unused error** — Removes `StrategyAlreadyExists` error from RocketPoolStrategyFactory
- **fix: resolve rebase conflicts and compilation errors** — Resolves naming convention mismatches (`_max_withdraw`, `totalDebtOwedToUserInAssetValue`), duplicate declarations, missing parameters, and a test fix for `enableBurning` gating in `_requireDragonSolvency`
