### PR TITLE
fix: use Floor rounding for dragon loss share burn (OSU-1492)

### DIFF
--- a/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
@@ -11,7 +11,7 @@ import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
  * @dev Behavior overview:
  *      - On report(), harvests the underlying position via BaseStrategy.harvestAndReport()
  *      - If newTotalAssets > oldTotalAssets, mints shares equal to the profit (asset value) to the dragon router
- *      - If losses occur and burning is enabled, burns dragon router shares (up to its balance) using rounding-up shares-to-burn
+ *      - If losses occur and burning is enabled, burns dragon router shares (up to its balance) using rounding-down shares-to-burn
  *      - No tracked-loss bucket exists; any loss not covered by dragon router burning reduces totalAssets and affects PPS for all holders
  *
  * Economic notes:
@@ -89,8 +89,11 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
      */
     function _handleDragonLossProtection(StrategyData storage S, uint256 loss) internal {
         if (S.enableBurning) {
-            // Convert loss to shares that should be burned
-            uint256 sharesToBurn = _convertToShares(S, loss, Math.Rounding.Ceil);
+            // Convert loss to shares that should be burned.
+            // Floor rounding: any sub-wei remainder is socialized via PPS reduction
+            // rather than over-burning dragon shares. This avoids systematically
+            // extracting value from dragon in favor of depositors.
+            uint256 sharesToBurn = _convertToShares(S, loss, Math.Rounding.Floor);
 
             // Can only burn up to available shares from dragon router
             uint256 sharesBurned = Math.min(sharesToBurn, S.balances[S.dragonRouter]);

--- a/test/unit/strategies/yieldDonating/Accounting.t.sol
+++ b/test/unit/strategies/yieldDonating/Accounting.t.sol
@@ -626,6 +626,75 @@ contract AccountingTest is Setup {
     }
 
     /**
+     * @notice Regression: Floor rounding must be used when PPS != 1
+     * @dev At PPS=1, Ceil and Floor produce the same result, masking the bug.
+     *      This test creates PPS < 1 via an unbacked loss with burning disabled,
+     *      then verifies a subsequent loss with burning enabled uses Floor rounding.
+     */
+    function test_burnConversion_floorRoundingAtNonUnityPPS() public {
+        // Step 1: Deposit and create profit so dragon gets shares via report
+        mintAndDepositIntoStrategy(strategy, user, 100e18);
+        asset.mint(address(yieldSource), 50e18); // 50 profit in yield source
+        vm.prank(keeper);
+        strategy.report(); // dragon gets ~50 shares from profit donation
+
+        // totalAssets = 150, totalSupply = 150 (100 user + 50 dragon), PPS = 1
+        uint256 dragonShares = strategy.balanceOf(donationAddress);
+        assertGt(dragonShares, 0, "Dragon should have shares from profit donation");
+
+        // Step 2: Create unbacked loss with burning DISABLED to push PPS < 1
+        vm.prank(management);
+        YieldDonatingTokenizedStrategy(address(strategy)).setEnableBurning(false);
+
+        yieldSource.simulateLoss(30e18); // lose 30 assets
+        vm.prank(keeper);
+        strategy.report(); // PPS drops, no shares burned
+
+        // totalAssets = 120, totalSupply = 150, PPS = 120/150 = 0.8
+        uint256 totalAssets = strategy.totalAssets();
+        uint256 totalSupply = strategy.totalSupply();
+        assertEq(totalAssets, 120e18, "Should have 120 assets after 30 loss");
+        assertEq(totalSupply, 150e18, "Supply unchanged when burning disabled");
+
+        // Step 3: Enable burning and trigger a small loss with non-zero remainder
+        vm.prank(management);
+        YieldDonatingTokenizedStrategy(address(strategy)).setEnableBurning(true);
+
+        // With totalSupply = 150e18 and totalAssets = 120e18, a loss of 7e18 gives:
+        //   loss * totalSupply / totalAssets = 7 * 150 / 120 = 1050 / 120 = 8.75
+        // At 1e18 precision this is exactly 8.75e18, so (7e18 * 150e18) % 120e18 == 0 (no remainder).
+        // For this test we specifically need a non-zero remainder:
+        //   (loss * totalSupply) % totalAssets != 0
+        // to exercise the floor-vs-ceil behavior when converting loss to shares.
+        //
+        // Taking loss = 7e18 + 1 breaks exact divisibility:
+        //   (7e18 + 1) * 150e18 % 120e18 != 0
+        // so the integer division loss * totalSupply / totalAssets has a truncated fractional part.
+        uint256 loss = 7e18 + 1;
+        yieldSource.simulateLoss(loss);
+
+        uint256 dragonSharesBefore = strategy.balanceOf(donationAddress);
+
+        // Compute expected floor shares: loss * totalSupply / totalAssets (integer division = floor)
+        uint256 floorShares = (loss * totalSupply) / totalAssets;
+        uint256 ceilShares = floorShares + 1; // ceil adds 1 when remainder != 0
+
+        // Verify our test parameters actually produce a remainder
+        assertGt((loss * totalSupply) % totalAssets, 0, "Test setup: must have non-zero remainder");
+        assertGt(ceilShares, floorShares, "Test setup: ceil must differ from floor");
+
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 dragonSharesAfter = strategy.balanceOf(donationAddress);
+        uint256 actualBurned = dragonSharesBefore - dragonSharesAfter;
+
+        // The fix: Floor rounding means we burn floorShares, not ceilShares
+        assertEq(actualBurned, floorShares, "Should burn floor(shares), not ceil");
+        assertTrue(actualBurned < ceilShares, "Must not over-burn by rounding up");
+    }
+
+    /**
      * @notice Test conversion rate consistency during burn operations
      */
     function test_burnConversion_rateConsistency() public {


### PR DESCRIPTION
## Summary

- Changed `Math.Rounding.Ceil` to `Math.Rounding.Floor` in `YieldDonatingTokenizedStrategy._handleDragonLossProtection` (line 93) to prevent over-burning 1 dragon share whenever `loss * totalSupply % totalAssets != 0`
- Updated NatSpec to reflect the corrected rounding direction
- Added regression test `test_burnConversion_floorRoundingAtNonUnityPPS` that operates at PPS < 1, where Floor and Ceil produce different results (all existing burn tests operated at PPS=1 where the difference is invisible)

Addresses Quentin's security audit finding V3 (Medium). Aligns with upstream Yearn V3, sibling `DragonTokenizedStrategy`, and Morpho Blue -- all of which use Floor rounding for loss-to-shares conversion.