### PR TITLE
ci(osu-1498):  add bages to core repo

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -258,6 +258,11 @@ jobs:
             fi
           }
 
+          # Export for badge steps
+          echo "COVERAGE_LINES=$LINES_PCT" >> $GITHUB_ENV
+          echo "COVERAGE_BRANCHES=$BRANCH_PCT" >> $GITHUB_ENV
+          echo "COVERAGE_FUNCTIONS=$FUNCS_PCT" >> $GITHUB_ENV
+
           check_threshold "Lines" "$LINES_PCT" || FAILED=1
           check_threshold "Statements" "$STMTS_PCT" || FAILED=1
           check_threshold "Branches" "$BRANCH_PCT" || FAILED=1
@@ -271,6 +276,45 @@ jobs:
 
           echo ""
           echo "All coverage metrics meet the ${THRESHOLD}% threshold."
+
+      - name: Update Coverage Badges
+        if: always() && github.event.pull_request.base.ref == 'develop'
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: coverage-lines.json
+          label: lines
+          message: ${{ env.COVERAGE_LINES }}%
+          valColorRange: ${{ env.COVERAGE_LINES }}
+          minColorRange: 0
+          maxColorRange: 100
+
+      - name: Update Branches Badge
+        if: always() && github.event.pull_request.base.ref == 'develop'
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: coverage-branches.json
+          label: branches
+          message: ${{ env.COVERAGE_BRANCHES }}%
+          valColorRange: ${{ env.COVERAGE_BRANCHES }}
+          minColorRange: 0
+          maxColorRange: 100
+
+      - name: Update Functions Badge
+        if: always() && github.event.pull_request.base.ref == 'develop'
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_SECRET }}
+          gistID: ${{ vars.COVERAGE_GIST_ID }}
+          filename: coverage-functions.json
+          label: functions
+          message: ${{ env.COVERAGE_FUNCTIONS }}%
+          valColorRange: ${{ env.COVERAGE_FUNCTIONS }}
+          minColorRange: 0
+          maxColorRange: 100
 
   kontrol-proofs:
     name: Kontrol Formal Verification

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -258,11 +258,6 @@ jobs:
             fi
           }
 
-          # Export for badge steps
-          echo "COVERAGE_LINES=$LINES_PCT" >> $GITHUB_ENV
-          echo "COVERAGE_BRANCHES=$BRANCH_PCT" >> $GITHUB_ENV
-          echo "COVERAGE_FUNCTIONS=$FUNCS_PCT" >> $GITHUB_ENV
-
           check_threshold "Lines" "$LINES_PCT" || FAILED=1
           check_threshold "Statements" "$STMTS_PCT" || FAILED=1
           check_threshold "Branches" "$BRANCH_PCT" || FAILED=1
@@ -276,45 +271,6 @@ jobs:
 
           echo ""
           echo "All coverage metrics meet the ${THRESHOLD}% threshold."
-
-      - name: Update Coverage Badges
-        if: always() && github.event.pull_request.base.ref == 'develop'
-        uses: schneegans/dynamic-badges-action@v1.7.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: ${{ vars.COVERAGE_GIST_ID }}
-          filename: coverage-lines.json
-          label: lines
-          message: ${{ env.COVERAGE_LINES }}%
-          valColorRange: ${{ env.COVERAGE_LINES }}
-          minColorRange: 0
-          maxColorRange: 100
-
-      - name: Update Branches Badge
-        if: always() && github.event.pull_request.base.ref == 'develop'
-        uses: schneegans/dynamic-badges-action@v1.7.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: ${{ vars.COVERAGE_GIST_ID }}
-          filename: coverage-branches.json
-          label: branches
-          message: ${{ env.COVERAGE_BRANCHES }}%
-          valColorRange: ${{ env.COVERAGE_BRANCHES }}
-          minColorRange: 0
-          maxColorRange: 100
-
-      - name: Update Functions Badge
-        if: always() && github.event.pull_request.base.ref == 'develop'
-        uses: schneegans/dynamic-badges-action@v1.7.0
-        with:
-          auth: ${{ secrets.GIST_SECRET }}
-          gistID: ${{ vars.COVERAGE_GIST_ID }}
-          filename: coverage-functions.json
-          label: functions
-          message: ${{ env.COVERAGE_FUNCTIONS }}%
-          valColorRange: ${{ env.COVERAGE_FUNCTIONS }}
-          minColorRange: 0
-          maxColorRange: 100
 
   kontrol-proofs:
     name: Kontrol Formal Verification

--- a/.github/workflows/push-to-develop.yml
+++ b/.github/workflows/push-to-develop.yml
@@ -104,3 +104,80 @@ jobs:
           name: Tests results                # Name of the check run which will be created
           path: '*.xml'                     # Path to test results (inside artifact .zip)
           reporter: java-junit              # Format of test results
+
+  coverage-badges:
+    name: Update Coverage Badges
+    needs: build-image
+    runs-on: general
+    environment: action
+    container:
+      image: ${{ vars.GCP_DOCKER_IMAGE_REGISTRY }}/core:${{ github.sha }}
+      credentials:
+        username: _json_key_base64
+        password: ${{ secrets.GCP_DOCKER_IMAGES_REGISTRY_SERVICE_ACCOUNT }}
+    env:
+      COVERAGE_GIST_ID: 3d581c9545c040ac95fdd354e69f9bc8
+    steps:
+      - name: Generate Coverage and Extract Metrics
+        env:
+          TEST_RPC_URL: "${{ vars.TEST_MAINNET_RPC_URL }}"
+          TEST_SAFE_SINGLETON: "0x41675C099F32341bf84BFc5382aF534df5C7461a"
+          TEST_SAFE_PROXY_FACTORY: "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67"
+          TEST_RPC_URL_POLYGON: "${{ vars.TEST_POLYGON_RPC_URL }}"
+          TEST_SAFE_SINGLETON_POLYGON: "0x41675C099F32341bf84BFc5382aF534df5C7461a"
+          TEST_SAFE_PROXY_FACTORY_POLYGON: "0x4e1DCf7AD4e460CfD30791CCC4F9c8a4f820ec67"
+        run: |
+          cd /app
+          yarn coverage:summary > full_coverage.txt 2>&1
+
+          TOTAL_LINE=$(grep "^| Total" full_coverage.txt || true)
+          if [ -z "$TOTAL_LINE" ]; then
+            echo "Could not find totals in coverage report."
+            exit 1
+          fi
+
+          echo "Coverage totals: $TOTAL_LINE"
+
+          LINES_PCT=$(echo "$TOTAL_LINE" | awk -F'|' '{print $3}' | grep -o "[0-9]\+\.[0-9]\+" | head -1)
+          BRANCH_PCT=$(echo "$TOTAL_LINE" | awk -F'|' '{print $5}' | grep -o "[0-9]\+\.[0-9]\+" | head -1)
+          FUNCS_PCT=$(echo "$TOTAL_LINE" | awk -F'|' '{print $6}' | grep -o "[0-9]\+\.[0-9]\+" | head -1)
+
+          echo "COVERAGE_LINES=$LINES_PCT" >> $GITHUB_ENV
+          echo "COVERAGE_BRANCHES=$BRANCH_PCT" >> $GITHUB_ENV
+          echo "COVERAGE_FUNCTIONS=$FUNCS_PCT" >> $GITHUB_ENV
+
+      - name: Update Lines Badge
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+        with:
+          auth: ${{ secrets.HOUSEKEEPER_GIST_ACCESS_PAT }}
+          gistID: ${{ env.COVERAGE_GIST_ID }}
+          filename: coverage-lines.json
+          label: lines
+          message: ${{ env.COVERAGE_LINES }}%
+          valColorRange: ${{ env.COVERAGE_LINES }}
+          minColorRange: 0
+          maxColorRange: 100
+
+      - name: Update Branches Badge
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+        with:
+          auth: ${{ secrets.HOUSEKEEPER_GIST_ACCESS_PAT }}
+          gistID: ${{ env.COVERAGE_GIST_ID }}
+          filename: coverage-branches.json
+          label: branches
+          message: ${{ env.COVERAGE_BRANCHES }}%
+          valColorRange: ${{ env.COVERAGE_BRANCHES }}
+          minColorRange: 0
+          maxColorRange: 100
+
+      - name: Update Functions Badge
+        uses: schneegans/dynamic-badges-action@e9a478b16159b4d31420099ba146cdc50f134483 # v1.7.0
+        with:
+          auth: ${{ secrets.HOUSEKEEPER_GIST_ACCESS_PAT }}
+          gistID: ${{ env.COVERAGE_GIST_ID }}
+          filename: coverage-functions.json
+          label: functions
+          message: ${{ env.COVERAGE_FUNCTIONS }}%
+          valColorRange: ${{ env.COVERAGE_FUNCTIONS }}
+          minColorRange: 0
+          maxColorRange: 100

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Octant V2 Core
 
-<!-- Coverage badges: set COVERAGE_GIST_ID repo variable and GIST_SECRET repo secret -->
-[![Lines](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/golemfoundation/COVERAGE_GIST_ID/raw/coverage-lines.json)](https://github.com/golemfoundation/octant-v2-core)
-[![Branches](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/golemfoundation/COVERAGE_GIST_ID/raw/coverage-branches.json)](https://github.com/golemfoundation/octant-v2-core)
-[![Functions](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/golemfoundation/COVERAGE_GIST_ID/raw/coverage-functions.json)](https://github.com/golemfoundation/octant-v2-core)
+<!-- Coverage badges: updated by push-to-develop workflow via schneegans/dynamic-badges-action -->
+[![Lines](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/golemfoundation/3d581c9545c040ac95fdd354e69f9bc8/raw/coverage-lines.json)](https://github.com/golemfoundation/octant-v2-core)
+[![Branches](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/golemfoundation/3d581c9545c040ac95fdd354e69f9bc8/raw/coverage-branches.json)](https://github.com/golemfoundation/octant-v2-core)
+[![Functions](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/golemfoundation/3d581c9545c040ac95fdd354e69f9bc8/raw/coverage-functions.json)](https://github.com/golemfoundation/octant-v2-core)
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# Octant V2 Core
+
+<!-- Coverage badges: set COVERAGE_GIST_ID repo variable and GIST_SECRET repo secret -->
+[![Lines](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/golemfoundation/COVERAGE_GIST_ID/raw/coverage-lines.json)](https://github.com/golemfoundation/octant-v2-core)
+[![Branches](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/golemfoundation/COVERAGE_GIST_ID/raw/coverage-branches.json)](https://github.com/golemfoundation/octant-v2-core)
+[![Functions](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/golemfoundation/COVERAGE_GIST_ID/raw/coverage-functions.json)](https://github.com/golemfoundation/octant-v2-core)
+
 ## Prerequisites
 
 - Node.js 22.16.0


### PR DESCRIPTION
## Summary
- Add coverage badges to README via GitHub Gist + shields.io

## Setup required (one-time)

1. Create a GitHub Gist under the `golemfoundation` account
2. Add repo variable `COVERAGE_GIST_ID` with the gist ID
3. Add repo secret `GIST_SECRET` with a PAT that has `gist` scope
4. Replace `COVERAGE_GIST_ID` in the badge URLs in `README.md` with the actual gist ID