### PR TITLE
Feature/osu 1505 yieldfowarder with swaps

### DIFF
--- a/kontrol.toml
+++ b/kontrol.toml
@@ -5,7 +5,7 @@ rekompile                  = true
 verbose                    = false
 debug                      = false
 require                    = 'verification/kontrol/octant-lemmas.k'
-module-import              = ['YDStrategyTest:OCTANT-LEMMAS', 'YSStrategyTest:OCTANT-LEMMAS']
+module-import              = ['YDStrategyTest:OCTANT-LEMMAS', 'YSStrategyTest:OCTANT-LEMMAS', 'YFTest:OCTANT-LEMMAS', 'SYFTest:OCTANT-LEMMAS']
 auxiliary-lemmas           = true
 
 [prove.default]
@@ -76,6 +76,24 @@ match-test                 = [
         "YSStrategyTest.testTransferUserToDragon(address,uint256)",
         "YSStrategyTest.testConversionSolventYS(uint256)",
         "YSStrategyTest.testConversionFallbackInsolventYS(uint256)",
+        # ============================================
+        # YieldForwarder proofs (5)
+        # ============================================
+        "YFTest.testReportAndForwardOnlyKeeper()",
+        "YFTest.testReportAndForwardReceiverGuarantee()",
+        "YFTest.testReportAndForwardNoResidualShares()",
+        "YFTest.testReportAndForwardZeroSharesPassthrough()",
+        "YFTest.testReportAndForwardReturnsRedeemAssets()",
+        # ============================================
+        # SwappingYieldForwarder proofs (7)
+        # ============================================
+        "SYFTest.testReportSwapAndForwardOnlyKeeper()",
+        "SYFTest.testReportSwapAndForwardReceiverGuarantee()",
+        "SYFTest.testReportSwapAndForwardNoResidualSourceAsset()",
+        "SYFTest.testReportSwapAndForwardZeroSharesPassthrough()",
+        "SYFTest.testReportSwapAndForwardZeroRedeemPassthrough()",
+        "SYFTest.testReportSwapAndForwardCorrectTokenRouting()",
+        "SYFTest.testInheritedReportAndForwardAccessControl()",
     ]
 
 [show.default]

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ISwapper } from "./interfaces/ISwapper.sol";
+import { YieldForwarder, IRedeemable, IReportable } from "./YieldForwarder.sol";
+
+/// @notice Minimal ERC4626 interface to read a strategy's underlying asset
+interface IERC4626Asset {
+    /// @notice Returns the address of the underlying asset
+    function asset() external view returns (address);
+}
+
+/**
+ * @title SwappingYieldForwarder
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice Extends YieldForwarder with an additional swap step before forwarding to the receiver.
+ * @dev Inherits reportAndForward() from YieldForwarder (no-swap fallback) and adds
+ *      reportSwapAndForward() which swaps via a pluggable ISwapper before forwarding.
+ *
+ *      This dual-mode design acts as a built-in circuit breaker: if the swap protocol
+ *      is unavailable, the keeper simply calls the inherited non-swapping path instead.
+ *
+ *      CALL CHAIN (with swap):
+ *      Keeper EOA -> reportSwapAndForward() -> strategy.report() -> profit shares
+ *      minted to this contract -> redeem shares to self -> swap via ISwapper ->
+ *      target asset forwarded to receiver
+ *
+ *      CALL CHAIN (without swap / fallback):
+ *      Keeper EOA -> reportAndForward() [inherited] -> strategy.report() -> profit shares
+ *      minted to this contract -> redeem shares directly to receiver
+ *
+ *      DESIGN:
+ *      - Fully immutable: no admin, no upgrades, no sweep
+ *      - Keeper-gated: only the designated keeper can trigger
+ *      - Single-purpose: assets can only flow to the hardcoded receiver
+ *      - Pluggable swap: ISwapper adapter handles DEX-specific logic
+ *      - Dual-mode: keeper picks swap vs no-swap path at call-time
+ *      - Strategy is passed as a call-time parameter to avoid circular dependencies
+ */
+contract SwappingYieldForwarder is YieldForwarder {
+    using SafeERC20 for IERC20;
+
+    // ============================================
+    // ERRORS
+    // ============================================
+
+    /// @notice Thrown when the swapper address is zero
+    error InvalidSwapper();
+
+    /// @notice Thrown when the target asset address is zero
+    error InvalidTargetAsset();
+
+    // ============================================
+    // EVENTS
+    // ============================================
+
+    /// @notice Emitted when shares are redeemed, swapped to target asset, and forwarded
+    /// @param strategy Address of the strategy whose shares were redeemed
+    /// @param receiver Address that received the target assets
+    /// @param shares Amount of shares redeemed
+    /// @param assetsIn Amount of underlying assets redeemed (swap input)
+    /// @param assetsOut Amount of target assets forwarded (swap output)
+    event YieldSwappedAndForwarded(
+        address indexed strategy,
+        address indexed receiver,
+        uint256 shares,
+        uint256 assetsIn,
+        uint256 assetsOut
+    );
+
+    // ============================================
+    // STATE
+    // ============================================
+
+    /// @notice The desired output token after swapping
+    /// @dev Set once at construction, cannot be changed
+    address public immutable targetAsset;
+
+    /// @notice The swap adapter used to convert underlying -> target asset
+    /// @dev Set once at construction, cannot be changed
+    ISwapper public immutable swapper;
+
+    // ============================================
+    // CONSTRUCTOR
+    // ============================================
+
+    /// @notice Creates a new SwappingYieldForwarder with fixed receiver, keeper, target asset, and swapper
+    /// @param _receiver Address that will receive all forwarded assets
+    /// @param _keeper Address authorized to call reportAndForward / reportSwapAndForward
+    /// @param _targetAsset Address of the desired output token after swapping
+    /// @param _swapper Address of the ISwapper implementation for DEX routing
+    constructor(
+        address _receiver,
+        address _keeper,
+        address _targetAsset,
+        address _swapper
+    ) YieldForwarder(_receiver, _keeper) {
+        if (_targetAsset == address(0)) revert InvalidTargetAsset();
+        if (_swapper == address(0)) revert InvalidSwapper();
+        targetAsset = _targetAsset;
+        swapper = ISwapper(_swapper);
+    }
+
+    // ============================================
+    // EXTERNAL FUNCTIONS
+    // ============================================
+
+    /**
+     * @notice Calls report() on the strategy, redeems profit shares, swaps the underlying
+     *         asset to the target asset via the configured ISwapper, and forwards to the receiver
+     * @dev The swap path: redeem to self -> transfer to swapper -> swapper.swap() -> receiver.
+     *      The swapper enforces minAmountOut internally and reverts if not met.
+     *
+     *      If report() produces no profit shares, the function returns 0 without reverting.
+     *      If redemption returns 0 assets, the function returns 0 without attempting a swap.
+     *
+     * @param strategy Address of the strategy contract (must implement IReportable, IRedeemable, IERC20, IERC4626Asset)
+     * @param maxLoss Maximum acceptable loss in basis points for the redemption
+     * @param minAmountOut Minimum acceptable amount of target asset after swap (slippage protection)
+     * @return assetsOut Amount of target asset forwarded to receiver (0 if no profit shares)
+     */
+    function reportSwapAndForward(
+        address strategy,
+        uint256 maxLoss,
+        uint256 minAmountOut
+    ) external returns (uint256 assetsOut) {
+        if (msg.sender != keeper) revert OnlyKeeper();
+
+        IReportable(strategy).report();
+
+        uint256 shares = IERC20(strategy).balanceOf(address(this));
+        if (shares == 0) return 0;
+
+        // Redeem to this contract (not receiver) so we can swap first
+        uint256 assetsIn = IRedeemable(strategy).redeem(shares, address(this), address(this), maxLoss);
+        if (assetsIn == 0) return 0;
+
+        address assetIn = IERC4626Asset(strategy).asset();
+
+        // Transfer underlying to swapper, then execute swap to receiver
+        IERC20(assetIn).safeTransfer(address(swapper), assetsIn);
+        assetsOut = swapper.swap(assetIn, targetAsset, assetsIn, minAmountOut, receiver);
+
+        emit YieldSwappedAndForwarded(strategy, receiver, shares, assetsIn, assetsOut);
+    }
+}

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -136,7 +136,10 @@ contract SwappingYieldForwarder is YieldForwarder {
 
         // Redeem to this contract (not receiver) so we can swap first
         uint256 assetsIn = IRedeemable(strategy).redeem(shares, address(this), address(this), maxLoss);
-        if (assetsIn == 0) return 0;
+        if (assetsIn == 0) {
+            emit YieldSwappedAndForwarded(strategy, receiver, shares, 0, 0);
+            return 0;
+        }
 
         address assetIn = IERC4626Asset(strategy).asset();
 

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -126,7 +126,7 @@ contract SwappingYieldForwarder is YieldForwarder {
         address strategy,
         uint256 maxLoss,
         uint256 minAmountOut
-    ) external returns (uint256 assetsOut) {
+    ) external nonReentrant returns (uint256 assetsOut) {
         if (msg.sender != keeper) revert OnlyKeeper();
 
         IReportable(strategy).report();

--- a/src/core/YieldForwarder.sol
+++ b/src/core/YieldForwarder.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /// @notice Minimal interface for strategy share redemption
 interface IRedeemable {
@@ -43,7 +44,7 @@ interface IReportable {
  *      - Single-purpose: assets can only flow to the hardcoded receiver
  *      - Strategy is passed as a call-time parameter to avoid circular dependencies
  */
-contract YieldForwarder {
+contract YieldForwarder is ReentrancyGuard {
     // ============================================
     // ERRORS
     // ============================================
@@ -111,7 +112,7 @@ contract YieldForwarder {
      * @param maxLoss Maximum acceptable loss in basis points for the redemption
      * @return assets Amount of underlying assets forwarded to receiver (0 if no profit shares)
      */
-    function reportAndForward(address strategy, uint256 maxLoss) external returns (uint256 assets) {
+    function reportAndForward(address strategy, uint256 maxLoss) external nonReentrant returns (uint256 assets) {
         if (msg.sender != keeper) revert OnlyKeeper();
 
         IReportable(strategy).report();

--- a/src/core/interfaces/ISwapper.sol
+++ b/src/core/interfaces/ISwapper.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+/**
+ * @title ISwapper
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice Minimal interface for pluggable token swap adapters
+ * @dev Implementations are expected to be stateless and hold no tokens between calls.
+ *      The caller transfers tokenIn to the swapper before calling swap().
+ */
+interface ISwapper {
+    /// @notice Execute a token swap and send output to receiver
+    /// @dev The caller MUST transfer `amountIn` of `tokenIn` to this contract before calling.
+    ///      Reverts if output is less than `minAmountOut`.
+    /// @param tokenIn Address of the input token
+    /// @param tokenOut Address of the output token
+    /// @param amountIn Amount of tokenIn to swap (already transferred to this contract)
+    /// @param minAmountOut Minimum acceptable output amount (reverts if not met)
+    /// @param receiver Address to receive the output tokens
+    /// @return amountOut Actual amount of tokenOut sent to receiver
+    function swap(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address receiver
+    ) external returns (uint256 amountOut);
+}

--- a/src/swappers/CurveSwapper.sol
+++ b/src/swappers/CurveSwapper.sol
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ISwapper } from "../core/interfaces/ISwapper.sol";
+
+/// @notice Minimal interface for Curve StableSwap pool exchange
+/// @dev Covers Curve V1 (StableSwap) pools that use int128 indices.
+///      Uses non-returning variant for compatibility with legacy pools (e.g., 3Pool)
+///      that do not return the output amount. Balance measurement is used instead.
+interface ICurvePool {
+    /// @notice Exchange tokens within the pool
+    /// @param i Index of the input token in the pool
+    /// @param j Index of the output token in the pool
+    /// @param dx Amount of input token to swap
+    /// @param min_dy Minimum amount of output token to receive
+    function exchange(int128 i, int128 j, uint256 dx, uint256 min_dy) external;
+}
+
+/**
+ * @title CurveSwapper
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice ISwapper adapter for direct Curve StableSwap pool exchanges
+ * @dev Performs single-pool swaps between correlated/pegged ERC20 assets via Curve's
+ *      StableSwap invariant, which provides near-zero slippage for pegged pairs.
+ *
+ *      Each deployment is configured for a specific pool and token pair via immutables.
+ *      Uses direct pool calls (not the Curve Router) for gas efficiency since the
+ *      exact pool is known at deploy time.
+ *
+ *      Key Curve pools on Ethereum mainnet:
+ *      - stETH/ETH:     0xDC24316b9AE028F1497c275EB9192a3Ea0f67022 (indices: 0=ETH, 1=stETH)
+ *      - rETH/wstETH:   0x447ddd4960d9fdbf6af9a790560d0af76795cb08 (indices: 0=rETH, 1=wstETH)
+ *      - 3Pool:         0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1c7 (indices: 0=DAI, 1=USDC, 2=USDT)
+ *
+ *      LIMITATIONS:
+ *      - ERC20-to-ERC20 only. Does not handle native ETH output (pools that return ETH
+ *        require wrapping to WETH which is not supported). For ETH-involving swaps,
+ *        use UniswapV3SwapperAdapter with WETH instead.
+ *      - Only supports Curve V1 (StableSwap) pools with int128 indices.
+ *
+ *      This contract is fully immutable and holds no tokens between calls.
+ */
+contract CurveSwapper is ISwapper {
+    using SafeERC20 for IERC20;
+
+    // ============================================
+    // ERRORS
+    // ============================================
+
+    /// @notice Thrown when the pool address is zero
+    error InvalidPool();
+
+    /// @notice Thrown when a token address is zero or does not match the configured pair
+    error InvalidToken();
+
+    // ============================================
+    // STATE
+    // ============================================
+
+    /// @notice The Curve pool to swap through
+    address public immutable pool;
+
+    /// @notice Index of the input token in the Curve pool
+    int128 public immutable indexIn;
+
+    /// @notice Index of the output token in the Curve pool
+    int128 public immutable indexOut;
+
+    /// @notice The expected input token for this swapper instance
+    address public immutable tokenIn;
+
+    /// @notice The expected output token for this swapper instance
+    address public immutable tokenOut;
+
+    // ============================================
+    // CONSTRUCTOR
+    // ============================================
+
+    /// @notice Creates a CurveSwapper configured for a specific pool and token pair
+    /// @param _pool Address of the Curve StableSwap pool
+    /// @param _indexIn Index of tokenIn in the pool's coins array
+    /// @param _indexOut Index of tokenOut in the pool's coins array
+    /// @param _tokenIn Address of the input token (must match pool.coins[_indexIn])
+    /// @param _tokenOut Address of the output token (must match pool.coins[_indexOut])
+    constructor(address _pool, int128 _indexIn, int128 _indexOut, address _tokenIn, address _tokenOut) {
+        if (_pool == address(0)) revert InvalidPool();
+        if (_tokenIn == address(0) || _tokenOut == address(0)) revert InvalidToken();
+        pool = _pool;
+        indexIn = _indexIn;
+        indexOut = _indexOut;
+        tokenIn = _tokenIn;
+        tokenOut = _tokenOut;
+    }
+
+    // ============================================
+    // EXTERNAL FUNCTIONS
+    // ============================================
+
+    /// @inheritdoc ISwapper
+    /// @dev Uses balance measurement for compatibility with legacy Curve pools (e.g., 3Pool)
+    ///      whose exchange() does not return the output amount.
+    function swap(
+        address _tokenIn,
+        address _tokenOut,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address receiver
+    ) external override returns (uint256 amountOut) {
+        if (_tokenIn != tokenIn || _tokenOut != tokenOut) revert InvalidToken();
+
+        IERC20(tokenIn).forceApprove(pool, amountIn);
+
+        uint256 balBefore = IERC20(tokenOut).balanceOf(address(this));
+        ICurvePool(pool).exchange(indexIn, indexOut, amountIn, minAmountOut);
+        amountOut = IERC20(tokenOut).balanceOf(address(this)) - balBefore;
+
+        IERC20(tokenOut).safeTransfer(receiver, amountOut);
+    }
+}

--- a/src/swappers/CurveSwapper.sol
+++ b/src/swappers/CurveSwapper.sol
@@ -56,6 +56,9 @@ contract CurveSwapper is ISwapper {
     /// @notice Thrown when a token address is zero or does not match the configured pair
     error InvalidToken();
 
+    /// @notice Thrown when pool indices are identical
+    error InvalidIndices();
+
     // ============================================
     // STATE
     // ============================================
@@ -88,6 +91,7 @@ contract CurveSwapper is ISwapper {
     constructor(address _pool, int128 _indexIn, int128 _indexOut, address _tokenIn, address _tokenOut) {
         if (_pool == address(0)) revert InvalidPool();
         if (_tokenIn == address(0) || _tokenOut == address(0)) revert InvalidToken();
+        if (_indexIn == _indexOut) revert InvalidIndices();
         pool = _pool;
         indexIn = _indexIn;
         indexOut = _indexOut;
@@ -116,6 +120,8 @@ contract CurveSwapper is ISwapper {
         uint256 balBefore = IERC20(tokenOut).balanceOf(address(this));
         ICurvePool(pool).exchange(indexIn, indexOut, amountIn, minAmountOut);
         amountOut = IERC20(tokenOut).balanceOf(address(this)) - balBefore;
+
+        IERC20(tokenIn).forceApprove(pool, 0);
 
         IERC20(tokenOut).safeTransfer(receiver, amountOut);
     }

--- a/src/swappers/CurveSwapper.sol
+++ b/src/swappers/CurveSwapper.sol
@@ -10,6 +10,10 @@ import { ISwapper } from "../core/interfaces/ISwapper.sol";
 ///      Uses non-returning variant for compatibility with legacy pools (e.g., 3Pool)
 ///      that do not return the output amount. Balance measurement is used instead.
 interface ICurvePool {
+    /// @notice Returns the token address at the given index in the pool
+    /// @param index Index of the token in the pool's coins array
+    function coins(uint256 index) external view returns (address);
+
     /// @notice Exchange tokens within the pool
     /// @param i Index of the input token in the pool
     /// @param j Index of the output token in the pool
@@ -59,6 +63,9 @@ contract CurveSwapper is ISwapper {
     /// @notice Thrown when pool indices are identical
     error InvalidIndices();
 
+    /// @notice Thrown when a token address does not match the pool's coins at the given index
+    error TokenIndexMismatch();
+
     // ============================================
     // STATE
     // ============================================
@@ -92,6 +99,8 @@ contract CurveSwapper is ISwapper {
         if (_pool == address(0)) revert InvalidPool();
         if (_tokenIn == address(0) || _tokenOut == address(0)) revert InvalidToken();
         if (_indexIn == _indexOut) revert InvalidIndices();
+        if (ICurvePool(_pool).coins(uint256(int256(_indexIn))) != _tokenIn) revert TokenIndexMismatch();
+        if (ICurvePool(_pool).coins(uint256(int256(_indexOut))) != _tokenOut) revert TokenIndexMismatch();
         pool = _pool;
         indexIn = _indexIn;
         indexOut = _indexOut;

--- a/src/swappers/PSMSwapper.sol
+++ b/src/swappers/PSMSwapper.sol
@@ -89,6 +89,9 @@ contract PSMSwapper is ISwapper {
     /// @param actual Amount actually received
     error NonOneToOneConversion(uint256 expected, uint256 actual);
 
+    /// @notice Thrown when conversionFactor is zero for the BUY_GEM route
+    error InvalidConversionFactor();
+
     // ============================================
     // CONSTRUCTOR
     // ============================================
@@ -103,6 +106,7 @@ contract PSMSwapper is ISwapper {
     constructor(address _protocol, Route _route, address _tokenIn, address _tokenOut, uint256 _conversionFactor) {
         if (_protocol == address(0)) revert InvalidProtocol();
         if (_tokenIn == address(0) || _tokenOut == address(0)) revert InvalidToken();
+        if (_route == Route.BUY_GEM && _conversionFactor == 0) revert InvalidConversionFactor();
         protocol = _protocol;
         route = _route;
         tokenIn = _tokenIn;

--- a/src/swappers/PSMSwapper.sol
+++ b/src/swappers/PSMSwapper.sol
@@ -146,6 +146,8 @@ contract PSMSwapper is ISwapper {
         IPSM(protocol).sellGem(address(this), amountIn);
         amountOut = IERC20(tokenOut).balanceOf(address(this)) - balBefore;
 
+        IERC20(tokenIn).forceApprove(protocol, 0);
+
         IERC20(tokenOut).safeTransfer(receiver, amountOut);
     }
 
@@ -156,6 +158,7 @@ contract PSMSwapper is ISwapper {
     function _buyGem(uint256 amountIn, address receiver) internal returns (uint256 amountOut) {
         uint256 tout = IPSM(protocol).tout();
         uint256 gemAmt = (amountIn * WAD) / (conversionFactor * (WAD + tout));
+        if (gemAmt == 0) revert InsufficientOutput(1, 0);
 
         IERC20(tokenIn).forceApprove(protocol, amountIn);
 

--- a/src/swappers/PSMSwapper.sol
+++ b/src/swappers/PSMSwapper.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ISwapper } from "../core/interfaces/ISwapper.sol";
+import { IPSM, IExchange } from "../strategies/interfaces/IPSM.sol";
+
+/**
+ * @title PSMSwapper
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice ISwapper adapter for Sky Protocol Peg Stability Module (PSM) and DaiUsds converter
+ * @dev Supports four swap routes for stablecoin conversions on Ethereum mainnet:
+ *
+ *      SELL_GEM:    gem (e.g., USDC) -> DAI/USDS via PSM (LitePSM or LitePSMWrapper)
+ *      BUY_GEM:     DAI/USDS -> gem (e.g., USDC) via PSM (LitePSM or LitePSMWrapper)
+ *      DAI_TO_USDS: DAI -> USDS via DaiUsds converter (always 1:1, permanently fee-free)
+ *      USDS_TO_DAI: USDS -> DAI via DaiUsds converter (always 1:1, permanently fee-free)
+ *
+ *      Key addresses on Ethereum mainnet:
+ *      - LitePSM (USDC/DAI):     0xf6e72Db5454dd049d0788e411b06CfAF16853042
+ *      - LitePSMWrapper (USDC/USDS): 0xA188EEC8F81263234dA3622A406892F3d630f98c
+ *      - DaiUsds converter:       0x3225737a9Bbb6473CB4a45b7244ACa2BeFdB276A
+ *
+ *      PSM fees (tin/tout) are currently 0% but are governance-controlled and may change.
+ *      The BUY_GEM route dynamically queries tout() to calculate the correct gem amount.
+ *
+ *      This contract is fully immutable and holds no tokens between calls.
+ */
+contract PSMSwapper is ISwapper {
+    using SafeERC20 for IERC20;
+
+    // ============================================
+    // TYPES
+    // ============================================
+
+    enum Route {
+        SELL_GEM, // gem (e.g., USDC) -> DAI/USDS via IPSM.sellGem()
+        BUY_GEM, // DAI/USDS -> gem (e.g., USDC) via IPSM.buyGem()
+        DAI_TO_USDS, // DAI -> USDS via IExchange.daiToUsds()
+        USDS_TO_DAI // USDS -> DAI via IExchange.usdsToDai()
+    }
+
+    // ============================================
+    // CONSTANTS
+    // ============================================
+
+    /// @dev 1e18, used for PSM fee calculations
+    uint256 internal constant WAD = 1e18;
+
+    // ============================================
+    // STATE
+    // ============================================
+
+    /// @notice The PSM or DaiUsds converter contract address
+    address public immutable protocol;
+
+    /// @notice The configured swap direction
+    Route public immutable route;
+
+    /// @notice The expected input token for this swapper instance
+    address public immutable tokenIn;
+
+    /// @notice The expected output token for this swapper instance
+    address public immutable tokenOut;
+
+    /// @notice Decimal conversion factor between gem and DAI/USDS (e.g., 1e12 for USDC)
+    /// @dev Only used for BUY_GEM route. Set to 0 for other routes.
+    uint256 public immutable conversionFactor;
+
+    // ============================================
+    // ERRORS
+    // ============================================
+
+    /// @notice Thrown when the protocol address is zero
+    error InvalidProtocol();
+
+    /// @notice Thrown when a token address is zero or does not match the configured route
+    error InvalidToken();
+
+    /// @notice Thrown when the swap output is less than the minimum required
+    /// @param expected Minimum amount expected
+    /// @param actual Amount actually received
+    error InsufficientOutput(uint256 expected, uint256 actual);
+
+    // ============================================
+    // CONSTRUCTOR
+    // ============================================
+
+    /// @notice Creates a PSMSwapper configured for a specific stablecoin swap route
+    /// @param _protocol Address of the PSM or DaiUsds converter contract
+    /// @param _route The swap direction this instance handles
+    /// @param _tokenIn Address of the input token
+    /// @param _tokenOut Address of the output token
+    /// @param _conversionFactor Decimal scaling factor (e.g., 1e12 for 6->18 decimal conversion).
+    ///        Required for BUY_GEM, ignored for other routes.
+    constructor(address _protocol, Route _route, address _tokenIn, address _tokenOut, uint256 _conversionFactor) {
+        if (_protocol == address(0)) revert InvalidProtocol();
+        if (_tokenIn == address(0) || _tokenOut == address(0)) revert InvalidToken();
+        protocol = _protocol;
+        route = _route;
+        tokenIn = _tokenIn;
+        tokenOut = _tokenOut;
+        conversionFactor = _conversionFactor;
+    }
+
+    // ============================================
+    // EXTERNAL FUNCTIONS
+    // ============================================
+
+    /// @inheritdoc ISwapper
+    function swap(
+        address _tokenIn,
+        address _tokenOut,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address receiver
+    ) external override returns (uint256 amountOut) {
+        if (_tokenIn != tokenIn || _tokenOut != tokenOut) revert InvalidToken();
+
+        if (route == Route.SELL_GEM) {
+            amountOut = _sellGem(amountIn, receiver);
+        } else if (route == Route.BUY_GEM) {
+            amountOut = _buyGem(amountIn, receiver);
+        } else if (route == Route.DAI_TO_USDS) {
+            amountOut = _daiToUsds(amountIn, receiver);
+        } else {
+            amountOut = _usdsToDai(amountIn, receiver);
+        }
+
+        if (amountOut < minAmountOut) revert InsufficientOutput(minAmountOut, amountOut);
+    }
+
+    // ============================================
+    // INTERNAL FUNCTIONS
+    // ============================================
+
+    /// @dev Sell gem (e.g., USDC) for DAI/USDS via PSM.
+    ///      PSM pulls gem from this contract and sends DAI/USDS to this contract,
+    ///      which then forwards to receiver.
+    function _sellGem(uint256 amountIn, address receiver) internal returns (uint256 amountOut) {
+        IERC20(tokenIn).forceApprove(protocol, amountIn);
+
+        uint256 balBefore = IERC20(tokenOut).balanceOf(address(this));
+        IPSM(protocol).sellGem(address(this), amountIn);
+        amountOut = IERC20(tokenOut).balanceOf(address(this)) - balBefore;
+
+        IERC20(tokenOut).safeTransfer(receiver, amountOut);
+    }
+
+    /// @dev Buy gem (e.g., USDC) with DAI/USDS via PSM.
+    ///      Calculates max gem purchasable from amountIn accounting for PSM fees (tout).
+    ///      PSM pulls DAI/USDS from this contract and sends gem to this contract,
+    ///      which then forwards to receiver.
+    function _buyGem(uint256 amountIn, address receiver) internal returns (uint256 amountOut) {
+        uint256 tout = IPSM(protocol).tout();
+        uint256 gemAmt = (amountIn * WAD) / (conversionFactor * (WAD + tout));
+
+        IERC20(tokenIn).forceApprove(protocol, amountIn);
+
+        uint256 balBefore = IERC20(tokenOut).balanceOf(address(this));
+        IPSM(protocol).buyGem(address(this), gemAmt);
+        amountOut = IERC20(tokenOut).balanceOf(address(this)) - balBefore;
+
+        // Reset approval for leftover (rounding may leave dust approved)
+        IERC20(tokenIn).forceApprove(protocol, 0);
+
+        IERC20(tokenOut).safeTransfer(receiver, amountOut);
+    }
+
+    /// @dev Convert DAI to USDS via DaiUsds converter (always 1:1, permanently fee-free).
+    ///      Output is sent directly to receiver by the converter contract.
+    function _daiToUsds(uint256 amountIn, address receiver) internal returns (uint256) {
+        IERC20(tokenIn).forceApprove(protocol, amountIn);
+        IExchange(protocol).daiToUsds(receiver, amountIn);
+        return amountIn;
+    }
+
+    /// @dev Convert USDS to DAI via DaiUsds converter (always 1:1, permanently fee-free).
+    ///      Output is sent directly to receiver by the converter contract.
+    function _usdsToDai(uint256 amountIn, address receiver) internal returns (uint256) {
+        IERC20(tokenIn).forceApprove(protocol, amountIn);
+        IExchange(protocol).usdsToDai(receiver, amountIn);
+        return amountIn;
+    }
+}

--- a/src/swappers/PSMSwapper.sol
+++ b/src/swappers/PSMSwapper.sol
@@ -84,6 +84,11 @@ contract PSMSwapper is ISwapper {
     /// @param actual Amount actually received
     error InsufficientOutput(uint256 expected, uint256 actual);
 
+    /// @notice Thrown when a 1:1 DaiUsds conversion does not produce exact output
+    /// @param expected The input amount (expected output for 1:1)
+    /// @param actual Amount actually received
+    error NonOneToOneConversion(uint256 expected, uint256 actual);
+
     // ============================================
     // CONSTRUCTOR
     // ============================================
@@ -125,8 +130,10 @@ contract PSMSwapper is ISwapper {
             amountOut = _buyGem(amountIn, receiver);
         } else if (route == Route.DAI_TO_USDS) {
             amountOut = _daiToUsds(amountIn, receiver);
+            minAmountOut = amountIn; // 1:1 converter, enforce exact output
         } else {
             amountOut = _usdsToDai(amountIn, receiver);
+            minAmountOut = amountIn; // 1:1 converter, enforce exact output
         }
 
         if (amountOut < minAmountOut) revert InsufficientOutput(minAmountOut, amountOut);
@@ -174,17 +181,23 @@ contract PSMSwapper is ISwapper {
 
     /// @dev Convert DAI to USDS via DaiUsds converter (always 1:1, permanently fee-free).
     ///      Output is sent directly to receiver by the converter contract.
-    function _daiToUsds(uint256 amountIn, address receiver) internal returns (uint256) {
+    ///      Reverts if the actual output does not match amountIn exactly.
+    function _daiToUsds(uint256 amountIn, address receiver) internal returns (uint256 amountOut) {
         IERC20(tokenIn).forceApprove(protocol, amountIn);
+        uint256 balBefore = IERC20(tokenOut).balanceOf(receiver);
         IExchange(protocol).daiToUsds(receiver, amountIn);
-        return amountIn;
+        amountOut = IERC20(tokenOut).balanceOf(receiver) - balBefore;
+        if (amountOut != amountIn) revert NonOneToOneConversion(amountIn, amountOut);
     }
 
     /// @dev Convert USDS to DAI via DaiUsds converter (always 1:1, permanently fee-free).
     ///      Output is sent directly to receiver by the converter contract.
-    function _usdsToDai(uint256 amountIn, address receiver) internal returns (uint256) {
+    ///      Reverts if the actual output does not match amountIn exactly.
+    function _usdsToDai(uint256 amountIn, address receiver) internal returns (uint256 amountOut) {
         IERC20(tokenIn).forceApprove(protocol, amountIn);
+        uint256 balBefore = IERC20(tokenOut).balanceOf(receiver);
         IExchange(protocol).usdsToDai(receiver, amountIn);
-        return amountIn;
+        amountOut = IERC20(tokenOut).balanceOf(receiver) - balBefore;
+        if (amountOut != amountIn) revert NonOneToOneConversion(amountIn, amountOut);
     }
 }

--- a/src/swappers/UniswapV3SwapperAdapter.sol
+++ b/src/swappers/UniswapV3SwapperAdapter.sol
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ISwapRouter } from "@tokenized-strategy-periphery/interfaces/Uniswap/V3/ISwapRouter.sol";
+import { ISwapper } from "../core/interfaces/ISwapper.sol";
+
+/**
+ * @title UniswapV3SwapperAdapter
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice ISwapper adapter for Uniswap V3 exact-input swaps
+ * @dev Supports both single-hop and multi-hop (via intermediate base token) swaps.
+ *
+ *      Single-hop: tokenIn --(fee)--> tokenOut
+ *      Multi-hop:  tokenIn --(fee)--> base --(feeOut)--> tokenOut
+ *
+ *      The routing mode is determined by the `base` constructor parameter:
+ *      - base == address(0): always single-hop with `fee`
+ *      - base != address(0): multi-hop unless tokenIn or tokenOut IS the base token,
+ *        in which case it falls back to single-hop with the appropriate fee tier
+ *
+ *      Uniswap V3 Router on Ethereum mainnet: 0xE592427A0AEce92De3Edee1F18E0157C05861564
+ *      Common base token (WETH):               0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2
+ *
+ *      Common fee tiers: 100 (0.01%), 500 (0.05%), 3000 (0.3%), 10000 (1%)
+ *
+ *      This contract is fully immutable and holds no tokens between calls.
+ */
+contract UniswapV3SwapperAdapter is ISwapper {
+    using SafeERC20 for IERC20;
+
+    // ============================================
+    // ERRORS
+    // ============================================
+
+    /// @notice Thrown when the router address is zero
+    error InvalidRouter();
+
+    /// @notice Thrown when a token address is zero
+    error InvalidToken();
+
+    // ============================================
+    // STATE
+    // ============================================
+
+    /// @notice The Uniswap V3 SwapRouter address
+    address public immutable router;
+
+    /// @notice Fee tier for direct swaps or the first hop (tokenIn -> base)
+    uint24 public immutable fee;
+
+    /// @notice Optional intermediate token for multi-hop routing (address(0) = direct swap)
+    address public immutable base;
+
+    /// @notice Fee tier for the second hop (base -> tokenOut), only used when base != address(0)
+    uint24 public immutable feeOut;
+
+    // ============================================
+    // CONSTRUCTOR
+    // ============================================
+
+    /// @notice Creates a UniswapV3SwapperAdapter with fixed routing configuration
+    /// @param _router Address of the Uniswap V3 SwapRouter
+    /// @param _fee Fee tier for direct swaps or first hop (e.g., 3000 for 0.3%)
+    /// @param _base Optional base token for multi-hop routing (address(0) for direct swaps)
+    /// @param _feeOut Fee tier for second hop when using multi-hop (ignored if _base is address(0))
+    constructor(address _router, uint24 _fee, address _base, uint24 _feeOut) {
+        if (_router == address(0)) revert InvalidRouter();
+        router = _router;
+        fee = _fee;
+        base = _base;
+        feeOut = _feeOut;
+    }
+
+    // ============================================
+    // EXTERNAL FUNCTIONS
+    // ============================================
+
+    /// @inheritdoc ISwapper
+    function swap(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address receiver
+    ) external override returns (uint256 amountOut) {
+        if (tokenIn == address(0) || tokenOut == address(0)) revert InvalidToken();
+
+        IERC20(tokenIn).forceApprove(router, amountIn);
+
+        if (base == address(0) || tokenIn == base || tokenOut == base) {
+            // Single-hop swap
+            // If tokenIn IS the base, use feeOut (base -> tokenOut pool)
+            // Otherwise use fee (tokenIn -> base/tokenOut pool)
+            uint24 poolFee = (base != address(0) && tokenIn == base) ? feeOut : fee;
+
+            amountOut = ISwapRouter(router).exactInputSingle(
+                ISwapRouter.ExactInputSingleParams(
+                    tokenIn,
+                    tokenOut,
+                    poolFee,
+                    receiver,
+                    block.timestamp,
+                    amountIn,
+                    minAmountOut,
+                    0
+                )
+            );
+        } else {
+            // Multi-hop: tokenIn --(fee)--> base --(feeOut)--> tokenOut
+            bytes memory path = abi.encodePacked(tokenIn, fee, base, feeOut, tokenOut);
+
+            amountOut = ISwapRouter(router).exactInput(
+                ISwapRouter.ExactInputParams(path, receiver, block.timestamp, amountIn, minAmountOut)
+            );
+        }
+    }
+}

--- a/src/swappers/UniswapV4SwapperAdapter.sol
+++ b/src/swappers/UniswapV4SwapperAdapter.sol
@@ -27,9 +27,11 @@ interface IV4PoolManager {
 
     /// @dev Returns BalanceDelta (a packed int256: upper 128 bits = amount0, lower 128 bits = amount1).
     ///      Negative = caller must settle (pay), Positive = caller may take (receive).
-    function swap(PoolKey memory key, SwapParams memory params, bytes calldata hookData)
-        external
-        returns (int256 swapDelta);
+    function swap(
+        PoolKey memory key,
+        SwapParams memory params,
+        bytes calldata hookData
+    ) external returns (int256 swapDelta);
 
     function sync(address currency) external;
     function settle() external payable returns (uint256 paid);
@@ -185,8 +187,10 @@ contract UniswapV4SwapperAdapter is ISwapper {
     function unlockCallback(bytes calldata data) external returns (bytes memory) {
         if (msg.sender != poolManager) revert UnauthorizedCallback();
 
-        (address tokenIn, address tokenOut, uint256 amountIn, uint256 minAmountOut, address receiver) =
-            abi.decode(data, (address, address, uint256, uint256, address));
+        (address tokenIn, address tokenOut, uint256 amountIn, uint256 minAmountOut, address receiver) = abi.decode(
+            data,
+            (address, address, uint256, uint256, address)
+        );
 
         uint256 amountOut;
 
@@ -214,11 +218,7 @@ contract UniswapV4SwapperAdapter is ISwapper {
     // ============================================
 
     /// @dev Execute a single-hop exact-input swap and return the output amount
-    function _singleHop(
-        address tokenIn,
-        address tokenOut,
-        uint256 amountIn
-    ) internal returns (uint256 amountOut) {
+    function _singleHop(address tokenIn, address tokenOut, uint256 amountIn) internal returns (uint256 amountOut) {
         // Select pool config: if tokenIn IS the base, use second-hop config
         uint24 poolFee = (base != address(0) && tokenIn == base) ? feeOut : fee;
         int24 poolTickSpacing = (base != address(0) && tokenIn == base) ? tickSpacingOut : tickSpacing;
@@ -245,22 +245,14 @@ contract UniswapV4SwapperAdapter is ISwapper {
 
     /// @dev Execute a two-hop exact-input swap: tokenIn → base → tokenOut
     ///      Base token deltas net to zero within the PoolManager's accounting.
-    function _multiHop(
-        address tokenIn,
-        address tokenOut,
-        uint256 amountIn
-    ) internal returns (uint256 amountOut) {
+    function _multiHop(address tokenIn, address tokenOut, uint256 amountIn) internal returns (uint256 amountOut) {
         // ── Hop 1: tokenIn → base ──
         bool zfo1 = tokenIn < base;
         (address c0_1, address c1_1) = zfo1 ? (tokenIn, base) : (base, tokenIn);
 
         int256 delta1 = IV4PoolManager(poolManager).swap(
             IV4PoolManager.PoolKey(c0_1, c1_1, fee, tickSpacing, hooks),
-            IV4PoolManager.SwapParams(
-                zfo1,
-                -int256(amountIn),
-                zfo1 ? MIN_SQRT_PRICE_LIMIT : MAX_SQRT_PRICE_LIMIT
-            ),
+            IV4PoolManager.SwapParams(zfo1, -int256(amountIn), zfo1 ? MIN_SQRT_PRICE_LIMIT : MAX_SQRT_PRICE_LIMIT),
             ""
         );
 
@@ -273,11 +265,7 @@ contract UniswapV4SwapperAdapter is ISwapper {
 
         int256 delta2 = IV4PoolManager(poolManager).swap(
             IV4PoolManager.PoolKey(c0_2, c1_2, feeOut, tickSpacingOut, hooksOut),
-            IV4PoolManager.SwapParams(
-                zfo2,
-                -int256(baseAmount),
-                zfo2 ? MIN_SQRT_PRICE_LIMIT : MAX_SQRT_PRICE_LIMIT
-            ),
+            IV4PoolManager.SwapParams(zfo2, -int256(baseAmount), zfo2 ? MIN_SQRT_PRICE_LIMIT : MAX_SQRT_PRICE_LIMIT),
             ""
         );
 

--- a/src/swappers/UniswapV4SwapperAdapter.sol
+++ b/src/swappers/UniswapV4SwapperAdapter.sol
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { ISwapper } from "../core/interfaces/ISwapper.sol";
+
+/// @notice Minimal Uniswap V4 PoolManager interface for executing swaps
+/// @dev Only the functions needed by UniswapV4SwapperAdapter are included.
+///      Currency in V4 is a user-defined type wrapping address; the ABI encoding is identical.
+interface IV4PoolManager {
+    struct PoolKey {
+        address currency0;
+        address currency1;
+        uint24 fee;
+        int24 tickSpacing;
+        address hooks;
+    }
+
+    struct SwapParams {
+        bool zeroForOne;
+        int256 amountSpecified;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    function unlock(bytes calldata data) external returns (bytes memory);
+
+    /// @dev Returns BalanceDelta (a packed int256: upper 128 bits = amount0, lower 128 bits = amount1).
+    ///      Negative = caller must settle (pay), Positive = caller may take (receive).
+    function swap(PoolKey memory key, SwapParams memory params, bytes calldata hookData)
+        external
+        returns (int256 swapDelta);
+
+    function sync(address currency) external;
+    function settle() external payable returns (uint256 paid);
+    function take(address currency, address to, uint256 amount) external;
+}
+
+/**
+ * @title UniswapV4SwapperAdapter
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice ISwapper adapter for Uniswap V4 exact-input swaps via the singleton PoolManager
+ * @dev Supports both single-hop and multi-hop (via intermediate base token) swaps,
+ *      mirroring the routing logic of UniswapV3SwapperAdapter.
+ *
+ *      Single-hop: tokenIn --(fee/tickSpacing/hooks)--> tokenOut
+ *      Multi-hop:  tokenIn --(fee/tickSpacing/hooks)--> base --(feeOut/tickSpacingOut/hooksOut)--> tokenOut
+ *
+ *      The routing mode is determined by the `base` constructor parameter:
+ *      - base == address(0): always single-hop
+ *      - base != address(0): multi-hop unless tokenIn or tokenOut IS the base token,
+ *        in which case it falls back to single-hop with the appropriate pool config
+ *
+ *      Settlement uses V4's sync/transfer/settle pattern for input tokens
+ *      and take() for output tokens. No ERC20 approvals are needed.
+ *
+ *      Uniswap V4 PoolManager on Ethereum mainnet: 0x000000000004444c5dc75cB358380D2e3dE08A90
+ *
+ *      This contract is fully immutable and holds no tokens between calls.
+ */
+contract UniswapV4SwapperAdapter is ISwapper {
+    using SafeERC20 for IERC20;
+
+    // ============================================
+    // ERRORS
+    // ============================================
+
+    /// @notice Thrown when the PoolManager address is zero
+    error InvalidPoolManager();
+
+    /// @notice Thrown when a token address is zero
+    error InvalidToken();
+
+    /// @notice Thrown when tickSpacing is zero (invalid V4 pool configuration)
+    error InvalidTickSpacing();
+
+    /// @notice Thrown when the callback caller is not the PoolManager
+    error UnauthorizedCallback();
+
+    /// @notice Thrown when the swap output is less than the minimum required
+    /// @param expected Minimum amount expected
+    /// @param actual Amount actually received
+    error InsufficientOutput(uint256 expected, uint256 actual);
+
+    // ============================================
+    // CONSTANTS
+    // ============================================
+
+    /// @dev Minimum sqrt price limit for V4 swaps (TickMath.MIN_SQRT_PRICE + 1)
+    uint160 internal constant MIN_SQRT_PRICE_LIMIT = 4295128740;
+
+    /// @dev Maximum sqrt price limit for V4 swaps (TickMath.MAX_SQRT_PRICE - 1)
+    uint160 internal constant MAX_SQRT_PRICE_LIMIT = 1461446703485210103287273052203988822378723970341;
+
+    // ============================================
+    // STATE
+    // ============================================
+
+    /// @notice The Uniswap V4 PoolManager singleton address
+    address public immutable poolManager;
+
+    /// @notice Fee tier for direct swaps or the first hop (tokenIn -> base)
+    uint24 public immutable fee;
+
+    /// @notice Tick spacing for direct swaps or the first hop
+    int24 public immutable tickSpacing;
+
+    /// @notice Hooks address for direct swaps or the first hop (address(0) = no hooks)
+    address public immutable hooks;
+
+    /// @notice Optional intermediate token for multi-hop routing (address(0) = direct swap)
+    address public immutable base;
+
+    /// @notice Fee tier for the second hop (base -> tokenOut), only used when base != address(0)
+    uint24 public immutable feeOut;
+
+    /// @notice Tick spacing for the second hop, only used when base != address(0)
+    int24 public immutable tickSpacingOut;
+
+    /// @notice Hooks address for the second hop (address(0) = no hooks)
+    address public immutable hooksOut;
+
+    // ============================================
+    // CONSTRUCTOR
+    // ============================================
+
+    /// @notice Creates a UniswapV4SwapperAdapter with fixed routing configuration
+    /// @param _poolManager Address of the Uniswap V4 PoolManager singleton
+    /// @param _fee Fee tier for direct swaps or first hop
+    /// @param _tickSpacing Tick spacing for direct swaps or first hop
+    /// @param _hooks Hooks address for direct swaps or first hop (address(0) = no hooks)
+    /// @param _base Optional base token for multi-hop routing (address(0) for direct swaps)
+    /// @param _feeOut Fee tier for second hop when using multi-hop (ignored if _base is address(0))
+    /// @param _tickSpacingOut Tick spacing for second hop (ignored if _base is address(0))
+    /// @param _hooksOut Hooks address for second hop (ignored if _base is address(0))
+    constructor(
+        address _poolManager,
+        uint24 _fee,
+        int24 _tickSpacing,
+        address _hooks,
+        address _base,
+        uint24 _feeOut,
+        int24 _tickSpacingOut,
+        address _hooksOut
+    ) {
+        if (_poolManager == address(0)) revert InvalidPoolManager();
+        if (_tickSpacing == 0) revert InvalidTickSpacing();
+        if (_base != address(0) && _tickSpacingOut == 0) revert InvalidTickSpacing();
+
+        poolManager = _poolManager;
+        fee = _fee;
+        tickSpacing = _tickSpacing;
+        hooks = _hooks;
+        base = _base;
+        feeOut = _feeOut;
+        tickSpacingOut = _tickSpacingOut;
+        hooksOut = _hooksOut;
+    }
+
+    // ============================================
+    // EXTERNAL FUNCTIONS
+    // ============================================
+
+    /// @inheritdoc ISwapper
+    function swap(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address receiver
+    ) external override returns (uint256 amountOut) {
+        if (tokenIn == address(0) || tokenOut == address(0)) revert InvalidToken();
+
+        bytes memory result = IV4PoolManager(poolManager).unlock(
+            abi.encode(tokenIn, tokenOut, amountIn, minAmountOut, receiver)
+        );
+        amountOut = abi.decode(result, (uint256));
+    }
+
+    /// @notice Callback invoked by PoolManager during unlock(); executes swaps and settles
+    /// @dev Only callable by the PoolManager. Reverts with UnauthorizedCallback otherwise.
+    /// @param data ABI-encoded (tokenIn, tokenOut, amountIn, minAmountOut, receiver)
+    /// @return ABI-encoded amountOut
+    function unlockCallback(bytes calldata data) external returns (bytes memory) {
+        if (msg.sender != poolManager) revert UnauthorizedCallback();
+
+        (address tokenIn, address tokenOut, uint256 amountIn, uint256 minAmountOut, address receiver) =
+            abi.decode(data, (address, address, uint256, uint256, address));
+
+        uint256 amountOut;
+
+        if (base == address(0) || tokenIn == base || tokenOut == base) {
+            amountOut = _singleHop(tokenIn, tokenOut, amountIn);
+        } else {
+            amountOut = _multiHop(tokenIn, tokenOut, amountIn);
+        }
+
+        if (amountOut < minAmountOut) revert InsufficientOutput(minAmountOut, amountOut);
+
+        // Settle input: sync balance snapshot → transfer tokens → settle delta
+        IV4PoolManager(poolManager).sync(tokenIn);
+        IERC20(tokenIn).safeTransfer(poolManager, amountIn);
+        IV4PoolManager(poolManager).settle();
+
+        // Take output directly to receiver
+        IV4PoolManager(poolManager).take(tokenOut, receiver, amountOut);
+
+        return abi.encode(amountOut);
+    }
+
+    // ============================================
+    // INTERNAL FUNCTIONS
+    // ============================================
+
+    /// @dev Execute a single-hop exact-input swap and return the output amount
+    function _singleHop(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn
+    ) internal returns (uint256 amountOut) {
+        // Select pool config: if tokenIn IS the base, use second-hop config
+        uint24 poolFee = (base != address(0) && tokenIn == base) ? feeOut : fee;
+        int24 poolTickSpacing = (base != address(0) && tokenIn == base) ? tickSpacingOut : tickSpacing;
+        address poolHooks = (base != address(0) && tokenIn == base) ? hooksOut : hooks;
+
+        // V4 requires currency0 < currency1 in the PoolKey
+        bool zeroForOne = tokenIn < tokenOut;
+        (address c0, address c1) = zeroForOne ? (tokenIn, tokenOut) : (tokenOut, tokenIn);
+
+        int256 delta = IV4PoolManager(poolManager).swap(
+            IV4PoolManager.PoolKey(c0, c1, poolFee, poolTickSpacing, poolHooks),
+            IV4PoolManager.SwapParams(
+                zeroForOne,
+                -int256(amountIn), // negative = exact input in V4
+                zeroForOne ? MIN_SQRT_PRICE_LIMIT : MAX_SQRT_PRICE_LIMIT
+            ),
+            ""
+        );
+
+        // Extract output from packed BalanceDelta (upper 128 = amount0, lower 128 = amount1)
+        // Output is the positive delta: amount1 for zeroForOne, amount0 for !zeroForOne
+        amountOut = uint256(int256(zeroForOne ? int128(delta) : int128(delta >> 128)));
+    }
+
+    /// @dev Execute a two-hop exact-input swap: tokenIn → base → tokenOut
+    ///      Base token deltas net to zero within the PoolManager's accounting.
+    function _multiHop(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn
+    ) internal returns (uint256 amountOut) {
+        // ── Hop 1: tokenIn → base ──
+        bool zfo1 = tokenIn < base;
+        (address c0_1, address c1_1) = zfo1 ? (tokenIn, base) : (base, tokenIn);
+
+        int256 delta1 = IV4PoolManager(poolManager).swap(
+            IV4PoolManager.PoolKey(c0_1, c1_1, fee, tickSpacing, hooks),
+            IV4PoolManager.SwapParams(
+                zfo1,
+                -int256(amountIn),
+                zfo1 ? MIN_SQRT_PRICE_LIMIT : MAX_SQRT_PRICE_LIMIT
+            ),
+            ""
+        );
+
+        // Extract base amount received (positive delta)
+        uint256 baseAmount = uint256(int256(zfo1 ? int128(delta1) : int128(delta1 >> 128)));
+
+        // ── Hop 2: base → tokenOut ──
+        bool zfo2 = base < tokenOut;
+        (address c0_2, address c1_2) = zfo2 ? (base, tokenOut) : (tokenOut, base);
+
+        int256 delta2 = IV4PoolManager(poolManager).swap(
+            IV4PoolManager.PoolKey(c0_2, c1_2, feeOut, tickSpacingOut, hooksOut),
+            IV4PoolManager.SwapParams(
+                zfo2,
+                -int256(baseAmount),
+                zfo2 ? MIN_SQRT_PRICE_LIMIT : MAX_SQRT_PRICE_LIMIT
+            ),
+            ""
+        );
+
+        // Extract final output amount (positive delta)
+        amountOut = uint256(int256(zfo2 ? int128(delta2) : int128(delta2 >> 128)));
+    }
+}

--- a/test/integration/strategies/config/MorphoTestConfig.sol
+++ b/test/integration/strategies/config/MorphoTestConfig.sol
@@ -16,8 +16,8 @@ library MorphoTestConfig {
     /// @notice Morpho Blue vault address
     address internal constant MORPHO_BLUE_VAULT = 0xBEEF01735c132Ada46AA9aA4c54623cAA92A64CB;
 
-    /// @notice Fork block number (latest - 90 days)
-    uint256 internal constant FORK_BLOCK = 22508883 - 6500 * 90;
+    /// @notice Fork block number for mainnet fork tests
+    uint256 internal constant FORK_BLOCK = 24_700_000;
 
     /// @notice Minimum deposit amount for fuzz tests (USDC has 6 decimals)
     uint256 internal constant MIN_DEPOSIT = 1e6;

--- a/test/integration/swappers/CurveSwapperIntegration.t.sol
+++ b/test/integration/swappers/CurveSwapperIntegration.t.sol
@@ -101,6 +101,27 @@ contract CurveSwapperIntegrationTest is BaseSwapperIntegrationTest {
         assertGt(ERC20(USDT).balanceOf(receiver), 0, "Receiver should have USDT");
     }
 
+    /// @notice Constructor reverts when tokenIn does not match pool.coins(indexIn)
+    function test_constructor_revertsOnTokenInIndexMismatch() public {
+        // INDEX_USDC=1 maps to USDC in 3Pool, but we pass USDT as tokenIn
+        vm.expectRevert(CurveSwapper.TokenIndexMismatch.selector);
+        new CurveSwapper(CURVE_3POOL, INDEX_USDC, INDEX_USDT, USDT, USDT);
+    }
+
+    /// @notice Constructor reverts when tokenOut does not match pool.coins(indexOut)
+    function test_constructor_revertsOnTokenOutIndexMismatch() public {
+        // INDEX_USDT=2 maps to USDT in 3Pool, but we pass USDC as tokenOut
+        vm.expectRevert(CurveSwapper.TokenIndexMismatch.selector);
+        new CurveSwapper(CURVE_3POOL, INDEX_USDC, INDEX_USDT, MorphoTestConfig.USDC, MorphoTestConfig.USDC);
+    }
+
+    /// @notice Constructor reverts when indices are swapped relative to tokens
+    function test_constructor_revertsOnSwappedIndices() public {
+        // Tokens are correct but indices are flipped
+        vm.expectRevert(CurveSwapper.TokenIndexMismatch.selector);
+        new CurveSwapper(CURVE_3POOL, INDEX_USDT, INDEX_USDC, MorphoTestConfig.USDC, USDT);
+    }
+
     /// @notice Verify swapper immutables are correctly set
     function test_curveSwapper_config() public view {
         assertEq(curveSwapper.pool(), CURVE_3POOL);

--- a/test/integration/swappers/CurveSwapperIntegration.t.sol
+++ b/test/integration/swappers/CurveSwapperIntegration.t.sol
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { CurveSwapper } from "src/swappers/CurveSwapper.sol";
+import { ISwapper } from "src/core/interfaces/ISwapper.sol";
+import { SwappingYieldForwarder } from "src/core/SwappingYieldForwarder.sol";
+import { MorphoTestConfig } from "test/integration/strategies/config/MorphoTestConfig.sol";
+import { BaseSwapperIntegrationTest } from "./base/BaseSwapperIntegrationTest.sol";
+
+/// @title CurveSwapperIntegration
+/// @notice Integration test: MorphoCompounder USDC profit → Curve 3Pool → USDT → receiver
+/// @dev Uses Curve 3Pool exchange on mainnet fork (USDC index=1, USDT index=2)
+contract CurveSwapperIntegrationTest is BaseSwapperIntegrationTest {
+    // Curve 3Pool mainnet
+    address internal constant CURVE_3POOL = 0xbEbc44782C7dB0a1A60Cb6fe97d0b483032FF1C7;
+    address internal constant USDT = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+
+    // 3Pool indices: 0=DAI, 1=USDC, 2=USDT
+    int128 internal constant INDEX_USDC = 1;
+    int128 internal constant INDEX_USDT = 2;
+
+    CurveSwapper public curveSwapper;
+
+    function _targetAsset() internal pure override returns (address) {
+        return USDT;
+    }
+
+    function _deploySwapper() internal override returns (ISwapper) {
+        curveSwapper = new CurveSwapper(CURVE_3POOL, INDEX_USDC, INDEX_USDT, MorphoTestConfig.USDC, USDT);
+        return ISwapper(address(curveSwapper));
+    }
+
+    function _labelSwapperAddresses() internal override {
+        vm.label(CURVE_3POOL, "Curve3Pool");
+        vm.label(USDT, "USDT");
+    }
+
+    function setUp() public {
+        _baseSetUp();
+    }
+
+    // ========== NO-SWAP FALLBACK TESTS ==========
+
+    function test_reportAndForward_noSwap() public {
+        _test_reportAndForward_noSwap();
+    }
+
+    function test_reportAndForward_zeroProfit() public {
+        _test_reportAndForward_zeroProfit();
+    }
+
+    // ========== SWAP PATH TESTS ==========
+
+    function test_reportSwapAndForward_fullFlow_Curve() public {
+        _test_reportSwapAndForward_fullFlow();
+    }
+
+    function test_reportSwapAndForward_zeroProfit_Curve() public {
+        _test_reportSwapAndForward_zeroProfit();
+    }
+
+    function test_reportSwapAndForward_multipleReports_Curve() public {
+        _test_reportSwapAndForward_multipleReports();
+    }
+
+    function test_reportSwapAndForward_emitsEvent_Curve() public {
+        _test_reportSwapAndForward_emitsEvent();
+    }
+
+    // ========== ACCESS CONTROL ==========
+
+    function test_onlyKeeper_reportAndForward_Curve() public {
+        _test_onlyKeeper_reportAndForward();
+    }
+
+    function test_onlyKeeper_reportSwapAndForward_Curve() public {
+        _test_onlyKeeper_reportSwapAndForward();
+    }
+
+    // ========== CURVE-SPECIFIC TESTS ==========
+
+    /// @notice Curve 3Pool: USDC→USDT should be near 1:1 for stablecoins
+    function test_curveSwap_nearOneToOne() public {
+        _depositAndReport(DEPOSIT_AMOUNT);
+
+        uint256 profit = 1_000e6;
+        _simulateProfit(profit);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        _clearMocks();
+
+        // Both USDC and USDT have 6 decimals, output should be very close to input
+        assertGt(assetsOut, 0, "Curve should produce nonzero USDT output");
+
+        // Receiver should have USDT
+        assertGt(ERC20(USDT).balanceOf(receiver), 0, "Receiver should have USDT");
+    }
+
+    /// @notice Verify swapper immutables are correctly set
+    function test_curveSwapper_config() public view {
+        assertEq(curveSwapper.pool(), CURVE_3POOL);
+        assertEq(curveSwapper.indexIn(), INDEX_USDC);
+        assertEq(curveSwapper.indexOut(), INDEX_USDT);
+        assertEq(curveSwapper.tokenIn(), MorphoTestConfig.USDC);
+        assertEq(curveSwapper.tokenOut(), USDT);
+    }
+}

--- a/test/integration/swappers/PSMSwapperIntegration.t.sol
+++ b/test/integration/swappers/PSMSwapperIntegration.t.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { PSMSwapper } from "src/swappers/PSMSwapper.sol";
+import { ISwapper } from "src/core/interfaces/ISwapper.sol";
+import { SwappingYieldForwarder } from "src/core/SwappingYieldForwarder.sol";
+import { MorphoTestConfig } from "test/integration/strategies/config/MorphoTestConfig.sol";
+import { BaseSwapperIntegrationTest } from "./base/BaseSwapperIntegrationTest.sol";
+
+/// @title PSMSwapperIntegration
+/// @notice Integration test: MorphoCompounder USDC profit → PSM → USDS → receiver
+/// @dev Uses LitePSMWrapper (USDC → USDS) via SELL_GEM route on mainnet fork
+contract PSMSwapperIntegrationTest is BaseSwapperIntegrationTest {
+    // Sky Protocol mainnet addresses
+    address internal constant LITE_PSM_WRAPPER = 0xA188EEC8F81263234dA3622A406892F3D630f98c;
+    address internal constant USDS = 0xdC035D45d973E3EC169d2276DDab16f1e407384F;
+
+    PSMSwapper public psmSwapper;
+
+    function _targetAsset() internal pure override returns (address) {
+        return USDS;
+    }
+
+    function _deploySwapper() internal override returns (ISwapper) {
+        psmSwapper = new PSMSwapper(
+            LITE_PSM_WRAPPER,
+            PSMSwapper.Route.SELL_GEM,
+            MorphoTestConfig.USDC,
+            USDS,
+            0 // conversionFactor not needed for SELL_GEM
+        );
+        return ISwapper(address(psmSwapper));
+    }
+
+    function _labelSwapperAddresses() internal override {
+        vm.label(LITE_PSM_WRAPPER, "LitePSMWrapper");
+        vm.label(USDS, "USDS");
+    }
+
+    function setUp() public {
+        _baseSetUp();
+    }
+
+    // ========== NO-SWAP FALLBACK TESTS ==========
+
+    function test_reportAndForward_noSwap() public {
+        _test_reportAndForward_noSwap();
+    }
+
+    function test_reportAndForward_zeroProfit() public {
+        _test_reportAndForward_zeroProfit();
+    }
+
+    // ========== SWAP PATH TESTS ==========
+
+    function test_reportSwapAndForward_fullFlow_PSM() public {
+        _test_reportSwapAndForward_fullFlow();
+    }
+
+    function test_reportSwapAndForward_zeroProfit_PSM() public {
+        _test_reportSwapAndForward_zeroProfit();
+    }
+
+    function test_reportSwapAndForward_multipleReports_PSM() public {
+        _test_reportSwapAndForward_multipleReports();
+    }
+
+    function test_reportSwapAndForward_emitsEvent_PSM() public {
+        _test_reportSwapAndForward_emitsEvent();
+    }
+
+    // ========== ACCESS CONTROL ==========
+
+    function test_onlyKeeper_reportAndForward_PSM() public {
+        _test_onlyKeeper_reportAndForward();
+    }
+
+    function test_onlyKeeper_reportSwapAndForward_PSM() public {
+        _test_onlyKeeper_reportSwapAndForward();
+    }
+
+    // ========== PSM-SPECIFIC TESTS ==========
+
+    /// @notice PSM SELL_GEM is 1:1 (currently 0% fee), verify output matches input closely
+    function test_psmSwap_nearOneToOne() public {
+        _depositAndReport(DEPOSIT_AMOUNT);
+
+        uint256 profit = 1_000e6; // 1k USDC
+        _simulateProfit(profit);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        _clearMocks();
+
+        // PSM has 0% fee currently, so USDS output should be very close to USDC input
+        // USDC has 6 decimals, USDS has 18 decimals, so we need to scale
+        // 1 USDC (1e6) → 1 USDS (1e18) through PSM
+        // assetsOut is in USDS (18 decimals)
+        assertGt(assetsOut, 0, "PSM should produce nonzero USDS output");
+
+        // Receiver should have USDS, not USDC
+        assertGt(ERC20(USDS).balanceOf(receiver), 0, "Receiver should have USDS");
+    }
+
+    /// @notice Verify swapper immutables are correctly set
+    function test_psmSwapper_config() public view {
+        assertEq(psmSwapper.protocol(), LITE_PSM_WRAPPER);
+        assertEq(uint256(psmSwapper.route()), uint256(PSMSwapper.Route.SELL_GEM));
+        assertEq(psmSwapper.tokenIn(), MorphoTestConfig.USDC);
+        assertEq(psmSwapper.tokenOut(), USDS);
+    }
+}

--- a/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { UniswapV3SwapperAdapter } from "src/swappers/UniswapV3SwapperAdapter.sol";
+import { ISwapper } from "src/core/interfaces/ISwapper.sol";
+import { SwappingYieldForwarder } from "src/core/SwappingYieldForwarder.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { MorphoCompounderStrategyFactory } from "src/factories/MorphoCompounderStrategyFactory.sol";
+import { IBaseHealthCheck } from "src/strategies/interfaces/IBaseHealthCheck.sol";
+import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
+import { MorphoTestConfig } from "test/integration/strategies/config/MorphoTestConfig.sol";
+import { BaseSwapperIntegrationTest } from "./base/BaseSwapperIntegrationTest.sol";
+
+/// @title UniswapV3SwapperIntegration
+/// @notice Integration test: MorphoCompounder USDC profit → Uniswap V3 → WETH → receiver
+/// @dev Uses Uniswap V3 single-hop swap (USDC/WETH 0.05% pool) on mainnet fork
+contract UniswapV3SwapperIntegrationTest is BaseSwapperIntegrationTest {
+    // Uniswap V3 mainnet
+    address internal constant UNISWAP_V3_ROUTER = 0xE592427A0AEce92De3Edee1F18E0157C05861564;
+    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+
+    // 500 = 0.05% fee tier (USDC/WETH)
+    uint24 internal constant FEE = 500;
+
+    UniswapV3SwapperAdapter public uniswapSwapper;
+
+    function _targetAsset() internal pure override returns (address) {
+        return WETH;
+    }
+
+    function _deploySwapper() internal override returns (ISwapper) {
+        uniswapSwapper = new UniswapV3SwapperAdapter(
+            UNISWAP_V3_ROUTER,
+            FEE,
+            address(0), // no base token (direct swap)
+            0 // feeOut unused for direct swap
+        );
+        return ISwapper(address(uniswapSwapper));
+    }
+
+    function _labelSwapperAddresses() internal override {
+        vm.label(UNISWAP_V3_ROUTER, "UniswapV3Router");
+        vm.label(WETH, "WETH");
+    }
+
+    function setUp() public {
+        _baseSetUp();
+    }
+
+    // ========== NO-SWAP FALLBACK TESTS ==========
+
+    function test_reportAndForward_noSwap() public {
+        _test_reportAndForward_noSwap();
+    }
+
+    function test_reportAndForward_zeroProfit() public {
+        _test_reportAndForward_zeroProfit();
+    }
+
+    // ========== SWAP PATH TESTS (single-hop, no base) ==========
+
+    function test_reportSwapAndForward_fullFlow_UniswapV3() public {
+        _test_reportSwapAndForward_fullFlow();
+    }
+
+    function test_reportSwapAndForward_zeroProfit_UniswapV3() public {
+        _test_reportSwapAndForward_zeroProfit();
+    }
+
+    function test_reportSwapAndForward_multipleReports_UniswapV3() public {
+        _test_reportSwapAndForward_multipleReports();
+    }
+
+    function test_reportSwapAndForward_emitsEvent_UniswapV3() public {
+        _test_reportSwapAndForward_emitsEvent();
+    }
+
+    // ========== ACCESS CONTROL ==========
+
+    function test_onlyKeeper_reportAndForward_UniswapV3() public {
+        _test_onlyKeeper_reportAndForward();
+    }
+
+    function test_onlyKeeper_reportSwapAndForward_UniswapV3() public {
+        _test_onlyKeeper_reportSwapAndForward();
+    }
+
+    // ========== UNISWAP-SPECIFIC TESTS ==========
+
+    /// @notice Uniswap V3: USDC → WETH produces a market-rate WETH output
+    function test_uniswapSwap_producesWETH() public {
+        _depositAndReport(DEPOSIT_AMOUNT);
+
+        uint256 profit = 1_000e6;
+        _simulateProfit(profit);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        _clearMocks();
+
+        assertGt(assetsOut, 0, "Uniswap should produce nonzero WETH output");
+        assertGt(ERC20(WETH).balanceOf(receiver), 0, "Receiver should have WETH");
+    }
+
+    /// @notice Verify swapper immutables are correctly set
+    function test_uniswapSwapper_config() public view {
+        assertEq(uniswapSwapper.router(), UNISWAP_V3_ROUTER);
+        assertEq(uniswapSwapper.fee(), FEE);
+        assertEq(uniswapSwapper.base(), address(0));
+        assertEq(uniswapSwapper.feeOut(), 0);
+    }
+}
+
+/// @title UniswapV3MultiHopTest
+/// @notice Tests all three routing paths in UniswapV3SwapperAdapter on a mainnet fork
+/// @dev Standalone adapter tests (no forwarder) to exercise:
+///      1. Multi-hop:           USDC --(500)--> WETH --(3000)--> DAI
+///      2. tokenOut == base:    USDC --(500)--> WETH  (single-hop, uses fee)
+///      3. tokenIn == base:     WETH --(3000)--> DAI  (single-hop, uses feeOut)
+contract UniswapV3MultiHopTest is Test {
+    address internal constant UNISWAP_V3_ROUTER = 0xE592427A0AEce92De3Edee1F18E0157C05861564;
+    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+
+    uint24 internal constant FEE_USDC_WETH = 500; // 0.05%
+    uint24 internal constant FEE_WETH_DAI = 3000; // 0.3%
+
+    uint256 internal constant SWAP_AMOUNT_USDC = 10_000e6; // 10k USDC
+    uint256 internal constant SWAP_AMOUNT_WETH = 1e18; // 1 WETH
+
+    address internal swapReceiver = address(0xBEEF);
+    uint256 internal mainnetFork;
+
+    function setUp() public {
+        mainnetFork = vm.createFork("mainnet", MorphoTestConfig.FORK_BLOCK);
+        vm.selectFork(mainnetFork);
+
+        vm.label(UNISWAP_V3_ROUTER, "UniswapV3Router");
+        vm.label(WETH, "WETH");
+        vm.label(USDC, "USDC");
+        vm.label(DAI, "DAI");
+        vm.label(swapReceiver, "SwapReceiver");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // MULTI-HOP: USDC → WETH → DAI  (neither token is base)
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice Multi-hop swap: USDC → WETH → DAI via exactInput path encoding
+    function test_multiHop_USDC_WETH_DAI() public {
+        UniswapV3SwapperAdapter adapter = new UniswapV3SwapperAdapter(
+            UNISWAP_V3_ROUTER,
+            FEE_USDC_WETH, // fee: USDC → WETH
+            WETH, // base token
+            FEE_WETH_DAI // feeOut: WETH → DAI
+        );
+
+        deal(USDC, address(this), SWAP_AMOUNT_USDC);
+        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+
+        uint256 amountOut = adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, 0, swapReceiver);
+
+        assertGt(amountOut, 0, "Multi-hop should produce nonzero DAI");
+        assertEq(ERC20(DAI).balanceOf(swapReceiver), amountOut, "Receiver should get exact DAI output");
+        assertEq(ERC20(USDC).balanceOf(address(adapter)), 0, "Adapter should hold no USDC");
+    }
+
+    /// @notice Multi-hop with minAmountOut slippage protection
+    function test_multiHop_respectsMinAmountOut() public {
+        UniswapV3SwapperAdapter adapter = new UniswapV3SwapperAdapter(
+            UNISWAP_V3_ROUTER,
+            FEE_USDC_WETH,
+            WETH,
+            FEE_WETH_DAI
+        );
+
+        deal(USDC, address(this), SWAP_AMOUNT_USDC);
+        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+
+        // Unreasonably high minAmountOut should revert
+        vm.expectRevert();
+        adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, type(uint256).max, swapReceiver);
+    }
+
+    /// @notice Multi-hop config is correctly set
+    function test_multiHop_config() public {
+        UniswapV3SwapperAdapter adapter = new UniswapV3SwapperAdapter(
+            UNISWAP_V3_ROUTER,
+            FEE_USDC_WETH,
+            WETH,
+            FEE_WETH_DAI
+        );
+
+        assertEq(adapter.router(), UNISWAP_V3_ROUTER);
+        assertEq(adapter.fee(), FEE_USDC_WETH);
+        assertEq(adapter.base(), WETH);
+        assertEq(adapter.feeOut(), FEE_WETH_DAI);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SINGLE-HOP FALLBACK: tokenOut == base  (USDC → WETH)
+    // Uses `fee` for the pool
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice When tokenOut == base, falls back to single-hop using `fee`
+    function test_singleHop_tokenOutIsBase_USDC_WETH() public {
+        UniswapV3SwapperAdapter adapter = new UniswapV3SwapperAdapter(
+            UNISWAP_V3_ROUTER,
+            FEE_USDC_WETH, // fee: used for USDC → WETH
+            WETH, // base
+            FEE_WETH_DAI // feeOut: unused here
+        );
+
+        deal(USDC, address(this), SWAP_AMOUNT_USDC);
+        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+
+        uint256 amountOut = adapter.swap(USDC, WETH, SWAP_AMOUNT_USDC, 0, swapReceiver);
+
+        assertGt(amountOut, 0, "Single-hop (tokenOut==base) should produce nonzero WETH");
+        assertEq(ERC20(WETH).balanceOf(swapReceiver), amountOut, "Receiver should get exact WETH output");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SINGLE-HOP FALLBACK: tokenIn == base  (WETH → DAI)
+    // Uses `feeOut` for the pool
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice When tokenIn == base, falls back to single-hop using `feeOut`
+    function test_singleHop_tokenInIsBase_WETH_DAI() public {
+        UniswapV3SwapperAdapter adapter = new UniswapV3SwapperAdapter(
+            UNISWAP_V3_ROUTER,
+            FEE_USDC_WETH, // fee: unused here
+            WETH, // base
+            FEE_WETH_DAI // feeOut: used for WETH → DAI
+        );
+
+        deal(WETH, address(this), SWAP_AMOUNT_WETH);
+        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+
+        uint256 amountOut = adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, 0, swapReceiver);
+
+        assertGt(amountOut, 0, "Single-hop (tokenIn==base) should produce nonzero DAI");
+        assertEq(ERC20(DAI).balanceOf(swapReceiver), amountOut, "Receiver should get exact DAI output");
+    }
+
+    /// @notice Verify fee selection: tokenIn==base uses feeOut, not fee
+    /// @dev Deploy with an invalid fee for the first hop. If the adapter incorrectly
+    ///      uses `fee` instead of `feeOut`, the swap will revert because no pool exists
+    ///      at that fee tier.
+    function test_singleHop_tokenInIsBase_usesFeeOut_notFee() public {
+        UniswapV3SwapperAdapter adapter = new UniswapV3SwapperAdapter(
+            UNISWAP_V3_ROUTER,
+            10_000, // fee: intentionally wrong tier (1%) — should NOT be used
+            WETH,
+            FEE_WETH_DAI // feeOut: correct tier (0.3%) — should be used
+        );
+
+        deal(WETH, address(this), SWAP_AMOUNT_WETH);
+        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+
+        // Should succeed because it uses feeOut (3000), not fee (10000)
+        uint256 amountOut = adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, 0, swapReceiver);
+        assertGt(amountOut, 0, "Should use feeOut for tokenIn==base path");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // MULTI-HOP END-TO-END WITH FORWARDER
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice Full forwarder flow with multi-hop: strategy USDC profit → WETH → DAI → receiver
+    function test_forwarder_multiHop_USDC_WETH_DAI() public {
+        // Deploy full stack with multi-hop swapper
+        UniswapV3SwapperAdapter multiHopAdapter = new UniswapV3SwapperAdapter(
+            UNISWAP_V3_ROUTER,
+            FEE_USDC_WETH,
+            WETH,
+            FEE_WETH_DAI
+        );
+
+        // Deploy implementation + factory + strategy + forwarder
+        YieldDonatingTokenizedStrategy impl = new YieldDonatingTokenizedStrategy{
+            salt: keccak256("OCT_YIELD_SKIMMING_STRATEGY_V1")
+        }();
+        vm.etch(MorphoTestConfig.TOKENIZED_STRATEGY_ADDRESS, address(impl).code);
+
+        address mgmt = address(0xA1);
+        address keeper = address(0xCAFE);
+        address recv = address(0xBEEF);
+
+        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(multiHopAdapter));
+
+        MorphoCompounderStrategyFactory fac = new MorphoCompounderStrategyFactory{
+            salt: keccak256("OCT_MORPHO_COMPOUNDER_STRATEGY_VAULT_FACTORY_V1")
+        }();
+
+        vm.startPrank(mgmt);
+        address stratAddr = fac.createStrategy(
+            "MorphoCompounder Donating Strategy",
+            "osMORPHO",
+            mgmt,
+            address(fwd),
+            address(0xA3),
+            address(fwd),
+            false,
+            address(impl)
+        );
+        vm.stopPrank();
+
+        // Deposit
+        address usr = address(0x1234);
+        deal(USDC, usr, 100_000e6);
+        vm.startPrank(usr);
+        ERC20(USDC).approve(stratAddr, type(uint256).max);
+        IERC4626(stratAddr).deposit(100_000e6, usr);
+        vm.stopPrank();
+
+        // Initial report
+        vm.prank(mgmt);
+        IBaseHealthCheck(stratAddr).setDoHealthCheck(false);
+        vm.prank(address(fwd));
+        IMockStrategy(stratAddr).report();
+
+        // Simulate profit
+        uint256 morphoShares = IERC4626(MorphoTestConfig.MORPHO_VAULT).balanceOf(stratAddr);
+        uint256 currentAssets = IERC4626(MorphoTestConfig.MORPHO_VAULT).convertToAssets(morphoShares);
+        vm.mockCall(
+            MorphoTestConfig.MORPHO_VAULT,
+            abi.encodeWithSelector(IERC4626.convertToAssets.selector, morphoShares),
+            abi.encode(currentAssets + 1_000e6)
+        );
+        deal(USDC, stratAddr, 1_000e6);
+
+        // Report, swap (multi-hop USDC→WETH→DAI), forward
+        vm.prank(keeper);
+        uint256 daiOut = fwd.reportSwapAndForward(stratAddr, 10_000, 0);
+        vm.clearMockedCalls();
+
+        assertGt(daiOut, 0, "Multi-hop through forwarder should produce DAI");
+        assertEq(ERC20(DAI).balanceOf(recv), daiOut, "Receiver should get DAI via multi-hop");
+    }
+}

--- a/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
@@ -129,20 +129,20 @@ contract UniswapV4SwapperIntegrationTest is BaseSwapperIntegrationTest {
 /// @title UniswapV4MultiHopTest
 /// @notice Tests all three routing paths in UniswapV4SwapperAdapter on a mainnet fork
 /// @dev Standalone adapter tests (no forwarder) to exercise:
-///      1. Multi-hop:           USDC --(3000/60)--> WETH --(3000/60)--> DAI
+///      1. Multi-hop:           USDC --(3000/60)--> WETH --(3000/60)--> LINK
 ///      2. tokenOut == base:    USDC --(3000/60)--> WETH  (single-hop, uses fee/tickSpacing)
-///      3. tokenIn == base:     WETH --(3000/60)--> DAI   (single-hop, uses feeOut/tickSpacingOut)
+///      3. tokenIn == base:     WETH --(3000/60)--> LINK  (single-hop, uses feeOut/tickSpacingOut)
 contract UniswapV4MultiHopTest is Test {
     address internal constant V4_POOL_MANAGER = 0x000000000004444c5dc75cB358380D2e3dE08A90;
+    address internal constant LINK = 0x514910771AF9Ca656af840dff83E8264EcF986CA;
     address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
-    address internal constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
 
-    // Pool params: USDC/WETH and WETH/DAI
+    // Pool params: USDC/WETH (first hop) and LINK/WETH (second hop)
     uint24 internal constant FEE_USDC_WETH = 3000; // 0.3%
     int24 internal constant TS_USDC_WETH = 60;
-    uint24 internal constant FEE_WETH_DAI = 3000; // 0.3%
-    int24 internal constant TS_WETH_DAI = 60;
+    uint24 internal constant FEE_LINK_WETH = 3000; // 0.3%
+    int24 internal constant TS_LINK_WETH = 60;
 
     uint256 internal constant SWAP_AMOUNT_USDC = 10_000e6; // 10k USDC
     uint256 internal constant SWAP_AMOUNT_WETH = 1e18; // 1 WETH
@@ -155,17 +155,17 @@ contract UniswapV4MultiHopTest is Test {
         vm.selectFork(mainnetFork);
 
         vm.label(V4_POOL_MANAGER, "V4PoolManager");
+        vm.label(LINK, "LINK");
         vm.label(WETH, "WETH");
         vm.label(USDC, "USDC");
-        vm.label(DAI, "DAI");
         vm.label(swapReceiver, "SwapReceiver");
     }
 
     // ═══════════════════════════════════════════════════════════
-    // MULTI-HOP: USDC → WETH → DAI (neither token is base)
+    // MULTI-HOP: USDC → WETH → LINK (neither token is base)
     // ═══════════════════════════════════════════════════════════
 
-    /// @notice Multi-hop swap: USDC → WETH → DAI via two V4 pools
+    /// @notice Multi-hop swap: USDC → WETH → LINK via two V4 pools
     function test_multiHop_USDC_WETH_DAI() public {
         UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
             V4_POOL_MANAGER,
@@ -173,18 +173,18 @@ contract UniswapV4MultiHopTest is Test {
             TS_USDC_WETH,
             address(0), // hooks
             WETH, // base
-            FEE_WETH_DAI,
-            TS_WETH_DAI,
+            FEE_LINK_WETH,
+            TS_LINK_WETH,
             address(0) // hooksOut
         );
 
         deal(USDC, address(this), SWAP_AMOUNT_USDC);
         IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
 
-        uint256 amountOut = adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, 0, swapReceiver);
+        uint256 amountOut = adapter.swap(USDC, LINK, SWAP_AMOUNT_USDC, 0, swapReceiver);
 
-        assertGt(amountOut, 0, "Multi-hop should produce nonzero DAI");
-        assertEq(ERC20(DAI).balanceOf(swapReceiver), amountOut, "Receiver should get exact DAI output");
+        assertGt(amountOut, 0, "Multi-hop should produce nonzero LINK");
+        assertEq(ERC20(LINK).balanceOf(swapReceiver), amountOut, "Receiver should get exact LINK output");
         assertEq(ERC20(USDC).balanceOf(address(adapter)), 0, "Adapter should hold no USDC");
     }
 
@@ -196,8 +196,8 @@ contract UniswapV4MultiHopTest is Test {
             TS_USDC_WETH,
             address(0),
             WETH,
-            FEE_WETH_DAI,
-            TS_WETH_DAI,
+            FEE_LINK_WETH,
+            TS_LINK_WETH,
             address(0)
         );
 
@@ -206,7 +206,7 @@ contract UniswapV4MultiHopTest is Test {
 
         // Unreasonably high minAmountOut should revert
         vm.expectRevert();
-        adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, type(uint256).max, swapReceiver);
+        adapter.swap(USDC, LINK, SWAP_AMOUNT_USDC, type(uint256).max, swapReceiver);
     }
 
     /// @notice Multi-hop config is correctly set
@@ -217,8 +217,8 @@ contract UniswapV4MultiHopTest is Test {
             TS_USDC_WETH,
             address(0),
             WETH,
-            FEE_WETH_DAI,
-            TS_WETH_DAI,
+            FEE_LINK_WETH,
+            TS_LINK_WETH,
             address(0)
         );
 
@@ -226,8 +226,8 @@ contract UniswapV4MultiHopTest is Test {
         assertEq(adapter.fee(), FEE_USDC_WETH);
         assertEq(adapter.tickSpacing(), TS_USDC_WETH);
         assertEq(adapter.base(), WETH);
-        assertEq(adapter.feeOut(), FEE_WETH_DAI);
-        assertEq(adapter.tickSpacingOut(), TS_WETH_DAI);
+        assertEq(adapter.feeOut(), FEE_LINK_WETH);
+        assertEq(adapter.tickSpacingOut(), TS_LINK_WETH);
     }
 
     // ═══════════════════════════════════════════════════════════
@@ -243,8 +243,8 @@ contract UniswapV4MultiHopTest is Test {
             TS_USDC_WETH,
             address(0), // hooks
             WETH, // base
-            FEE_WETH_DAI,
-            TS_WETH_DAI,
+            FEE_LINK_WETH,
+            TS_LINK_WETH,
             address(0) // hooksOut
         );
 
@@ -258,7 +258,7 @@ contract UniswapV4MultiHopTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════
-    // SINGLE-HOP FALLBACK: tokenIn == base (WETH → DAI)
+    // SINGLE-HOP FALLBACK: tokenIn == base (WETH → LINK)
     // Uses `feeOut`/`tickSpacingOut` for the pool
     // ═══════════════════════════════════════════════════════════
 
@@ -270,18 +270,18 @@ contract UniswapV4MultiHopTest is Test {
             TS_USDC_WETH,
             address(0),
             WETH,
-            FEE_WETH_DAI,
-            TS_WETH_DAI,
+            FEE_LINK_WETH,
+            TS_LINK_WETH,
             address(0)
         );
 
         deal(WETH, address(this), SWAP_AMOUNT_WETH);
         IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
 
-        uint256 amountOut = adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, 0, swapReceiver);
+        uint256 amountOut = adapter.swap(WETH, LINK, SWAP_AMOUNT_WETH, 0, swapReceiver);
 
-        assertGt(amountOut, 0, "Single-hop (tokenIn==base) should produce nonzero DAI");
-        assertEq(ERC20(DAI).balanceOf(swapReceiver), amountOut, "Receiver should get exact DAI output");
+        assertGt(amountOut, 0, "Single-hop (tokenIn==base) should produce nonzero LINK");
+        assertEq(ERC20(LINK).balanceOf(swapReceiver), amountOut, "Receiver should get exact LINK output");
     }
 
     /// @notice Verify fee selection: tokenIn==base uses feeOut/tickSpacingOut, not fee/tickSpacing
@@ -294,8 +294,8 @@ contract UniswapV4MultiHopTest is Test {
             200, // tickSpacing: intentionally wrong — should NOT be used
             address(0),
             WETH,
-            FEE_WETH_DAI, // feeOut: correct — should be used
-            TS_WETH_DAI, // tickSpacingOut: correct — should be used
+            FEE_LINK_WETH, // feeOut: correct — should be used
+            TS_LINK_WETH, // tickSpacingOut: correct — should be used
             address(0)
         );
 
@@ -303,7 +303,7 @@ contract UniswapV4MultiHopTest is Test {
         IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
 
         // Should succeed because it uses feeOut/tickSpacingOut, not fee/tickSpacing
-        uint256 amountOut = adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, 0, swapReceiver);
+        uint256 amountOut = adapter.swap(WETH, LINK, SWAP_AMOUNT_WETH, 0, swapReceiver);
         assertGt(amountOut, 0, "Should use feeOut for tokenIn==base path");
     }
 
@@ -311,17 +311,17 @@ contract UniswapV4MultiHopTest is Test {
     // MULTI-HOP END-TO-END WITH FORWARDER
     // ═══════════════════════════════════════════════════════════
 
-    /// @notice Full forwarder flow with multi-hop: strategy USDC profit → WETH → DAI → receiver
+    /// @notice Full forwarder flow with multi-hop: strategy USDC profit → WETH → LINK → receiver
     function test_forwarder_multiHop_USDC_WETH_DAI() public {
-        // Deploy full stack with multi-hop swapper
+        // Deploy full stack with multi-hop swapper (USDC→WETH→LINK)
         UniswapV4SwapperAdapter multiHopAdapter = new UniswapV4SwapperAdapter(
             V4_POOL_MANAGER,
             FEE_USDC_WETH,
             TS_USDC_WETH,
             address(0),
             WETH,
-            FEE_WETH_DAI,
-            TS_WETH_DAI,
+            FEE_LINK_WETH,
+            TS_LINK_WETH,
             address(0)
         );
 
@@ -335,7 +335,7 @@ contract UniswapV4MultiHopTest is Test {
         address keeper = address(0xCAFE);
         address recv = address(0xBEEF);
 
-        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(multiHopAdapter));
+        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, LINK, address(multiHopAdapter));
 
         MorphoCompounderStrategyFactory fac = new MorphoCompounderStrategyFactory{
             salt: keccak256("OCT_MORPHO_COMPOUNDER_STRATEGY_VAULT_FACTORY_V1")
@@ -378,12 +378,12 @@ contract UniswapV4MultiHopTest is Test {
         );
         deal(USDC, stratAddr, 1_000e6);
 
-        // Report, swap (multi-hop USDC→WETH→DAI via V4), forward
+        // Report, swap (multi-hop USDC→WETH→LINK via V4), forward
         vm.prank(keeper);
-        uint256 daiOut = fwd.reportSwapAndForward(stratAddr, 10_000, 0);
+        uint256 wbtcOut = fwd.reportSwapAndForward(stratAddr, 10_000, 0);
         vm.clearMockedCalls();
 
-        assertGt(daiOut, 0, "Multi-hop through forwarder should produce DAI");
-        assertEq(ERC20(DAI).balanceOf(recv), daiOut, "Receiver should get DAI via multi-hop");
+        assertGt(wbtcOut, 0, "Multi-hop through forwarder should produce LINK");
+        assertEq(ERC20(LINK).balanceOf(recv), wbtcOut, "Receiver should get LINK via multi-hop");
     }
 }

--- a/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
@@ -191,7 +191,14 @@ contract UniswapV4MultiHopTest is Test {
     /// @notice Multi-hop with minAmountOut slippage protection
     function test_multiHop_respectsMinAmountOut() public {
         UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
-            V4_POOL_MANAGER, FEE_USDC_WETH, TS_USDC_WETH, address(0), WETH, FEE_WETH_DAI, TS_WETH_DAI, address(0)
+            V4_POOL_MANAGER,
+            FEE_USDC_WETH,
+            TS_USDC_WETH,
+            address(0),
+            WETH,
+            FEE_WETH_DAI,
+            TS_WETH_DAI,
+            address(0)
         );
 
         deal(USDC, address(this), SWAP_AMOUNT_USDC);
@@ -205,7 +212,14 @@ contract UniswapV4MultiHopTest is Test {
     /// @notice Multi-hop config is correctly set
     function test_multiHop_config() public {
         UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
-            V4_POOL_MANAGER, FEE_USDC_WETH, TS_USDC_WETH, address(0), WETH, FEE_WETH_DAI, TS_WETH_DAI, address(0)
+            V4_POOL_MANAGER,
+            FEE_USDC_WETH,
+            TS_USDC_WETH,
+            address(0),
+            WETH,
+            FEE_WETH_DAI,
+            TS_WETH_DAI,
+            address(0)
         );
 
         assertEq(adapter.poolManager(), V4_POOL_MANAGER);
@@ -301,12 +315,20 @@ contract UniswapV4MultiHopTest is Test {
     function test_forwarder_multiHop_USDC_WETH_DAI() public {
         // Deploy full stack with multi-hop swapper
         UniswapV4SwapperAdapter multiHopAdapter = new UniswapV4SwapperAdapter(
-            V4_POOL_MANAGER, FEE_USDC_WETH, TS_USDC_WETH, address(0), WETH, FEE_WETH_DAI, TS_WETH_DAI, address(0)
+            V4_POOL_MANAGER,
+            FEE_USDC_WETH,
+            TS_USDC_WETH,
+            address(0),
+            WETH,
+            FEE_WETH_DAI,
+            TS_WETH_DAI,
+            address(0)
         );
 
         // Deploy implementation + factory + strategy + forwarder
-        YieldDonatingTokenizedStrategy impl =
-            new YieldDonatingTokenizedStrategy{ salt: keccak256("OCT_YIELD_SKIMMING_STRATEGY_V1") }();
+        YieldDonatingTokenizedStrategy impl = new YieldDonatingTokenizedStrategy{
+            salt: keccak256("OCT_YIELD_SKIMMING_STRATEGY_V1")
+        }();
         vm.etch(MorphoTestConfig.TOKENIZED_STRATEGY_ADDRESS, address(impl).code);
 
         address mgmt = address(0xA1);
@@ -315,8 +337,9 @@ contract UniswapV4MultiHopTest is Test {
 
         SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(multiHopAdapter));
 
-        MorphoCompounderStrategyFactory fac =
-            new MorphoCompounderStrategyFactory{ salt: keccak256("OCT_MORPHO_COMPOUNDER_STRATEGY_VAULT_FACTORY_V1") }();
+        MorphoCompounderStrategyFactory fac = new MorphoCompounderStrategyFactory{
+            salt: keccak256("OCT_MORPHO_COMPOUNDER_STRATEGY_VAULT_FACTORY_V1")
+        }();
 
         vm.startPrank(mgmt);
         address stratAddr = fac.createStrategy(

--- a/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+
+import { UniswapV4SwapperAdapter, IV4PoolManager } from "src/swappers/UniswapV4SwapperAdapter.sol";
+import { ISwapper } from "src/core/interfaces/ISwapper.sol";
+import { SwappingYieldForwarder } from "src/core/SwappingYieldForwarder.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { MorphoCompounderStrategyFactory } from "src/factories/MorphoCompounderStrategyFactory.sol";
+import { IBaseHealthCheck } from "src/strategies/interfaces/IBaseHealthCheck.sol";
+import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
+import { MorphoTestConfig } from "test/integration/strategies/config/MorphoTestConfig.sol";
+import { BaseSwapperIntegrationTest } from "./base/BaseSwapperIntegrationTest.sol";
+
+/// @title UniswapV4SwapperIntegrationTest
+/// @notice Integration test: MorphoCompounder USDC profit → Uniswap V4 → WETH → receiver
+/// @dev Uses Uniswap V4 single-hop swap (USDC/WETH pool) on mainnet fork.
+///      Pool parameters (fee/tickSpacing) must match an existing V4 pool at the fork block.
+contract UniswapV4SwapperIntegrationTest is BaseSwapperIntegrationTest {
+    // Uniswap V4 mainnet
+    address internal constant V4_POOL_MANAGER = 0x000000000004444c5dc75cB358380D2e3dE08A90;
+    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+
+    // Pool parameters for USDC/WETH on V4
+    // These must match an initialized pool on mainnet at the fork block
+    uint24 internal constant FEE = 3000; // 0.3%
+    int24 internal constant TICK_SPACING = 60;
+    address internal constant HOOKS = address(0); // no hooks
+
+    UniswapV4SwapperAdapter public uniswapV4Swapper;
+
+    function _targetAsset() internal pure override returns (address) {
+        return WETH;
+    }
+
+    function _deploySwapper() internal override returns (ISwapper) {
+        uniswapV4Swapper = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER,
+            FEE,
+            TICK_SPACING,
+            HOOKS,
+            address(0), // no base token (direct swap)
+            0, // feeOut unused
+            0, // tickSpacingOut unused
+            address(0) // hooksOut unused
+        );
+        return ISwapper(address(uniswapV4Swapper));
+    }
+
+    function _labelSwapperAddresses() internal override {
+        vm.label(V4_POOL_MANAGER, "V4PoolManager");
+        vm.label(WETH, "WETH");
+    }
+
+    function setUp() public {
+        _baseSetUp();
+    }
+
+    // ========== NO-SWAP FALLBACK TESTS ==========
+
+    function test_reportAndForward_noSwap() public {
+        _test_reportAndForward_noSwap();
+    }
+
+    function test_reportAndForward_zeroProfit() public {
+        _test_reportAndForward_zeroProfit();
+    }
+
+    // ========== SWAP PATH TESTS (single-hop via V4) ==========
+
+    function test_reportSwapAndForward_fullFlow_UniswapV4() public {
+        _test_reportSwapAndForward_fullFlow();
+    }
+
+    function test_reportSwapAndForward_zeroProfit_UniswapV4() public {
+        _test_reportSwapAndForward_zeroProfit();
+    }
+
+    function test_reportSwapAndForward_multipleReports_UniswapV4() public {
+        _test_reportSwapAndForward_multipleReports();
+    }
+
+    function test_reportSwapAndForward_emitsEvent_UniswapV4() public {
+        _test_reportSwapAndForward_emitsEvent();
+    }
+
+    // ========== ACCESS CONTROL ==========
+
+    function test_onlyKeeper_reportAndForward_UniswapV4() public {
+        _test_onlyKeeper_reportAndForward();
+    }
+
+    function test_onlyKeeper_reportSwapAndForward_UniswapV4() public {
+        _test_onlyKeeper_reportSwapAndForward();
+    }
+
+    // ========== V4-SPECIFIC TESTS ==========
+
+    /// @notice V4: USDC → WETH produces a market-rate WETH output
+    function test_v4Swap_producesWETH() public {
+        _depositAndReport(DEPOSIT_AMOUNT);
+
+        uint256 profit = 1_000e6;
+        _simulateProfit(profit);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        _clearMocks();
+
+        assertGt(assetsOut, 0, "V4 should produce nonzero WETH output");
+        assertGt(ERC20(WETH).balanceOf(receiver), 0, "Receiver should have WETH");
+    }
+
+    /// @notice Verify swapper immutables are correctly set
+    function test_v4Swapper_config() public view {
+        assertEq(uniswapV4Swapper.poolManager(), V4_POOL_MANAGER);
+        assertEq(uniswapV4Swapper.fee(), FEE);
+        assertEq(uniswapV4Swapper.tickSpacing(), TICK_SPACING);
+        assertEq(uniswapV4Swapper.hooks(), HOOKS);
+        assertEq(uniswapV4Swapper.base(), address(0));
+    }
+}
+
+/// @title UniswapV4MultiHopTest
+/// @notice Tests all three routing paths in UniswapV4SwapperAdapter on a mainnet fork
+/// @dev Standalone adapter tests (no forwarder) to exercise:
+///      1. Multi-hop:           USDC --(3000/60)--> WETH --(3000/60)--> DAI
+///      2. tokenOut == base:    USDC --(3000/60)--> WETH  (single-hop, uses fee/tickSpacing)
+///      3. tokenIn == base:     WETH --(3000/60)--> DAI   (single-hop, uses feeOut/tickSpacingOut)
+contract UniswapV4MultiHopTest is Test {
+    address internal constant V4_POOL_MANAGER = 0x000000000004444c5dc75cB358380D2e3dE08A90;
+    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+    address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+
+    // Pool params: USDC/WETH and WETH/DAI
+    uint24 internal constant FEE_USDC_WETH = 3000; // 0.3%
+    int24 internal constant TS_USDC_WETH = 60;
+    uint24 internal constant FEE_WETH_DAI = 3000; // 0.3%
+    int24 internal constant TS_WETH_DAI = 60;
+
+    uint256 internal constant SWAP_AMOUNT_USDC = 10_000e6; // 10k USDC
+    uint256 internal constant SWAP_AMOUNT_WETH = 1e18; // 1 WETH
+
+    address internal swapReceiver = address(0xBEEF);
+    uint256 internal mainnetFork;
+
+    function setUp() public {
+        mainnetFork = vm.createFork("mainnet", MorphoTestConfig.FORK_BLOCK);
+        vm.selectFork(mainnetFork);
+
+        vm.label(V4_POOL_MANAGER, "V4PoolManager");
+        vm.label(WETH, "WETH");
+        vm.label(USDC, "USDC");
+        vm.label(DAI, "DAI");
+        vm.label(swapReceiver, "SwapReceiver");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // MULTI-HOP: USDC → WETH → DAI (neither token is base)
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice Multi-hop swap: USDC → WETH → DAI via two V4 pools
+    function test_multiHop_USDC_WETH_DAI() public {
+        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER,
+            FEE_USDC_WETH,
+            TS_USDC_WETH,
+            address(0), // hooks
+            WETH, // base
+            FEE_WETH_DAI,
+            TS_WETH_DAI,
+            address(0) // hooksOut
+        );
+
+        deal(USDC, address(this), SWAP_AMOUNT_USDC);
+        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+
+        uint256 amountOut = adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, 0, swapReceiver);
+
+        assertGt(amountOut, 0, "Multi-hop should produce nonzero DAI");
+        assertEq(ERC20(DAI).balanceOf(swapReceiver), amountOut, "Receiver should get exact DAI output");
+        assertEq(ERC20(USDC).balanceOf(address(adapter)), 0, "Adapter should hold no USDC");
+    }
+
+    /// @notice Multi-hop with minAmountOut slippage protection
+    function test_multiHop_respectsMinAmountOut() public {
+        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER, FEE_USDC_WETH, TS_USDC_WETH, address(0), WETH, FEE_WETH_DAI, TS_WETH_DAI, address(0)
+        );
+
+        deal(USDC, address(this), SWAP_AMOUNT_USDC);
+        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+
+        // Unreasonably high minAmountOut should revert
+        vm.expectRevert();
+        adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, type(uint256).max, swapReceiver);
+    }
+
+    /// @notice Multi-hop config is correctly set
+    function test_multiHop_config() public {
+        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER, FEE_USDC_WETH, TS_USDC_WETH, address(0), WETH, FEE_WETH_DAI, TS_WETH_DAI, address(0)
+        );
+
+        assertEq(adapter.poolManager(), V4_POOL_MANAGER);
+        assertEq(adapter.fee(), FEE_USDC_WETH);
+        assertEq(adapter.tickSpacing(), TS_USDC_WETH);
+        assertEq(adapter.base(), WETH);
+        assertEq(adapter.feeOut(), FEE_WETH_DAI);
+        assertEq(adapter.tickSpacingOut(), TS_WETH_DAI);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SINGLE-HOP FALLBACK: tokenOut == base (USDC → WETH)
+    // Uses `fee`/`tickSpacing` for the pool
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice When tokenOut == base, falls back to single-hop using fee/tickSpacing
+    function test_singleHop_tokenOutIsBase_USDC_WETH() public {
+        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER,
+            FEE_USDC_WETH,
+            TS_USDC_WETH,
+            address(0), // hooks
+            WETH, // base
+            FEE_WETH_DAI,
+            TS_WETH_DAI,
+            address(0) // hooksOut
+        );
+
+        deal(USDC, address(this), SWAP_AMOUNT_USDC);
+        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+
+        uint256 amountOut = adapter.swap(USDC, WETH, SWAP_AMOUNT_USDC, 0, swapReceiver);
+
+        assertGt(amountOut, 0, "Single-hop (tokenOut==base) should produce nonzero WETH");
+        assertEq(ERC20(WETH).balanceOf(swapReceiver), amountOut, "Receiver should get exact WETH output");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SINGLE-HOP FALLBACK: tokenIn == base (WETH → DAI)
+    // Uses `feeOut`/`tickSpacingOut` for the pool
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice When tokenIn == base, falls back to single-hop using feeOut/tickSpacingOut
+    function test_singleHop_tokenInIsBase_WETH_DAI() public {
+        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER,
+            FEE_USDC_WETH,
+            TS_USDC_WETH,
+            address(0),
+            WETH,
+            FEE_WETH_DAI,
+            TS_WETH_DAI,
+            address(0)
+        );
+
+        deal(WETH, address(this), SWAP_AMOUNT_WETH);
+        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+
+        uint256 amountOut = adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, 0, swapReceiver);
+
+        assertGt(amountOut, 0, "Single-hop (tokenIn==base) should produce nonzero DAI");
+        assertEq(ERC20(DAI).balanceOf(swapReceiver), amountOut, "Receiver should get exact DAI output");
+    }
+
+    /// @notice Verify fee selection: tokenIn==base uses feeOut/tickSpacingOut, not fee/tickSpacing
+    /// @dev Deploy with invalid first-hop params. If the adapter incorrectly uses fee/tickSpacing
+    ///      instead of feeOut/tickSpacingOut, the swap will revert because no pool exists.
+    function test_singleHop_tokenInIsBase_usesFeeOut_notFee() public {
+        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER,
+            10_000, // fee: intentionally wrong — should NOT be used
+            200, // tickSpacing: intentionally wrong — should NOT be used
+            address(0),
+            WETH,
+            FEE_WETH_DAI, // feeOut: correct — should be used
+            TS_WETH_DAI, // tickSpacingOut: correct — should be used
+            address(0)
+        );
+
+        deal(WETH, address(this), SWAP_AMOUNT_WETH);
+        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+
+        // Should succeed because it uses feeOut/tickSpacingOut, not fee/tickSpacing
+        uint256 amountOut = adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, 0, swapReceiver);
+        assertGt(amountOut, 0, "Should use feeOut for tokenIn==base path");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // MULTI-HOP END-TO-END WITH FORWARDER
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice Full forwarder flow with multi-hop: strategy USDC profit → WETH → DAI → receiver
+    function test_forwarder_multiHop_USDC_WETH_DAI() public {
+        // Deploy full stack with multi-hop swapper
+        UniswapV4SwapperAdapter multiHopAdapter = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER, FEE_USDC_WETH, TS_USDC_WETH, address(0), WETH, FEE_WETH_DAI, TS_WETH_DAI, address(0)
+        );
+
+        // Deploy implementation + factory + strategy + forwarder
+        YieldDonatingTokenizedStrategy impl =
+            new YieldDonatingTokenizedStrategy{ salt: keccak256("OCT_YIELD_SKIMMING_STRATEGY_V1") }();
+        vm.etch(MorphoTestConfig.TOKENIZED_STRATEGY_ADDRESS, address(impl).code);
+
+        address mgmt = address(0xA1);
+        address keeper = address(0xCAFE);
+        address recv = address(0xBEEF);
+
+        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(multiHopAdapter));
+
+        MorphoCompounderStrategyFactory fac =
+            new MorphoCompounderStrategyFactory{ salt: keccak256("OCT_MORPHO_COMPOUNDER_STRATEGY_VAULT_FACTORY_V1") }();
+
+        vm.startPrank(mgmt);
+        address stratAddr = fac.createStrategy(
+            "MorphoCompounder Donating Strategy",
+            "osMORPHO",
+            mgmt,
+            address(fwd),
+            address(0xA3),
+            address(fwd),
+            false,
+            address(impl)
+        );
+        vm.stopPrank();
+
+        // Deposit
+        address usr = address(0x1234);
+        deal(USDC, usr, 100_000e6);
+        vm.startPrank(usr);
+        ERC20(USDC).approve(stratAddr, type(uint256).max);
+        IERC4626(stratAddr).deposit(100_000e6, usr);
+        vm.stopPrank();
+
+        // Initial report
+        vm.prank(mgmt);
+        IBaseHealthCheck(stratAddr).setDoHealthCheck(false);
+        vm.prank(address(fwd));
+        IMockStrategy(stratAddr).report();
+
+        // Simulate profit
+        uint256 morphoShares = IERC4626(MorphoTestConfig.MORPHO_VAULT).balanceOf(stratAddr);
+        uint256 currentAssets = IERC4626(MorphoTestConfig.MORPHO_VAULT).convertToAssets(morphoShares);
+        vm.mockCall(
+            MorphoTestConfig.MORPHO_VAULT,
+            abi.encodeWithSelector(IERC4626.convertToAssets.selector, morphoShares),
+            abi.encode(currentAssets + 1_000e6)
+        );
+        deal(USDC, stratAddr, 1_000e6);
+
+        // Report, swap (multi-hop USDC→WETH→DAI via V4), forward
+        vm.prank(keeper);
+        uint256 daiOut = fwd.reportSwapAndForward(stratAddr, 10_000, 0);
+        vm.clearMockedCalls();
+
+        assertGt(daiOut, 0, "Multi-hop through forwarder should produce DAI");
+        assertEq(ERC20(DAI).balanceOf(recv), daiOut, "Receiver should get DAI via multi-hop");
+    }
+}

--- a/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
@@ -129,20 +129,20 @@ contract UniswapV4SwapperIntegrationTest is BaseSwapperIntegrationTest {
 /// @title UniswapV4MultiHopTest
 /// @notice Tests all three routing paths in UniswapV4SwapperAdapter on a mainnet fork
 /// @dev Standalone adapter tests (no forwarder) to exercise:
-///      1. Multi-hop:           USDC --(3000/60)--> WETH --(3000/60)--> LINK
-///      2. tokenOut == base:    USDC --(3000/60)--> WETH  (single-hop, uses fee/tickSpacing)
-///      3. tokenIn == base:     WETH --(3000/60)--> LINK  (single-hop, uses feeOut/tickSpacingOut)
+///      1. Multi-hop:           WETH --(3000/60)--> USDC --(100/1)--> DAI
+///      2. tokenOut == base:    WETH --(3000/60)--> USDC  (single-hop, uses fee/tickSpacing)
+///      3. tokenIn == base:     USDC --(100/1)---> DAI   (single-hop, uses feeOut/tickSpacingOut)
 contract UniswapV4MultiHopTest is Test {
     address internal constant V4_POOL_MANAGER = 0x000000000004444c5dc75cB358380D2e3dE08A90;
-    address internal constant LINK = 0x514910771AF9Ca656af840dff83E8264EcF986CA;
     address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
     address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+    address internal constant DAI = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
 
-    // Pool params: USDC/WETH (first hop) and LINK/WETH (second hop)
-    uint24 internal constant FEE_USDC_WETH = 3000; // 0.3%
-    int24 internal constant TS_USDC_WETH = 60;
-    uint24 internal constant FEE_LINK_WETH = 3000; // 0.3%
-    int24 internal constant TS_LINK_WETH = 60;
+    // Pool params: WETH/USDC (first hop) and USDC/DAI (second hop)
+    uint24 internal constant FEE_WETH_USDC = 3000; // 0.3%
+    int24 internal constant TS_WETH_USDC = 60;
+    uint24 internal constant FEE_USDC_DAI = 100; // 0.01%
+    int24 internal constant TS_USDC_DAI = 1;
 
     uint256 internal constant SWAP_AMOUNT_USDC = 10_000e6; // 10k USDC
     uint256 internal constant SWAP_AMOUNT_WETH = 1e18; // 1 WETH
@@ -155,133 +155,133 @@ contract UniswapV4MultiHopTest is Test {
         vm.selectFork(mainnetFork);
 
         vm.label(V4_POOL_MANAGER, "V4PoolManager");
-        vm.label(LINK, "LINK");
         vm.label(WETH, "WETH");
         vm.label(USDC, "USDC");
+        vm.label(DAI, "DAI");
         vm.label(swapReceiver, "SwapReceiver");
     }
 
     // ═══════════════════════════════════════════════════════════
-    // MULTI-HOP: USDC → WETH → LINK (neither token is base)
+    // MULTI-HOP: WETH → USDC → DAI (neither token is base)
     // ═══════════════════════════════════════════════════════════
 
-    /// @notice Multi-hop swap: USDC → WETH → LINK via two V4 pools
-    function test_multiHop_USDC_WETH_DAI() public {
+    /// @notice Multi-hop swap: WETH → USDC → DAI via two V4 pools
+    function test_multiHop_WETH_USDC_DAI() public {
         UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
             V4_POOL_MANAGER,
-            FEE_USDC_WETH,
-            TS_USDC_WETH,
+            FEE_WETH_USDC,
+            TS_WETH_USDC,
             address(0), // hooks
-            WETH, // base
-            FEE_LINK_WETH,
-            TS_LINK_WETH,
+            USDC, // base
+            FEE_USDC_DAI,
+            TS_USDC_DAI,
             address(0) // hooksOut
         );
 
-        deal(USDC, address(this), SWAP_AMOUNT_USDC);
-        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+        deal(WETH, address(this), SWAP_AMOUNT_WETH);
+        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
 
-        uint256 amountOut = adapter.swap(USDC, LINK, SWAP_AMOUNT_USDC, 0, swapReceiver);
+        uint256 amountOut = adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, 0, swapReceiver);
 
-        assertGt(amountOut, 0, "Multi-hop should produce nonzero LINK");
-        assertEq(ERC20(LINK).balanceOf(swapReceiver), amountOut, "Receiver should get exact LINK output");
-        assertEq(ERC20(USDC).balanceOf(address(adapter)), 0, "Adapter should hold no USDC");
+        assertGt(amountOut, 0, "Multi-hop should produce nonzero DAI");
+        assertEq(ERC20(DAI).balanceOf(swapReceiver), amountOut, "Receiver should get exact DAI output");
+        assertEq(ERC20(WETH).balanceOf(address(adapter)), 0, "Adapter should hold no WETH");
     }
 
     /// @notice Multi-hop with minAmountOut slippage protection
     function test_multiHop_respectsMinAmountOut() public {
         UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
             V4_POOL_MANAGER,
-            FEE_USDC_WETH,
-            TS_USDC_WETH,
+            FEE_WETH_USDC,
+            TS_WETH_USDC,
             address(0),
-            WETH,
-            FEE_LINK_WETH,
-            TS_LINK_WETH,
-            address(0)
-        );
-
-        deal(USDC, address(this), SWAP_AMOUNT_USDC);
-        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
-
-        // Unreasonably high minAmountOut should revert
-        vm.expectRevert();
-        adapter.swap(USDC, LINK, SWAP_AMOUNT_USDC, type(uint256).max, swapReceiver);
-    }
-
-    /// @notice Multi-hop config is correctly set
-    function test_multiHop_config() public {
-        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
-            V4_POOL_MANAGER,
-            FEE_USDC_WETH,
-            TS_USDC_WETH,
-            address(0),
-            WETH,
-            FEE_LINK_WETH,
-            TS_LINK_WETH,
-            address(0)
-        );
-
-        assertEq(adapter.poolManager(), V4_POOL_MANAGER);
-        assertEq(adapter.fee(), FEE_USDC_WETH);
-        assertEq(adapter.tickSpacing(), TS_USDC_WETH);
-        assertEq(adapter.base(), WETH);
-        assertEq(adapter.feeOut(), FEE_LINK_WETH);
-        assertEq(adapter.tickSpacingOut(), TS_LINK_WETH);
-    }
-
-    // ═══════════════════════════════════════════════════════════
-    // SINGLE-HOP FALLBACK: tokenOut == base (USDC → WETH)
-    // Uses `fee`/`tickSpacing` for the pool
-    // ═══════════════════════════════════════════════════════════
-
-    /// @notice When tokenOut == base, falls back to single-hop using fee/tickSpacing
-    function test_singleHop_tokenOutIsBase_USDC_WETH() public {
-        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
-            V4_POOL_MANAGER,
-            FEE_USDC_WETH,
-            TS_USDC_WETH,
-            address(0), // hooks
-            WETH, // base
-            FEE_LINK_WETH,
-            TS_LINK_WETH,
-            address(0) // hooksOut
-        );
-
-        deal(USDC, address(this), SWAP_AMOUNT_USDC);
-        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
-
-        uint256 amountOut = adapter.swap(USDC, WETH, SWAP_AMOUNT_USDC, 0, swapReceiver);
-
-        assertGt(amountOut, 0, "Single-hop (tokenOut==base) should produce nonzero WETH");
-        assertEq(ERC20(WETH).balanceOf(swapReceiver), amountOut, "Receiver should get exact WETH output");
-    }
-
-    // ═══════════════════════════════════════════════════════════
-    // SINGLE-HOP FALLBACK: tokenIn == base (WETH → LINK)
-    // Uses `feeOut`/`tickSpacingOut` for the pool
-    // ═══════════════════════════════════════════════════════════
-
-    /// @notice When tokenIn == base, falls back to single-hop using feeOut/tickSpacingOut
-    function test_singleHop_tokenInIsBase_WETH_DAI() public {
-        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
-            V4_POOL_MANAGER,
-            FEE_USDC_WETH,
-            TS_USDC_WETH,
-            address(0),
-            WETH,
-            FEE_LINK_WETH,
-            TS_LINK_WETH,
+            USDC,
+            FEE_USDC_DAI,
+            TS_USDC_DAI,
             address(0)
         );
 
         deal(WETH, address(this), SWAP_AMOUNT_WETH);
         IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
 
-        uint256 amountOut = adapter.swap(WETH, LINK, SWAP_AMOUNT_WETH, 0, swapReceiver);
+        // Unreasonably high minAmountOut should revert
+        vm.expectRevert();
+        adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, type(uint256).max, swapReceiver);
+    }
 
-        assertGt(amountOut, 0, "Single-hop (tokenIn==base) should produce nonzero LINK");
-        assertEq(ERC20(LINK).balanceOf(swapReceiver), amountOut, "Receiver should get exact LINK output");
+    /// @notice Multi-hop config is correctly set
+    function test_multiHop_config() public {
+        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER,
+            FEE_WETH_USDC,
+            TS_WETH_USDC,
+            address(0),
+            USDC,
+            FEE_USDC_DAI,
+            TS_USDC_DAI,
+            address(0)
+        );
+
+        assertEq(adapter.poolManager(), V4_POOL_MANAGER);
+        assertEq(adapter.fee(), FEE_WETH_USDC);
+        assertEq(adapter.tickSpacing(), TS_WETH_USDC);
+        assertEq(adapter.base(), USDC);
+        assertEq(adapter.feeOut(), FEE_USDC_DAI);
+        assertEq(adapter.tickSpacingOut(), TS_USDC_DAI);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SINGLE-HOP FALLBACK: tokenOut == base (WETH → USDC)
+    // Uses `fee`/`tickSpacing` for the pool
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice When tokenOut == base, falls back to single-hop using fee/tickSpacing
+    function test_singleHop_tokenOutIsBase_WETH_USDC() public {
+        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER,
+            FEE_WETH_USDC,
+            TS_WETH_USDC,
+            address(0), // hooks
+            USDC, // base
+            FEE_USDC_DAI,
+            TS_USDC_DAI,
+            address(0) // hooksOut
+        );
+
+        deal(WETH, address(this), SWAP_AMOUNT_WETH);
+        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+
+        uint256 amountOut = adapter.swap(WETH, USDC, SWAP_AMOUNT_WETH, 0, swapReceiver);
+
+        assertGt(amountOut, 0, "Single-hop (tokenOut==base) should produce nonzero USDC");
+        assertEq(ERC20(USDC).balanceOf(swapReceiver), amountOut, "Receiver should get exact USDC output");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SINGLE-HOP FALLBACK: tokenIn == base (USDC → DAI)
+    // Uses `feeOut`/`tickSpacingOut` for the pool
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice When tokenIn == base, falls back to single-hop using feeOut/tickSpacingOut
+    function test_singleHop_tokenInIsBase_USDC_DAI() public {
+        UniswapV4SwapperAdapter adapter = new UniswapV4SwapperAdapter(
+            V4_POOL_MANAGER,
+            FEE_WETH_USDC,
+            TS_WETH_USDC,
+            address(0),
+            USDC,
+            FEE_USDC_DAI,
+            TS_USDC_DAI,
+            address(0)
+        );
+
+        deal(USDC, address(this), SWAP_AMOUNT_USDC);
+        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+
+        uint256 amountOut = adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, 0, swapReceiver);
+
+        assertGt(amountOut, 0, "Single-hop (tokenIn==base) should produce nonzero DAI");
+        assertEq(ERC20(DAI).balanceOf(swapReceiver), amountOut, "Receiver should get exact DAI output");
     }
 
     /// @notice Verify fee selection: tokenIn==base uses feeOut/tickSpacingOut, not fee/tickSpacing
@@ -293,35 +293,35 @@ contract UniswapV4MultiHopTest is Test {
             10_000, // fee: intentionally wrong — should NOT be used
             200, // tickSpacing: intentionally wrong — should NOT be used
             address(0),
-            WETH,
-            FEE_LINK_WETH, // feeOut: correct — should be used
-            TS_LINK_WETH, // tickSpacingOut: correct — should be used
+            USDC,
+            FEE_USDC_DAI, // feeOut: correct — should be used
+            TS_USDC_DAI, // tickSpacingOut: correct — should be used
             address(0)
         );
 
-        deal(WETH, address(this), SWAP_AMOUNT_WETH);
-        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+        deal(USDC, address(this), SWAP_AMOUNT_USDC);
+        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
 
         // Should succeed because it uses feeOut/tickSpacingOut, not fee/tickSpacing
-        uint256 amountOut = adapter.swap(WETH, LINK, SWAP_AMOUNT_WETH, 0, swapReceiver);
+        uint256 amountOut = adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, 0, swapReceiver);
         assertGt(amountOut, 0, "Should use feeOut for tokenIn==base path");
     }
 
     // ═══════════════════════════════════════════════════════════
-    // MULTI-HOP END-TO-END WITH FORWARDER
+    // FORWARDER END-TO-END WITH SWAP
     // ═══════════════════════════════════════════════════════════
 
-    /// @notice Full forwarder flow with multi-hop: strategy USDC profit → WETH → LINK → receiver
-    function test_forwarder_multiHop_USDC_WETH_DAI() public {
-        // Deploy full stack with multi-hop swapper (USDC→WETH→LINK)
-        UniswapV4SwapperAdapter multiHopAdapter = new UniswapV4SwapperAdapter(
+    /// @notice Full forwarder flow: strategy USDC profit → swap to DAI → receiver
+    function test_forwarder_swapAndForward_USDC_DAI() public {
+        // Deploy swapper with base=USDC (strategy profit is USDC, so tokenIn==base → single-hop to DAI)
+        UniswapV4SwapperAdapter swapAdapter = new UniswapV4SwapperAdapter(
             V4_POOL_MANAGER,
-            FEE_USDC_WETH,
-            TS_USDC_WETH,
+            FEE_WETH_USDC,
+            TS_WETH_USDC,
             address(0),
-            WETH,
-            FEE_LINK_WETH,
-            TS_LINK_WETH,
+            USDC,
+            FEE_USDC_DAI,
+            TS_USDC_DAI,
             address(0)
         );
 
@@ -335,7 +335,7 @@ contract UniswapV4MultiHopTest is Test {
         address keeper = address(0xCAFE);
         address recv = address(0xBEEF);
 
-        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, LINK, address(multiHopAdapter));
+        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(swapAdapter));
 
         MorphoCompounderStrategyFactory fac = new MorphoCompounderStrategyFactory{
             salt: keccak256("OCT_MORPHO_COMPOUNDER_STRATEGY_VAULT_FACTORY_V1")
@@ -378,12 +378,12 @@ contract UniswapV4MultiHopTest is Test {
         );
         deal(USDC, stratAddr, 1_000e6);
 
-        // Report, swap (multi-hop USDC→WETH→LINK via V4), forward
+        // Report, swap (USDC→DAI via V4), forward
         vm.prank(keeper);
-        uint256 wbtcOut = fwd.reportSwapAndForward(stratAddr, 10_000, 0);
+        uint256 daiOut = fwd.reportSwapAndForward(stratAddr, 10_000, 0);
         vm.clearMockedCalls();
 
-        assertGt(wbtcOut, 0, "Multi-hop through forwarder should produce LINK");
-        assertEq(ERC20(LINK).balanceOf(recv), wbtcOut, "Receiver should get LINK via multi-hop");
+        assertGt(daiOut, 0, "Forwarder should produce DAI via swap");
+        assertEq(ERC20(DAI).balanceOf(recv), daiOut, "Receiver should get DAI");
     }
 }

--- a/test/integration/swappers/base/BaseSwapperIntegrationTest.sol
+++ b/test/integration/swappers/base/BaseSwapperIntegrationTest.sol
@@ -1,0 +1,266 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
+import { MorphoCompounderStrategyFactory } from "src/factories/MorphoCompounderStrategyFactory.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { SwappingYieldForwarder } from "src/core/SwappingYieldForwarder.sol";
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+import { ISwapper } from "src/core/interfaces/ISwapper.sol";
+import { IBaseHealthCheck } from "src/strategies/interfaces/IBaseHealthCheck.sol";
+
+import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
+import { MorphoTestConfig } from "test/integration/strategies/config/MorphoTestConfig.sol";
+
+/// @title BaseSwapperIntegrationTest
+/// @notice Abstract base for swapper integration tests using MorphoCompounder strategy on mainnet fork
+/// @dev Concrete tests only need to implement _deploySwapper() and _targetAsset().
+///      This base class handles: strategy deployment, forwarder wiring, deposit + profit simulation,
+///      and shared test flows for both swap and no-swap paths.
+abstract contract BaseSwapperIntegrationTest is Test {
+    using SafeERC20 for ERC20;
+
+    // ========== STATE ==========
+
+    MorphoCompounderStrategy public strategy;
+    MorphoCompounderStrategyFactory public factory;
+    YieldDonatingTokenizedStrategy public implementation;
+    SwappingYieldForwarder public forwarder;
+
+    address public management = address(0xA1);
+    address public keeperEOA = address(0xCAFE);
+    address public emergencyAdmin = address(0xA3);
+    address public receiver = address(0xBEEF);
+    address public user = address(0x1234);
+
+    uint256 public mainnetFork;
+    uint256 public constant DEPOSIT_AMOUNT = 100_000e6; // 100k USDC
+
+    // ========== ABSTRACT ==========
+
+    /// @notice Deploy and return the concrete ISwapper implementation
+    function _deploySwapper() internal virtual returns (ISwapper);
+
+    /// @notice Return the address of the target asset after swap
+    function _targetAsset() internal view virtual returns (address);
+
+    /// @notice Label addresses specific to the concrete swapper
+    function _labelSwapperAddresses() internal virtual;
+
+    // ========== SETUP ==========
+
+    function _baseSetUp() internal {
+        mainnetFork = vm.createFork("mainnet", MorphoTestConfig.FORK_BLOCK);
+        vm.selectFork(mainnetFork);
+
+        // 1. Etch YieldDonatingTokenizedStrategy implementation
+        implementation = new YieldDonatingTokenizedStrategy{ salt: keccak256("OCT_YIELD_SKIMMING_STRATEGY_V1") }();
+        vm.etch(MorphoTestConfig.TOKENIZED_STRATEGY_ADDRESS, address(implementation).code);
+
+        // 2. Deploy swapper (concrete test provides this)
+        ISwapper swapper = _deploySwapper();
+
+        // 3. Deploy SwappingYieldForwarder
+        forwarder = new SwappingYieldForwarder(receiver, keeperEOA, _targetAsset(), address(swapper));
+
+        // 4. Deploy MorphoCompounder strategy via factory with forwarder as keeper AND donation address
+        factory = new MorphoCompounderStrategyFactory{
+            salt: keccak256("OCT_MORPHO_COMPOUNDER_STRATEGY_VAULT_FACTORY_V1")
+        }();
+
+        vm.startPrank(management);
+        address strategyAddr = factory.createStrategy(
+            "MorphoCompounder Donating Strategy",
+            "osMORPHO",
+            management,
+            address(forwarder), // keeper = forwarder (so forwarder can call report)
+            emergencyAdmin,
+            address(forwarder), // donationAddress = forwarder (profit shares minted here)
+            false,
+            address(implementation)
+        );
+        vm.stopPrank();
+
+        strategy = MorphoCompounderStrategy(strategyAddr);
+
+        // 5. Airdrop USDC to user and approve
+        deal(MorphoTestConfig.USDC, user, DEPOSIT_AMOUNT);
+        vm.prank(user);
+        ERC20(MorphoTestConfig.USDC).approve(address(strategy), type(uint256).max);
+
+        // 6. Labels
+        vm.label(address(strategy), "MorphoCompounderStrategy");
+        vm.label(address(forwarder), "SwappingYieldForwarder");
+        vm.label(address(swapper), "Swapper");
+        vm.label(receiver, "Receiver");
+        vm.label(keeperEOA, "KeeperEOA");
+        vm.label(management, "Management");
+        vm.label(user, "User");
+        vm.label(MorphoTestConfig.USDC, "USDC");
+        _labelSwapperAddresses();
+    }
+
+    // ========== HELPERS ==========
+
+    /// @notice Deposit into strategy, then run initial report so strategy deploys to Morpho
+    /// @dev Disables health check for the initial report (Morpho rounding can cause 1 wei "loss")
+    function _depositAndReport(uint256 amount) internal {
+        vm.prank(user);
+        IERC4626(address(strategy)).deposit(amount, user);
+
+        // Disable health check for initial report (Morpho vault rounding)
+        vm.prank(management);
+        IBaseHealthCheck(address(strategy)).setDoHealthCheck(false);
+
+        // Initial report deploys funds into Morpho and sets baseline
+        vm.prank(address(forwarder));
+        IMockStrategy(address(strategy)).report();
+    }
+
+    /// @notice Simulate profit by mocking Morpho vault convertToAssets to return inflated value
+    /// @dev After calling report(), the strategy will see this as profit and mint shares to donationAddress
+    function _simulateProfit(uint256 profitAmount) internal {
+        uint256 morphoShares = IERC4626(MorphoTestConfig.MORPHO_VAULT).balanceOf(address(strategy));
+        uint256 currentAssets = IERC4626(MorphoTestConfig.MORPHO_VAULT).convertToAssets(morphoShares);
+
+        // Mock convertToAssets to return inflated value
+        vm.mockCall(
+            MorphoTestConfig.MORPHO_VAULT,
+            abi.encodeWithSelector(IERC4626.convertToAssets.selector, morphoShares),
+            abi.encode(currentAssets + profitAmount)
+        );
+
+        // Airdrop actual USDC to strategy so redeem has real tokens
+        deal(MorphoTestConfig.USDC, address(strategy), profitAmount);
+    }
+
+    function _clearMocks() internal {
+        vm.clearMockedCalls();
+    }
+
+    // ========== SHARED TEST: NO-SWAP FALLBACK ==========
+
+    function _test_reportAndForward_noSwap() internal {
+        _depositAndReport(DEPOSIT_AMOUNT);
+
+        uint256 profit = 1_000e6; // 1k USDC profit
+        _simulateProfit(profit);
+
+        uint256 receiverUsdcBefore = ERC20(MorphoTestConfig.USDC).balanceOf(receiver);
+
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 10_000);
+
+        _clearMocks();
+
+        assertGt(assets, 0, "Should forward nonzero underlying assets");
+        assertEq(
+            ERC20(MorphoTestConfig.USDC).balanceOf(receiver),
+            receiverUsdcBefore + assets,
+            "Receiver should get underlying USDC"
+        );
+        assertEq(IERC20(address(strategy)).balanceOf(address(forwarder)), 0, "Forwarder should have 0 shares");
+    }
+
+    function _test_reportAndForward_zeroProfit() internal {
+        _depositAndReport(DEPOSIT_AMOUNT);
+
+        // No profit simulation — just call again
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 10_000);
+
+        assertEq(assets, 0, "Should return 0 when no profit");
+    }
+
+    // ========== SHARED TEST: SWAP PATH ==========
+
+    function _test_reportSwapAndForward_fullFlow() internal {
+        _depositAndReport(DEPOSIT_AMOUNT);
+
+        uint256 profit = 1_000e6; // 1k USDC profit
+        _simulateProfit(profit);
+
+        uint256 receiverTargetBefore = ERC20(_targetAsset()).balanceOf(receiver);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        _clearMocks();
+
+        assertGt(assetsOut, 0, "Should swap and forward nonzero target assets");
+        assertEq(
+            ERC20(_targetAsset()).balanceOf(receiver),
+            receiverTargetBefore + assetsOut,
+            "Receiver should get target asset"
+        );
+        assertEq(IERC20(address(strategy)).balanceOf(address(forwarder)), 0, "Forwarder should have 0 shares");
+    }
+
+    function _test_reportSwapAndForward_zeroProfit() internal {
+        _depositAndReport(DEPOSIT_AMOUNT);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        assertEq(assetsOut, 0, "Should return 0 when no profit");
+        assertEq(ERC20(_targetAsset()).balanceOf(receiver), 0, "Receiver gets nothing");
+    }
+
+    function _test_reportSwapAndForward_multipleReports() internal {
+        _depositAndReport(DEPOSIT_AMOUNT);
+
+        // First profit cycle
+        _simulateProfit(500e6);
+        vm.prank(keeperEOA);
+        uint256 assets1 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        _clearMocks();
+        assertGt(assets1, 0, "First report should yield target assets");
+
+        // Second profit cycle
+        _simulateProfit(1_500e6);
+        vm.prank(keeperEOA);
+        uint256 assets2 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        _clearMocks();
+        assertGt(assets2, 0, "Second report should yield target assets");
+
+        assertEq(
+            ERC20(_targetAsset()).balanceOf(receiver),
+            assets1 + assets2,
+            "Receiver should accumulate all payouts"
+        );
+    }
+
+    function _test_reportSwapAndForward_emitsEvent() internal {
+        _depositAndReport(DEPOSIT_AMOUNT);
+
+        _simulateProfit(1_000e6);
+
+        vm.expectEmit(true, true, false, false);
+        emit SwappingYieldForwarder.YieldSwappedAndForwarded(address(strategy), receiver, 0, 0, 0);
+
+        vm.prank(keeperEOA);
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        _clearMocks();
+    }
+
+    // ========== SHARED TEST: ACCESS CONTROL ==========
+
+    function _test_onlyKeeper_reportAndForward() internal {
+        vm.prank(address(0x1111));
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        forwarder.reportAndForward(address(strategy), 0);
+    }
+
+    function _test_onlyKeeper_reportSwapAndForward() internal {
+        vm.prank(address(0x1111));
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        forwarder.reportSwapAndForward(address(strategy), 0, 0);
+    }
+}

--- a/test/mocks/MockSwapper.sol
+++ b/test/mocks/MockSwapper.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ISwapper } from "src/core/interfaces/ISwapper.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+
+/// @notice Mock swapper for unit testing SwappingYieldForwarder
+/// @dev Receives input tokens (ignored) and mints output tokens at a configurable rate
+contract MockSwapper is ISwapper {
+    address public immutable outputToken;
+    uint256 public exchangeRate; // WAD (1e18 = 1:1)
+
+    error InsufficientOutput(uint256 expected, uint256 actual);
+
+    constructor(address _outputToken, uint256 _exchangeRate) {
+        outputToken = _outputToken;
+        exchangeRate = _exchangeRate;
+    }
+
+    function swap(
+        address,
+        address,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address receiver
+    ) external override returns (uint256 amountOut) {
+        amountOut = (amountIn * exchangeRate) / 1e18;
+        if (amountOut < minAmountOut) revert InsufficientOutput(minAmountOut, amountOut);
+        ERC20Mock(outputToken).mint(receiver, amountOut);
+        return amountOut;
+    }
+}

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -1,0 +1,341 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test, Vm } from "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+
+import { SwappingYieldForwarder } from "src/core/SwappingYieldForwarder.sol";
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+
+import { MockFactory } from "test/mocks/MockFactory.sol";
+import { MockStrategy } from "test/mocks/core/tokenized-strategies/MockStrategy.sol";
+import { MockYieldSource } from "test/mocks/core/tokenized-strategies/MockYieldSource.sol";
+import { MockSwapper } from "test/mocks/MockSwapper.sol";
+import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
+
+contract SwappingYieldForwarderTest is Test {
+    SwappingYieldForwarder public forwarder;
+    ERC20Mock public asset;
+    ERC20Mock public targetAsset;
+    IMockStrategy public strategy;
+    MockYieldSource public yieldSource;
+    MockFactory public mockFactory;
+    MockSwapper public swapper;
+    YieldDonatingTokenizedStrategy public implementation;
+
+    address public receiver = address(0xBEEF);
+    address public keeperEOA = address(0xCAFE);
+    address public management = address(0xA1);
+    address public emergencyAdmin = address(0xA2);
+    address public user = address(0xA3);
+    address public protocolFeeRecipient = address(0xA4);
+
+    uint256 public constant DEPOSIT_AMOUNT = 100e18;
+
+    function setUp() public {
+        mockFactory = new MockFactory(0, protocolFeeRecipient);
+        implementation = new YieldDonatingTokenizedStrategy();
+
+        asset = new ERC20Mock();
+        targetAsset = new ERC20Mock();
+        yieldSource = new MockYieldSource(address(asset));
+
+        // Deploy swapper (1:1 rate)
+        swapper = new MockSwapper(address(targetAsset), 1e18);
+
+        // Deploy SwappingYieldForwarder
+        forwarder = new SwappingYieldForwarder(receiver, keeperEOA, address(targetAsset), address(swapper));
+
+        // Deploy strategy with forwarder as both keeper and donation address
+        strategy = IMockStrategy(
+            address(
+                new MockStrategy(
+                    address(asset),
+                    address(yieldSource),
+                    management,
+                    address(forwarder),
+                    emergencyAdmin,
+                    address(forwarder),
+                    address(implementation)
+                )
+            )
+        );
+
+        vm.startPrank(management);
+        strategy.setKeeper(address(forwarder));
+        strategy.setEmergencyAdmin(emergencyAdmin);
+        strategy.setPendingManagement(management);
+        strategy.acceptManagement();
+        vm.stopPrank();
+
+        vm.label(receiver, "Receiver");
+        vm.label(keeperEOA, "KeeperEOA");
+        vm.label(address(forwarder), "SwappingYieldForwarder");
+        vm.label(address(strategy), "Strategy");
+        vm.label(address(asset), "Asset");
+        vm.label(address(targetAsset), "TargetAsset");
+        vm.label(address(yieldSource), "YieldSource");
+        vm.label(address(swapper), "MockSwapper");
+    }
+
+    function _depositIntoStrategy(address _user, uint256 _amount) internal {
+        asset.mint(_user, _amount);
+        vm.startPrank(_user);
+        asset.approve(address(strategy), _amount);
+        strategy.deposit(_amount, _user);
+        vm.stopPrank();
+    }
+
+    function _simulateProfit(uint256 _profit) internal {
+        asset.mint(address(yieldSource), _profit);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // CONSTRUCTOR TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_constructor_setsReceiver() public view {
+        assertEq(forwarder.receiver(), receiver);
+    }
+
+    function test_constructor_setsKeeper() public view {
+        assertEq(forwarder.keeper(), keeperEOA);
+    }
+
+    function test_constructor_setsTargetAsset() public view {
+        assertEq(forwarder.targetAsset(), address(targetAsset));
+    }
+
+    function test_constructor_setsSwapper() public view {
+        assertEq(address(forwarder.swapper()), address(swapper));
+    }
+
+    function test_constructor_revertsOnZeroReceiver() public {
+        vm.expectRevert(YieldForwarder.InvalidReceiver.selector);
+        new SwappingYieldForwarder(address(0), keeperEOA, address(targetAsset), address(swapper));
+    }
+
+    function test_constructor_revertsOnZeroKeeper() public {
+        vm.expectRevert(YieldForwarder.InvalidKeeper.selector);
+        new SwappingYieldForwarder(receiver, address(0), address(targetAsset), address(swapper));
+    }
+
+    function test_constructor_revertsOnZeroTargetAsset() public {
+        vm.expectRevert(SwappingYieldForwarder.InvalidTargetAsset.selector);
+        new SwappingYieldForwarder(receiver, keeperEOA, address(0), address(swapper));
+    }
+
+    function test_constructor_revertsOnZeroSwapper() public {
+        vm.expectRevert(SwappingYieldForwarder.InvalidSwapper.selector);
+        new SwappingYieldForwarder(receiver, keeperEOA, address(targetAsset), address(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // reportAndForward — NO-SWAP FALLBACK PATH
+    // ═══════════════════════════════════════════════════════════
+
+    function test_reportAndForward_fullFlow() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        uint256 profit = 10e18;
+        _simulateProfit(profit);
+
+        uint256 receiverBalanceBefore = asset.balanceOf(receiver);
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 10_000);
+
+        assertGt(assets, 0, "Should forward nonzero assets");
+        assertEq(asset.balanceOf(receiver), receiverBalanceBefore + assets, "Receiver should get underlying asset");
+        assertEq(strategy.balanceOf(address(forwarder)), 0, "Forwarder should have 0 shares");
+        // Receiver gets underlying asset, NOT target asset
+        assertEq(targetAsset.balanceOf(receiver), 0, "Receiver should NOT get target asset on no-swap path");
+    }
+
+    function test_reportAndForward_revertsWhenNotKeeper() public {
+        vm.prank(address(0x1111));
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        forwarder.reportAndForward(address(strategy), 0);
+    }
+
+    function test_reportAndForward_zeroProfit_returnsZero() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 10_000);
+
+        assertEq(assets, 0, "Should return 0 when no profit");
+    }
+
+    function test_reportAndForward_emitsEvent() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        _simulateProfit(20e18);
+
+        vm.expectEmit(true, true, false, false);
+        emit YieldForwarder.YieldForwarded(address(strategy), receiver, 0, 0);
+
+        vm.prank(keeperEOA);
+        forwarder.reportAndForward(address(strategy), 10_000);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // reportSwapAndForward — SWAP PATH
+    // ═══════════════════════════════════════════════════════════
+
+    function test_reportSwapAndForward_fullFlow() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        uint256 profit = 10e18;
+        _simulateProfit(profit);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        assertGt(assetsOut, 0, "Should swap and forward nonzero target assets");
+        assertEq(targetAsset.balanceOf(receiver), assetsOut, "Receiver should get target asset");
+        assertEq(strategy.balanceOf(address(forwarder)), 0, "Forwarder should have 0 shares");
+        // Underlying asset should NOT be at receiver (it was swapped)
+        assertEq(asset.balanceOf(receiver), 0, "Receiver should NOT get underlying on swap path");
+    }
+
+    function test_reportSwapAndForward_revertsWhenNotKeeper() public {
+        vm.prank(address(0x1111));
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        forwarder.reportSwapAndForward(address(strategy), 0, 0);
+    }
+
+    function test_reportSwapAndForward_zeroProfit_returnsZero() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        assertEq(assetsOut, 0, "Should return 0 when no profit");
+        assertEq(targetAsset.balanceOf(receiver), 0, "Receiver should get nothing");
+    }
+
+    function test_reportSwapAndForward_emitsEvent() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        _simulateProfit(20e18);
+
+        vm.expectEmit(true, true, false, false);
+        emit SwappingYieldForwarder.YieldSwappedAndForwarded(address(strategy), receiver, 0, 0, 0);
+
+        vm.prank(keeperEOA);
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+    }
+
+    function test_reportSwapAndForward_multipleReports() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        // First profit cycle
+        _simulateProfit(5e18);
+        vm.prank(keeperEOA);
+        uint256 assets1 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        assertGt(assets1, 0, "First report should yield target assets");
+
+        // Second profit cycle
+        _simulateProfit(15e18);
+        vm.prank(keeperEOA);
+        uint256 assets2 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        assertGt(assets2, 0, "Second report should yield target assets");
+
+        assertEq(targetAsset.balanceOf(receiver), assets1 + assets2, "Receiver should accumulate all payouts");
+    }
+
+    function test_reportSwapAndForward_respectsMinAmountOut() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        _simulateProfit(10e18);
+
+        // minAmountOut too high should revert (swapper enforces it)
+        vm.prank(keeperEOA);
+        vm.expectRevert();
+        forwarder.reportSwapAndForward(address(strategy), 10_000, type(uint256).max);
+    }
+
+    function test_reportSwapAndForward_lossScenario_noSharesMinted() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        // Simulate loss
+        vm.prank(address(strategy));
+        yieldSource.simulateLoss(5e18);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        assertEq(assetsOut, 0, "Loss report should return 0");
+        assertEq(targetAsset.balanceOf(receiver), 0, "Receiver gets nothing on loss");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // FUZZ TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_reportSwapAndForward_fuzz_profitAmount(uint256 profit) public {
+        profit = bound(profit, 1e15, 1e27);
+
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        _simulateProfit(profit);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        assertGt(assetsOut, 0, "Should always forward positive target assets for positive profit");
+        assertEq(strategy.balanceOf(address(forwarder)), 0, "Forwarder should redeem all shares");
+        assertEq(targetAsset.balanceOf(receiver), assetsOut, "Receiver balance should match returned assets");
+    }
+
+    function test_reportAndForward_fuzz_profitAmount(uint256 profit) public {
+        profit = bound(profit, 1e15, 1e27);
+
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        _simulateProfit(profit);
+
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 10_000);
+
+        assertGt(assets, 0, "Should always forward positive assets for positive profit");
+        assertEq(strategy.balanceOf(address(forwarder)), 0, "Forwarder should redeem all shares");
+        assertEq(asset.balanceOf(receiver), assets, "Receiver balance should match returned assets");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // ROLE VERIFICATION
+    // ═══════════════════════════════════════════════════════════
+
+    function test_strategyDonationAddressIsForwarder() public view {
+        assertEq(strategy.dragonRouter(), address(forwarder), "Strategy donation address should be forwarder");
+    }
+
+    function test_strategyKeeperIsForwarder() public view {
+        assertEq(strategy.keeper(), address(forwarder), "Strategy keeper should be forwarder");
+    }
+}

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -289,8 +289,9 @@ contract SwappingYieldForwarderTest is Test {
         assertEq(targetAsset.balanceOf(receiver), 0, "Receiver gets nothing on loss");
     }
 
-    /// @notice Covers the `if (assetsIn == 0) return 0` branch in reportSwapAndForward.
-    ///         shares > 0 but redeem returns 0 assets (e.g., extreme rounding in strategy).
+    /// @notice Covers the `if (assetsIn == 0)` branch in reportSwapAndForward.
+    ///         shares > 0 but redeem returns 0 assets (e.g., illiquid vault with maxLoss=MAX_BPS).
+    ///         Must still emit YieldSwappedAndForwarded for monitoring observability.
     function test_reportSwapAndForward_sharesExistButRedeemReturnsZero() public {
         _depositIntoStrategy(user, DEPOSIT_AMOUNT);
         vm.prank(address(forwarder));
@@ -298,13 +299,15 @@ contract SwappingYieldForwarderTest is Test {
 
         _simulateProfit(10e18);
 
-        // Mock strategy.report() to do nothing special (shares already get minted)
-        // Mock strategy.redeem() to return 0 assets (extreme edge case)
+        // Mock strategy.redeem() to return 0 assets (simulates illiquid vault)
         vm.mockCall(
             address(strategy),
             abi.encodeWithSelector(bytes4(keccak256("redeem(uint256,address,address,uint256)"))),
             abi.encode(uint256(0))
         );
+
+        vm.expectEmit(true, true, false, false);
+        emit SwappingYieldForwarder.YieldSwappedAndForwarded(address(strategy), receiver, 0, 0, 0);
 
         vm.prank(keeperEOA);
         uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -289,6 +289,32 @@ contract SwappingYieldForwarderTest is Test {
         assertEq(targetAsset.balanceOf(receiver), 0, "Receiver gets nothing on loss");
     }
 
+    /// @notice Covers the `if (assetsIn == 0) return 0` branch in reportSwapAndForward.
+    ///         shares > 0 but redeem returns 0 assets (e.g., extreme rounding in strategy).
+    function test_reportSwapAndForward_sharesExistButRedeemReturnsZero() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+
+        _simulateProfit(10e18);
+
+        // Mock strategy.report() to do nothing special (shares already get minted)
+        // Mock strategy.redeem() to return 0 assets (extreme edge case)
+        vm.mockCall(
+            address(strategy),
+            abi.encodeWithSelector(bytes4(keccak256("redeem(uint256,address,address,uint256)"))),
+            abi.encode(uint256(0))
+        );
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        assertEq(assetsOut, 0, "Should return 0 when redeem returns 0 assets");
+        assertEq(targetAsset.balanceOf(receiver), 0, "Receiver gets nothing");
+
+        vm.clearMockedCalls();
+    }
+
     // ═══════════════════════════════════════════════════════════
     // FUZZ TESTS
     // ═══════════════════════════════════════════════════════════

--- a/test/unit/swappers/CurveSwapper.t.sol
+++ b/test/unit/swappers/CurveSwapper.t.sol
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+
+import { CurveSwapper } from "src/swappers/CurveSwapper.sol";
+
+contract CurveSwapperTest is Test {
+    ERC20Mock public tokenIn;
+    ERC20Mock public tokenOut;
+    MockCurvePool public pool;
+
+    address public receiver = address(0xBEEF);
+
+    int128 internal constant INDEX_IN = 1;
+    int128 internal constant INDEX_OUT = 2;
+
+    function setUp() public {
+        tokenIn = new ERC20Mock();
+        tokenOut = new ERC20Mock();
+        pool = new MockCurvePool(address(tokenIn), address(tokenOut));
+
+        vm.label(address(tokenIn), "TokenIn");
+        vm.label(address(tokenOut), "TokenOut");
+        vm.label(address(pool), "CurvePool");
+        vm.label(receiver, "Receiver");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // CONSTRUCTOR TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_constructor_setsImmutables() public {
+        CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
+        assertEq(s.pool(), address(pool));
+        assertEq(s.indexIn(), INDEX_IN);
+        assertEq(s.indexOut(), INDEX_OUT);
+        assertEq(s.tokenIn(), address(tokenIn));
+        assertEq(s.tokenOut(), address(tokenOut));
+    }
+
+    function test_constructor_revertsOnZeroPool() public {
+        vm.expectRevert(CurveSwapper.InvalidPool.selector);
+        new CurveSwapper(address(0), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
+    }
+
+    function test_constructor_revertsOnZeroTokenIn() public {
+        vm.expectRevert(CurveSwapper.InvalidToken.selector);
+        new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(0), address(tokenOut));
+    }
+
+    function test_constructor_revertsOnZeroTokenOut() public {
+        vm.expectRevert(CurveSwapper.InvalidToken.selector);
+        new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — TOKEN MISMATCH
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_revertsOnTokenInMismatch() public {
+        CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
+        vm.expectRevert(CurveSwapper.InvalidToken.selector);
+        s.swap(address(0xDEAD), address(tokenOut), 100, 0, receiver);
+    }
+
+    function test_swap_revertsOnTokenOutMismatch() public {
+        CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
+        vm.expectRevert(CurveSwapper.InvalidToken.selector);
+        s.swap(address(tokenIn), address(0xDEAD), 100, 0, receiver);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — FULL FLOW
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_fullFlow() public {
+        CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
+
+        uint256 amountIn = 1000e18;
+        tokenIn.mint(address(s), amountIn);
+
+        uint256 amountOut = s.swap(address(tokenIn), address(tokenOut), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "Output should match 1:1 from mock pool");
+        assertEq(tokenOut.balanceOf(receiver), amountOut, "Receiver should have output tokens");
+    }
+
+    function test_swap_respectsMinAmountOut() public {
+        CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
+
+        uint256 amountIn = 1000e18;
+        tokenIn.mint(address(s), amountIn);
+
+        // Pool enforces minAmountOut via the mock
+        pool.setSlippage(50); // 50% output
+
+        // The Curve pool's exchange will be called with min_dy, and the pool mock will
+        // output less. However, since CurveSwapper passes minAmountOut to the pool,
+        // the pool itself should revert. Let's test that the CurveSwapper forwards minAmountOut.
+        // In our mock, the pool doesn't enforce min_dy, so this tests the balance measurement.
+        uint256 amountOut = s.swap(address(tokenIn), address(tokenOut), amountIn, 0, receiver);
+        assertEq(amountOut, 500e18, "Output should reflect slippage");
+    }
+
+    function test_swap_fuzz(uint256 amountIn) public {
+        amountIn = bound(amountIn, 1, 1e30);
+        CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
+
+        tokenIn.mint(address(s), amountIn);
+        uint256 amountOut = s.swap(address(tokenIn), address(tokenOut), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "1:1 mock output");
+        assertEq(tokenOut.balanceOf(receiver), amountOut);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════
+// MOCK CURVE POOL
+// ═══════════════════════════════════════════════════════════
+
+contract MockCurvePool {
+    ERC20Mock public tokenIn;
+    ERC20Mock public tokenOut;
+    uint256 public slippagePct = 100; // 100 = no slippage
+
+    constructor(address _tokenIn, address _tokenOut) {
+        tokenIn = ERC20Mock(_tokenIn);
+        tokenOut = ERC20Mock(_tokenOut);
+    }
+
+    function setSlippage(uint256 _pct) external {
+        slippagePct = _pct;
+    }
+
+    /// @dev Simulates Curve exchange: pulls tokenIn, mints tokenOut to caller (1:1 with optional slippage)
+    function exchange(int128, int128, uint256 dx, uint256) external {
+        tokenIn.transferFrom(msg.sender, address(this), dx);
+        uint256 dy = (dx * slippagePct) / 100;
+        tokenOut.mint(msg.sender, dy);
+    }
+}

--- a/test/unit/swappers/CurveSwapper.t.sol
+++ b/test/unit/swappers/CurveSwapper.t.sol
@@ -55,6 +55,11 @@ contract CurveSwapperTest is Test {
         new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(0));
     }
 
+    function test_constructor_revertsOnSameIndices() public {
+        vm.expectRevert(CurveSwapper.InvalidIndices.selector);
+        new CurveSwapper(address(pool), INDEX_IN, INDEX_IN, address(tokenIn), address(tokenOut));
+    }
+
     // ═══════════════════════════════════════════════════════════
     // SWAP — TOKEN MISMATCH
     // ═══════════════════════════════════════════════════════════

--- a/test/unit/swappers/CurveSwapper.t.sol
+++ b/test/unit/swappers/CurveSwapper.t.sol
@@ -19,7 +19,7 @@ contract CurveSwapperTest is Test {
     function setUp() public {
         tokenIn = new ERC20Mock();
         tokenOut = new ERC20Mock();
-        pool = new MockCurvePool(address(tokenIn), address(tokenOut));
+        pool = new MockCurvePool(address(tokenIn), address(tokenOut), INDEX_IN, INDEX_OUT);
 
         vm.label(address(tokenIn), "TokenIn");
         vm.label(address(tokenOut), "TokenOut");
@@ -58,6 +58,24 @@ contract CurveSwapperTest is Test {
     function test_constructor_revertsOnSameIndices() public {
         vm.expectRevert(CurveSwapper.InvalidIndices.selector);
         new CurveSwapper(address(pool), INDEX_IN, INDEX_IN, address(tokenIn), address(tokenOut));
+    }
+
+    function test_constructor_revertsOnTokenInIndexMismatch() public {
+        // pool.coins(INDEX_IN) = tokenIn, but we pass tokenOut as _tokenIn
+        vm.expectRevert(CurveSwapper.TokenIndexMismatch.selector);
+        new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenOut), address(tokenOut));
+    }
+
+    function test_constructor_revertsOnTokenOutIndexMismatch() public {
+        // pool.coins(INDEX_OUT) = tokenOut, but we pass tokenIn as _tokenOut
+        vm.expectRevert(CurveSwapper.TokenIndexMismatch.selector);
+        new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenIn));
+    }
+
+    function test_constructor_revertsOnSwappedIndices() public {
+        // Correct tokens but swapped indices (INDEX_OUT for tokenIn, INDEX_IN for tokenOut)
+        vm.expectRevert(CurveSwapper.TokenIndexMismatch.selector);
+        new CurveSwapper(address(pool), INDEX_OUT, INDEX_IN, address(tokenIn), address(tokenOut));
     }
 
     // ═══════════════════════════════════════════════════════════
@@ -126,13 +144,16 @@ contract CurveSwapperTest is Test {
 // ═══════════════════════════════════════════════════════════
 
 contract MockCurvePool {
+    mapping(uint256 => address) public coins;
     ERC20Mock public tokenIn;
     ERC20Mock public tokenOut;
     uint256 public slippagePct = 100; // 100 = no slippage
 
-    constructor(address _tokenIn, address _tokenOut) {
+    constructor(address _tokenIn, address _tokenOut, int128 _indexIn, int128 _indexOut) {
         tokenIn = ERC20Mock(_tokenIn);
         tokenOut = ERC20Mock(_tokenOut);
+        coins[uint256(int256(_indexIn))] = _tokenIn;
+        coins[uint256(int256(_indexOut))] = _tokenOut;
     }
 
     function setSlippage(uint256 _pct) external {

--- a/test/unit/swappers/PSMSwapper.t.sol
+++ b/test/unit/swappers/PSMSwapper.t.sol
@@ -157,7 +157,8 @@ contract PSMSwapperTest is Test {
         uint256 amountIn = 1000e18;
         dai.mint(address(s), amountIn);
 
-        uint256 amountOut = s.swap(address(dai), address(usds), amountIn, 0, receiver);
+        // minAmountOut = amountIn: 1:1 conversion, exact output enforced internally
+        uint256 amountOut = s.swap(address(dai), address(usds), amountIn, amountIn, receiver);
 
         assertEq(amountOut, amountIn, "DAI_TO_USDS: should be 1:1");
         assertEq(usds.balanceOf(receiver), amountIn, "Receiver should have USDS");
@@ -176,7 +177,8 @@ contract PSMSwapperTest is Test {
         uint256 amountIn = 1000e18;
         usds.mint(address(s), amountIn);
 
-        uint256 amountOut = s.swap(address(usds), address(dai), amountIn, 0, receiver);
+        // minAmountOut = amountIn: 1:1 conversion, exact output enforced internally
+        uint256 amountOut = s.swap(address(usds), address(dai), amountIn, amountIn, receiver);
 
         assertEq(amountOut, amountIn, "USDS_TO_DAI: should be 1:1");
         assertEq(dai.balanceOf(receiver), amountIn, "Receiver should have DAI");
@@ -223,7 +225,7 @@ contract PSMSwapperTest is Test {
         s.swap(address(dai), address(gem), tinyAmount, 0, receiver);
     }
 
-    function test_swap_daiToUsds_insufficientOutput() public {
+    function test_swap_daiToUsds_ignoresCallerMinAmountOut() public {
         MockExchange mockExchange = new MockExchange(address(dai), address(usds));
         PSMSwapper s = new PSMSwapper(
             address(mockExchange),
@@ -236,9 +238,71 @@ contract PSMSwapperTest is Test {
         uint256 amountIn = 1000e18;
         dai.mint(address(s), amountIn);
 
-        uint256 tooHigh = 2000e18;
-        vm.expectRevert(abi.encodeWithSelector(PSMSwapper.InsufficientOutput.selector, tooHigh, amountIn));
-        s.swap(address(dai), address(usds), amountIn, tooHigh, receiver);
+        // Caller passes 0 as minAmountOut, but contract enforces amountIn internally
+        uint256 amountOut = s.swap(address(dai), address(usds), amountIn, 0, receiver);
+        assertEq(amountOut, amountIn, "1:1 enforced regardless of caller minAmountOut");
+    }
+
+    function test_swap_usdsToDai_ignoresCallerMinAmountOut() public {
+        MockExchange mockExchange = new MockExchange(address(usds), address(dai));
+        PSMSwapper s = new PSMSwapper(
+            address(mockExchange),
+            PSMSwapper.Route.USDS_TO_DAI,
+            address(usds),
+            address(dai),
+            0
+        );
+
+        uint256 amountIn = 1000e18;
+        usds.mint(address(s), amountIn);
+
+        // Caller passes 0 as minAmountOut, but contract enforces amountIn internally
+        uint256 amountOut = s.swap(address(usds), address(dai), amountIn, 0, receiver);
+        assertEq(amountOut, amountIn, "1:1 enforced regardless of caller minAmountOut");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — NON-1:1 CONVERSION REVERT
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_daiToUsds_revertsOnNonOneToOne() public {
+        MockExchange mockExchange = new MockExchange(address(dai), address(usds));
+        mockExchange.setSkim(1); // converter returns 1 wei less than expected
+        PSMSwapper s = new PSMSwapper(
+            address(mockExchange),
+            PSMSwapper.Route.DAI_TO_USDS,
+            address(dai),
+            address(usds),
+            0
+        );
+
+        uint256 amountIn = 1000e18;
+        dai.mint(address(s), amountIn);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PSMSwapper.NonOneToOneConversion.selector, amountIn, amountIn - 1)
+        );
+        s.swap(address(dai), address(usds), amountIn, 0, receiver);
+    }
+
+    function test_swap_usdsToDai_revertsOnNonOneToOne() public {
+        MockExchange mockExchange = new MockExchange(address(usds), address(dai));
+        mockExchange.setSkim(1); // converter returns 1 wei less than expected
+        PSMSwapper s = new PSMSwapper(
+            address(mockExchange),
+            PSMSwapper.Route.USDS_TO_DAI,
+            address(usds),
+            address(dai),
+            0
+        );
+
+        uint256 amountIn = 1000e18;
+        usds.mint(address(s), amountIn);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(PSMSwapper.NonOneToOneConversion.selector, amountIn, amountIn - 1)
+        );
+        s.swap(address(usds), address(dai), amountIn, 0, receiver);
     }
 }
 
@@ -280,25 +344,30 @@ contract MockPSM {
     }
 }
 
-/// @dev Mock DaiUsds Exchange that simulates 1:1 conversion
+/// @dev Mock DaiUsds Exchange that simulates 1:1 conversion (with optional skim for testing)
 contract MockExchange {
     ERC20Mock public tokenIn;
     ERC20Mock public tokenOut;
+    uint256 public skim; // amount to withhold from output (0 = perfect 1:1)
 
     constructor(address _tokenIn, address _tokenOut) {
         tokenIn = ERC20Mock(_tokenIn);
         tokenOut = ERC20Mock(_tokenOut);
     }
 
+    function setSkim(uint256 _skim) external {
+        skim = _skim;
+    }
+
     /// @dev DAI -> USDS: pull DAI from caller, mint USDS to usr
     function daiToUsds(address usr, uint256 wad) external {
         tokenIn.transferFrom(msg.sender, address(this), wad);
-        tokenOut.mint(usr, wad);
+        tokenOut.mint(usr, wad - skim);
     }
 
     /// @dev USDS -> DAI: pull USDS from caller, mint DAI to usr
     function usdsToDai(address usr, uint256 wad) external {
         tokenIn.transferFrom(msg.sender, address(this), wad);
-        tokenOut.mint(usr, wad);
+        tokenOut.mint(usr, wad - skim);
     }
 }

--- a/test/unit/swappers/PSMSwapper.t.sol
+++ b/test/unit/swappers/PSMSwapper.t.sol
@@ -1,0 +1,284 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+
+import { PSMSwapper } from "src/swappers/PSMSwapper.sol";
+import { IPSM, IExchange } from "src/strategies/interfaces/IPSM.sol";
+
+contract PSMSwapperTest is Test {
+    ERC20Mock public gem; // e.g., USDC (6 decimals conceptually, but ERC20Mock uses 18)
+    ERC20Mock public dai;
+    ERC20Mock public usds;
+
+    address public protocol = address(0xABC1);
+    address public exchange = address(0xABC2);
+    address public receiver = address(0xBEEF);
+
+    uint256 internal constant WAD = 1e18;
+    uint256 internal constant CONVERSION_FACTOR = 1e12; // 6 -> 18 decimal conversion
+
+    function setUp() public {
+        gem = new ERC20Mock();
+        dai = new ERC20Mock();
+        usds = new ERC20Mock();
+
+        vm.label(address(gem), "GEM");
+        vm.label(address(dai), "DAI");
+        vm.label(address(usds), "USDS");
+        vm.label(protocol, "PSM");
+        vm.label(exchange, "DaiUsdsExchange");
+        vm.label(receiver, "Receiver");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // CONSTRUCTOR TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_constructor_setsImmutables() public {
+        PSMSwapper s = new PSMSwapper(protocol, PSMSwapper.Route.SELL_GEM, address(gem), address(dai), 0);
+        assertEq(s.protocol(), protocol);
+        assertEq(uint8(s.route()), uint8(PSMSwapper.Route.SELL_GEM));
+        assertEq(s.tokenIn(), address(gem));
+        assertEq(s.tokenOut(), address(dai));
+        assertEq(s.conversionFactor(), 0);
+    }
+
+    function test_constructor_revertsOnZeroProtocol() public {
+        vm.expectRevert(PSMSwapper.InvalidProtocol.selector);
+        new PSMSwapper(address(0), PSMSwapper.Route.SELL_GEM, address(gem), address(dai), 0);
+    }
+
+    function test_constructor_revertsOnZeroTokenIn() public {
+        vm.expectRevert(PSMSwapper.InvalidToken.selector);
+        new PSMSwapper(protocol, PSMSwapper.Route.SELL_GEM, address(0), address(dai), 0);
+    }
+
+    function test_constructor_revertsOnZeroTokenOut() public {
+        vm.expectRevert(PSMSwapper.InvalidToken.selector);
+        new PSMSwapper(protocol, PSMSwapper.Route.SELL_GEM, address(gem), address(0), 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — TOKEN MISMATCH
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_revertsOnTokenInMismatch() public {
+        PSMSwapper s = new PSMSwapper(protocol, PSMSwapper.Route.SELL_GEM, address(gem), address(dai), 0);
+        vm.expectRevert(PSMSwapper.InvalidToken.selector);
+        s.swap(address(0xDEAD), address(dai), 100, 0, receiver);
+    }
+
+    function test_swap_revertsOnTokenOutMismatch() public {
+        PSMSwapper s = new PSMSwapper(protocol, PSMSwapper.Route.SELL_GEM, address(gem), address(dai), 0);
+        vm.expectRevert(PSMSwapper.InvalidToken.selector);
+        s.swap(address(gem), address(0xDEAD), 100, 0, receiver);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — INSUFFICIENT OUTPUT
+    // ═══════════════════════════════════════════════════════════
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — FULL ROUTE TESTS (using mock PSM/Exchange)
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_sellGem_route() public {
+        MockPSM mockPSM = new MockPSM(address(gem), address(dai));
+        PSMSwapper s = new PSMSwapper(address(mockPSM), PSMSwapper.Route.SELL_GEM, address(gem), address(dai), 0);
+
+        uint256 amountIn = 1000e18;
+        gem.mint(address(s), amountIn);
+
+        uint256 amountOut = s.swap(address(gem), address(dai), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn * WAD / WAD, "SELL_GEM: output should match 1:1");
+        assertEq(dai.balanceOf(receiver), amountOut, "Receiver should have DAI");
+    }
+
+    function test_swap_buyGem_route() public {
+        MockPSM mockPSM = new MockPSM(address(dai), address(gem));
+        mockPSM.setTout(0); // 0% fee
+
+        PSMSwapper s = new PSMSwapper(
+            address(mockPSM),
+            PSMSwapper.Route.BUY_GEM,
+            address(dai),
+            address(gem),
+            CONVERSION_FACTOR
+        );
+
+        uint256 amountIn = 1000e18;
+        dai.mint(address(s), amountIn);
+
+        uint256 amountOut = s.swap(address(dai), address(gem), amountIn, 0, receiver);
+
+        // gemAmt = amountIn * WAD / (CONVERSION_FACTOR * (WAD + 0)) = 1000e18 / 1e12 = 1000e6
+        uint256 expectedGemAmt = amountIn * WAD / (CONVERSION_FACTOR * WAD);
+        assertEq(amountOut, expectedGemAmt, "BUY_GEM: output should match fee-adjusted amount");
+        assertEq(gem.balanceOf(receiver), amountOut, "Receiver should have gem");
+    }
+
+    function test_swap_buyGem_withFee() public {
+        MockPSM mockPSM = new MockPSM(address(dai), address(gem));
+        uint256 tout = 0.01e18; // 1% fee
+        mockPSM.setTout(tout);
+
+        PSMSwapper s = new PSMSwapper(
+            address(mockPSM),
+            PSMSwapper.Route.BUY_GEM,
+            address(dai),
+            address(gem),
+            CONVERSION_FACTOR
+        );
+
+        uint256 amountIn = 1000e18;
+        dai.mint(address(s), amountIn);
+
+        uint256 amountOut = s.swap(address(dai), address(gem), amountIn, 0, receiver);
+
+        uint256 expectedGemAmt = (amountIn * WAD) / (CONVERSION_FACTOR * (WAD + tout));
+        assertEq(amountOut, expectedGemAmt, "BUY_GEM with fee: output should be fee-adjusted");
+        assertEq(gem.balanceOf(receiver), amountOut, "Receiver should have gem");
+    }
+
+    function test_swap_daiToUsds_route() public {
+        MockExchange mockExchange = new MockExchange(address(dai), address(usds));
+        PSMSwapper s = new PSMSwapper(
+            address(mockExchange),
+            PSMSwapper.Route.DAI_TO_USDS,
+            address(dai),
+            address(usds),
+            0
+        );
+
+        uint256 amountIn = 1000e18;
+        dai.mint(address(s), amountIn);
+
+        uint256 amountOut = s.swap(address(dai), address(usds), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "DAI_TO_USDS: should be 1:1");
+        assertEq(usds.balanceOf(receiver), amountIn, "Receiver should have USDS");
+    }
+
+    function test_swap_usdsToDai_route() public {
+        MockExchange mockExchange = new MockExchange(address(usds), address(dai));
+        PSMSwapper s = new PSMSwapper(
+            address(mockExchange),
+            PSMSwapper.Route.USDS_TO_DAI,
+            address(usds),
+            address(dai),
+            0
+        );
+
+        uint256 amountIn = 1000e18;
+        usds.mint(address(s), amountIn);
+
+        uint256 amountOut = s.swap(address(usds), address(dai), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "USDS_TO_DAI: should be 1:1");
+        assertEq(dai.balanceOf(receiver), amountIn, "Receiver should have DAI");
+    }
+
+    function test_swap_buyGem_insufficientOutput() public {
+        MockPSM mockPSM = new MockPSM(address(dai), address(gem));
+        mockPSM.setTout(0);
+
+        PSMSwapper s = new PSMSwapper(
+            address(mockPSM),
+            PSMSwapper.Route.BUY_GEM,
+            address(dai),
+            address(gem),
+            CONVERSION_FACTOR
+        );
+
+        uint256 amountIn = 1000e18;
+        dai.mint(address(s), amountIn);
+
+        // Expected gem = 1000e6, require more
+        uint256 tooHigh = 2000e6;
+        vm.expectRevert(abi.encodeWithSelector(PSMSwapper.InsufficientOutput.selector, tooHigh, 1000e6));
+        s.swap(address(dai), address(gem), amountIn, tooHigh, receiver);
+    }
+
+    function test_swap_daiToUsds_insufficientOutput() public {
+        MockExchange mockExchange = new MockExchange(address(dai), address(usds));
+        PSMSwapper s = new PSMSwapper(
+            address(mockExchange),
+            PSMSwapper.Route.DAI_TO_USDS,
+            address(dai),
+            address(usds),
+            0
+        );
+
+        uint256 amountIn = 1000e18;
+        dai.mint(address(s), amountIn);
+
+        uint256 tooHigh = 2000e18;
+        vm.expectRevert(abi.encodeWithSelector(PSMSwapper.InsufficientOutput.selector, tooHigh, amountIn));
+        s.swap(address(dai), address(usds), amountIn, tooHigh, receiver);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════
+// MOCK CONTRACTS
+// ═══════════════════════════════════════════════════════════
+
+/// @dev Mock PSM that simulates sellGem and buyGem
+contract MockPSM {
+    ERC20Mock public tokenIn;
+    ERC20Mock public tokenOut;
+    uint256 public tout_;
+
+    constructor(address _tokenIn, address _tokenOut) {
+        tokenIn = ERC20Mock(_tokenIn);
+        tokenOut = ERC20Mock(_tokenOut);
+    }
+
+    function setTout(uint256 _tout) external {
+        tout_ = _tout;
+    }
+
+    function tout() external view returns (uint256) {
+        return tout_;
+    }
+
+    /// @dev sellGem: caller sends gem, PSM mints DAI/USDS to caller (1:1 at 18 decimals)
+    function sellGem(address usr, uint256 gemAmt) external {
+        // Pull gem from caller
+        tokenIn.transferFrom(msg.sender, address(this), gemAmt);
+        // Mint output to usr (caller is the swapper contract, usr is the swapper too)
+        tokenOut.mint(usr, gemAmt);
+    }
+
+    /// @dev buyGem: caller sends DAI, PSM sends gem to caller
+    function buyGem(address usr, uint256 gemAmt) external {
+        // Mint gem to usr
+        tokenOut.mint(usr, gemAmt);
+    }
+}
+
+/// @dev Mock DaiUsds Exchange that simulates 1:1 conversion
+contract MockExchange {
+    ERC20Mock public tokenIn;
+    ERC20Mock public tokenOut;
+
+    constructor(address _tokenIn, address _tokenOut) {
+        tokenIn = ERC20Mock(_tokenIn);
+        tokenOut = ERC20Mock(_tokenOut);
+    }
+
+    /// @dev DAI -> USDS: pull DAI from caller, mint USDS to usr
+    function daiToUsds(address usr, uint256 wad) external {
+        tokenIn.transferFrom(msg.sender, address(this), wad);
+        tokenOut.mint(usr, wad);
+    }
+
+    /// @dev USDS -> DAI: pull USDS from caller, mint DAI to usr
+    function usdsToDai(address usr, uint256 wad) external {
+        tokenIn.transferFrom(msg.sender, address(this), wad);
+        tokenOut.mint(usr, wad);
+    }
+}

--- a/test/unit/swappers/PSMSwapper.t.sol
+++ b/test/unit/swappers/PSMSwapper.t.sol
@@ -94,7 +94,7 @@ contract PSMSwapperTest is Test {
 
         uint256 amountOut = s.swap(address(gem), address(dai), amountIn, 0, receiver);
 
-        assertEq(amountOut, amountIn * WAD / WAD, "SELL_GEM: output should match 1:1");
+        assertEq(amountOut, (amountIn * WAD) / WAD, "SELL_GEM: output should match 1:1");
         assertEq(dai.balanceOf(receiver), amountOut, "Receiver should have DAI");
     }
 
@@ -116,7 +116,7 @@ contract PSMSwapperTest is Test {
         uint256 amountOut = s.swap(address(dai), address(gem), amountIn, 0, receiver);
 
         // gemAmt = amountIn * WAD / (CONVERSION_FACTOR * (WAD + 0)) = 1000e18 / 1e12 = 1000e6
-        uint256 expectedGemAmt = amountIn * WAD / (CONVERSION_FACTOR * WAD);
+        uint256 expectedGemAmt = (amountIn * WAD) / (CONVERSION_FACTOR * WAD);
         assertEq(amountOut, expectedGemAmt, "BUY_GEM: output should match fee-adjusted amount");
         assertEq(gem.balanceOf(receiver), amountOut, "Receiver should have gem");
     }
@@ -201,6 +201,26 @@ contract PSMSwapperTest is Test {
         uint256 tooHigh = 2000e6;
         vm.expectRevert(abi.encodeWithSelector(PSMSwapper.InsufficientOutput.selector, tooHigh, 1000e6));
         s.swap(address(dai), address(gem), amountIn, tooHigh, receiver);
+    }
+
+    function test_swap_buyGem_revertsOnZeroGemAmt() public {
+        MockPSM mockPSM = new MockPSM(address(dai), address(gem));
+        mockPSM.setTout(0);
+
+        PSMSwapper s = new PSMSwapper(
+            address(mockPSM),
+            PSMSwapper.Route.BUY_GEM,
+            address(dai),
+            address(gem),
+            CONVERSION_FACTOR
+        );
+
+        // amountIn too small: 999 wei of DAI with 1e12 conversion = gemAmt truncates to 0
+        uint256 tinyAmount = CONVERSION_FACTOR - 1;
+        dai.mint(address(s), tinyAmount);
+
+        vm.expectRevert(abi.encodeWithSelector(PSMSwapper.InsufficientOutput.selector, 1, 0));
+        s.swap(address(dai), address(gem), tinyAmount, 0, receiver);
     }
 
     function test_swap_daiToUsds_insufficientOutput() public {

--- a/test/unit/swappers/PSMSwapper.t.sol
+++ b/test/unit/swappers/PSMSwapper.t.sol
@@ -61,6 +61,18 @@ contract PSMSwapperTest is Test {
         new PSMSwapper(protocol, PSMSwapper.Route.SELL_GEM, address(gem), address(0), 0);
     }
 
+    function test_constructor_revertsOnZeroConversionFactorForBuyGem() public {
+        vm.expectRevert(PSMSwapper.InvalidConversionFactor.selector);
+        new PSMSwapper(protocol, PSMSwapper.Route.BUY_GEM, address(dai), address(gem), 0);
+    }
+
+    function test_constructor_allowsZeroConversionFactorForNonBuyGemRoutes() public {
+        // SELL_GEM, DAI_TO_USDS, USDS_TO_DAI should all accept conversionFactor = 0
+        new PSMSwapper(protocol, PSMSwapper.Route.SELL_GEM, address(gem), address(dai), 0);
+        new PSMSwapper(protocol, PSMSwapper.Route.DAI_TO_USDS, address(dai), address(usds), 0);
+        new PSMSwapper(protocol, PSMSwapper.Route.USDS_TO_DAI, address(usds), address(dai), 0);
+    }
+
     // ═══════════════════════════════════════════════════════════
     // SWAP — TOKEN MISMATCH
     // ═══════════════════════════════════════════════════════════
@@ -279,9 +291,7 @@ contract PSMSwapperTest is Test {
         uint256 amountIn = 1000e18;
         dai.mint(address(s), amountIn);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(PSMSwapper.NonOneToOneConversion.selector, amountIn, amountIn - 1)
-        );
+        vm.expectRevert(abi.encodeWithSelector(PSMSwapper.NonOneToOneConversion.selector, amountIn, amountIn - 1));
         s.swap(address(dai), address(usds), amountIn, 0, receiver);
     }
 
@@ -299,9 +309,7 @@ contract PSMSwapperTest is Test {
         uint256 amountIn = 1000e18;
         usds.mint(address(s), amountIn);
 
-        vm.expectRevert(
-            abi.encodeWithSelector(PSMSwapper.NonOneToOneConversion.selector, amountIn, amountIn - 1)
-        );
+        vm.expectRevert(abi.encodeWithSelector(PSMSwapper.NonOneToOneConversion.selector, amountIn, amountIn - 1));
         s.swap(address(usds), address(dai), amountIn, 0, receiver);
     }
 }

--- a/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
@@ -1,0 +1,180 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { ISwapRouter } from "@tokenized-strategy-periphery/interfaces/Uniswap/V3/ISwapRouter.sol";
+
+import { UniswapV3SwapperAdapter } from "src/swappers/UniswapV3SwapperAdapter.sol";
+
+contract UniswapV3SwapperAdapterTest is Test {
+    ERC20Mock public tokenA;
+    ERC20Mock public tokenB;
+    ERC20Mock public baseToken;
+    MockUniRouter public router;
+
+    address public receiver = address(0xBEEF);
+
+    uint24 internal constant FEE = 3000;
+    uint24 internal constant FEE_OUT = 500;
+
+    function setUp() public {
+        tokenA = new ERC20Mock();
+        tokenB = new ERC20Mock();
+        baseToken = new ERC20Mock();
+        router = new MockUniRouter();
+
+        vm.label(address(tokenA), "TokenA");
+        vm.label(address(tokenB), "TokenB");
+        vm.label(address(baseToken), "BaseToken");
+        vm.label(address(router), "Router");
+        vm.label(receiver, "Receiver");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // CONSTRUCTOR TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_constructor_setsImmutables() public {
+        UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
+        assertEq(s.router(), address(router));
+        assertEq(s.fee(), FEE);
+        assertEq(s.base(), address(baseToken));
+        assertEq(s.feeOut(), FEE_OUT);
+    }
+
+    function test_constructor_revertsOnZeroRouter() public {
+        vm.expectRevert(UniswapV3SwapperAdapter.InvalidRouter.selector);
+        new UniswapV3SwapperAdapter(address(0), FEE, address(baseToken), FEE_OUT);
+    }
+
+    function test_constructor_allowsZeroBase() public {
+        // base == address(0) is valid — means direct swap
+        UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(0), 0);
+        assertEq(s.base(), address(0));
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — TOKEN VALIDATION
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_revertsOnZeroTokenIn() public {
+        UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(0), 0);
+        vm.expectRevert(UniswapV3SwapperAdapter.InvalidToken.selector);
+        s.swap(address(0), address(tokenB), 100, 0, receiver);
+    }
+
+    function test_swap_revertsOnZeroTokenOut() public {
+        UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(0), 0);
+        vm.expectRevert(UniswapV3SwapperAdapter.InvalidToken.selector);
+        s.swap(address(tokenA), address(0), 100, 0, receiver);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — SINGLE-HOP (no base)
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_singleHop_noBase() public {
+        UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(0), 0);
+
+        uint256 amountIn = 1000e18;
+        tokenA.mint(address(s), amountIn);
+
+        router.setOutputToken(address(tokenB));
+
+        uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "Single-hop should return 1:1 from mock");
+        assertEq(tokenB.balanceOf(receiver), amountOut, "Receiver should have output");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — SINGLE-HOP (tokenOut == base)
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_singleHop_tokenOutIsBase() public {
+        // base != 0, tokenOut == base => single-hop with fee
+        UniswapV3SwapperAdapter s =
+            new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
+
+        uint256 amountIn = 500e18;
+        tokenA.mint(address(s), amountIn);
+        router.setOutputToken(address(baseToken));
+
+        uint256 amountOut = s.swap(address(tokenA), address(baseToken), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "tokenOut==base: single-hop 1:1");
+        assertEq(baseToken.balanceOf(receiver), amountOut);
+        // Verify fee used is `fee` (not feeOut) — captured in mock
+        assertEq(router.lastFee(), FEE, "Should use fee when tokenOut==base");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — SINGLE-HOP (tokenIn == base)
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_singleHop_tokenInIsBase() public {
+        // base != 0, tokenIn == base => single-hop with feeOut
+        UniswapV3SwapperAdapter s =
+            new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
+
+        uint256 amountIn = 500e18;
+        baseToken.mint(address(s), amountIn);
+        router.setOutputToken(address(tokenB));
+
+        uint256 amountOut = s.swap(address(baseToken), address(tokenB), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "tokenIn==base: single-hop 1:1");
+        assertEq(tokenB.balanceOf(receiver), amountOut);
+        // Verify fee used is `feeOut` (not fee) — captured in mock
+        assertEq(router.lastFee(), FEE_OUT, "Should use feeOut when tokenIn==base");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — MULTI-HOP
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_multiHop() public {
+        UniswapV3SwapperAdapter s =
+            new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
+
+        uint256 amountIn = 1000e18;
+        tokenA.mint(address(s), amountIn);
+        router.setOutputToken(address(tokenB));
+
+        uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "Multi-hop should return 1:1 from mock");
+        assertEq(tokenB.balanceOf(receiver), amountOut);
+        assertTrue(router.lastWasMultiHop(), "Should have used multi-hop path");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════
+// MOCK UNISWAP V3 ROUTER
+// ═══════════════════════════════════════════════════════════
+
+contract MockUniRouter {
+    address public outputToken;
+    uint24 public lastFee;
+    bool public lastWasMultiHop;
+
+    function setOutputToken(address _token) external {
+        outputToken = _token;
+    }
+
+    function exactInputSingle(
+        ISwapRouter.ExactInputSingleParams calldata params
+    ) external returns (uint256 amountOut) {
+        lastFee = params.fee;
+        lastWasMultiHop = false;
+        amountOut = params.amountIn;
+        ERC20Mock(outputToken).mint(params.recipient, amountOut);
+    }
+
+    function exactInput(ISwapRouter.ExactInputParams calldata params) external returns (uint256 amountOut) {
+        lastWasMultiHop = true;
+        amountOut = params.amountIn;
+        ERC20Mock(outputToken).mint(params.recipient, amountOut);
+    }
+}

--- a/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
@@ -94,8 +94,7 @@ contract UniswapV3SwapperAdapterTest is Test {
 
     function test_swap_singleHop_tokenOutIsBase() public {
         // base != 0, tokenOut == base => single-hop with fee
-        UniswapV3SwapperAdapter s =
-            new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
+        UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
 
         uint256 amountIn = 500e18;
         tokenA.mint(address(s), amountIn);
@@ -115,8 +114,7 @@ contract UniswapV3SwapperAdapterTest is Test {
 
     function test_swap_singleHop_tokenInIsBase() public {
         // base != 0, tokenIn == base => single-hop with feeOut
-        UniswapV3SwapperAdapter s =
-            new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
+        UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
 
         uint256 amountIn = 500e18;
         baseToken.mint(address(s), amountIn);
@@ -135,8 +133,7 @@ contract UniswapV3SwapperAdapterTest is Test {
     // ═══════════════════════════════════════════════════════════
 
     function test_swap_multiHop() public {
-        UniswapV3SwapperAdapter s =
-            new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
+        UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
 
         uint256 amountIn = 1000e18;
         tokenA.mint(address(s), amountIn);
@@ -163,9 +160,7 @@ contract MockUniRouter {
         outputToken = _token;
     }
 
-    function exactInputSingle(
-        ISwapRouter.ExactInputSingleParams calldata params
-    ) external returns (uint256 amountOut) {
+    function exactInputSingle(ISwapRouter.ExactInputSingleParams calldata params) external returns (uint256 amountOut) {
         lastFee = params.fee;
         lastWasMultiHop = false;
         amountOut = params.amountIn;

--- a/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
@@ -38,7 +38,14 @@ contract UniswapV4SwapperAdapterTest is Test {
 
     function test_constructor_setsImmutables() public {
         UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
-            address(pm), FEE, TICK_SPACING, address(0), address(baseToken), FEE_OUT, TICK_SPACING_OUT, address(0)
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(baseToken),
+            FEE_OUT,
+            TICK_SPACING_OUT,
+            address(0)
         );
         assertEq(s.poolManager(), address(pm));
         assertEq(s.fee(), FEE);
@@ -63,21 +70,44 @@ contract UniswapV4SwapperAdapterTest is Test {
     function test_constructor_revertsOnZeroTickSpacingOutWithBase() public {
         vm.expectRevert(UniswapV4SwapperAdapter.InvalidTickSpacing.selector);
         new UniswapV4SwapperAdapter(
-            address(pm), FEE, TICK_SPACING, address(0), address(baseToken), FEE_OUT, 0, address(0)
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(baseToken),
+            FEE_OUT,
+            0,
+            address(0)
         );
     }
 
     function test_constructor_allowsZeroBase() public {
         // base == address(0) is valid — means direct swap
-        UniswapV4SwapperAdapter s =
-            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
         assertEq(s.base(), address(0));
     }
 
     function test_constructor_allowsZeroTickSpacingOutWhenNoBase() public {
         // tickSpacingOut == 0 is fine when base == address(0) (second hop not used)
-        UniswapV4SwapperAdapter s =
-            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
         assertEq(s.tickSpacingOut(), 0);
     }
 
@@ -86,15 +116,31 @@ contract UniswapV4SwapperAdapterTest is Test {
     // ═══════════════════════════════════════════════════════════
 
     function test_swap_revertsOnZeroTokenIn() public {
-        UniswapV4SwapperAdapter s =
-            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
         vm.expectRevert(UniswapV4SwapperAdapter.InvalidToken.selector);
         s.swap(address(0), address(tokenB), 100, 0, receiver);
     }
 
     function test_swap_revertsOnZeroTokenOut() public {
-        UniswapV4SwapperAdapter s =
-            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
         vm.expectRevert(UniswapV4SwapperAdapter.InvalidToken.selector);
         s.swap(address(tokenA), address(0), 100, 0, receiver);
     }
@@ -104,8 +150,16 @@ contract UniswapV4SwapperAdapterTest is Test {
     // ═══════════════════════════════════════════════════════════
 
     function test_unlockCallback_revertsUnauthorized() public {
-        UniswapV4SwapperAdapter s =
-            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
 
         // Call unlockCallback directly (not from poolManager)
         vm.expectRevert(UniswapV4SwapperAdapter.UnauthorizedCallback.selector);
@@ -117,8 +171,16 @@ contract UniswapV4SwapperAdapterTest is Test {
     // ═══════════════════════════════════════════════════════════
 
     function test_swap_singleHop_noBase() public {
-        UniswapV4SwapperAdapter s =
-            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
 
         uint256 amountIn = 1000e18;
         tokenA.mint(address(s), amountIn);
@@ -137,7 +199,14 @@ contract UniswapV4SwapperAdapterTest is Test {
 
     function test_swap_singleHop_tokenOutIsBase() public {
         UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
-            address(pm), FEE, TICK_SPACING, address(0), address(baseToken), FEE_OUT, TICK_SPACING_OUT, address(0)
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(baseToken),
+            FEE_OUT,
+            TICK_SPACING_OUT,
+            address(0)
         );
 
         uint256 amountIn = 500e18;
@@ -159,7 +228,14 @@ contract UniswapV4SwapperAdapterTest is Test {
 
     function test_swap_singleHop_tokenInIsBase() public {
         UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
-            address(pm), FEE, TICK_SPACING, address(0), address(baseToken), FEE_OUT, TICK_SPACING_OUT, address(0)
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(baseToken),
+            FEE_OUT,
+            TICK_SPACING_OUT,
+            address(0)
         );
 
         uint256 amountIn = 500e18;
@@ -181,7 +257,14 @@ contract UniswapV4SwapperAdapterTest is Test {
 
     function test_swap_multiHop() public {
         UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
-            address(pm), FEE, TICK_SPACING, address(0), address(baseToken), FEE_OUT, TICK_SPACING_OUT, address(0)
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(baseToken),
+            FEE_OUT,
+            TICK_SPACING_OUT,
+            address(0)
         );
 
         uint256 amountIn = 1000e18;
@@ -200,8 +283,16 @@ contract UniswapV4SwapperAdapterTest is Test {
     // ═══════════════════════════════════════════════════════════
 
     function test_swap_revertsOnInsufficientOutput() public {
-        UniswapV4SwapperAdapter s =
-            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
 
         uint256 amountIn = 1000e18;
         tokenA.mint(address(s), amountIn);
@@ -217,8 +308,16 @@ contract UniswapV4SwapperAdapterTest is Test {
     // ═══════════════════════════════════════════════════════════
 
     function test_swap_correctZeroForOne() public {
-        UniswapV4SwapperAdapter s =
-            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
 
         uint256 amountIn = 100e18;
 
@@ -235,8 +334,16 @@ contract UniswapV4SwapperAdapterTest is Test {
     }
 
     function test_swap_correctNotZeroForOne() public {
-        UniswapV4SwapperAdapter s =
-            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
 
         uint256 amountIn = 100e18;
 
@@ -320,7 +427,7 @@ contract MockV4PoolManager {
     }
 
     /// @dev No-op for mock — balance snapshot
-    function sync(address /* currency */ ) external { }
+    function sync(address /* currency */) external {}
 
     /// @dev No-op for mock — settlement accounting
     function settle() external payable returns (uint256) {

--- a/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
@@ -1,0 +1,338 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+
+import { UniswapV4SwapperAdapter, IV4PoolManager } from "src/swappers/UniswapV4SwapperAdapter.sol";
+
+contract UniswapV4SwapperAdapterTest is Test {
+    ERC20Mock public tokenA;
+    ERC20Mock public tokenB;
+    ERC20Mock public baseToken;
+    MockV4PoolManager public pm;
+
+    address public receiver = address(0xBEEF);
+
+    uint24 internal constant FEE = 3000;
+    uint24 internal constant FEE_OUT = 500;
+    int24 internal constant TICK_SPACING = 60;
+    int24 internal constant TICK_SPACING_OUT = 10;
+
+    function setUp() public {
+        tokenA = new ERC20Mock();
+        tokenB = new ERC20Mock();
+        baseToken = new ERC20Mock();
+        pm = new MockV4PoolManager();
+
+        vm.label(address(tokenA), "TokenA");
+        vm.label(address(tokenB), "TokenB");
+        vm.label(address(baseToken), "BaseToken");
+        vm.label(address(pm), "PoolManager");
+        vm.label(receiver, "Receiver");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // CONSTRUCTOR TESTS
+    // ═══════════════════════════════════════════════════════════
+
+    function test_constructor_setsImmutables() public {
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm), FEE, TICK_SPACING, address(0), address(baseToken), FEE_OUT, TICK_SPACING_OUT, address(0)
+        );
+        assertEq(s.poolManager(), address(pm));
+        assertEq(s.fee(), FEE);
+        assertEq(s.tickSpacing(), TICK_SPACING);
+        assertEq(s.hooks(), address(0));
+        assertEq(s.base(), address(baseToken));
+        assertEq(s.feeOut(), FEE_OUT);
+        assertEq(s.tickSpacingOut(), TICK_SPACING_OUT);
+        assertEq(s.hooksOut(), address(0));
+    }
+
+    function test_constructor_revertsOnZeroPoolManager() public {
+        vm.expectRevert(UniswapV4SwapperAdapter.InvalidPoolManager.selector);
+        new UniswapV4SwapperAdapter(address(0), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+    }
+
+    function test_constructor_revertsOnZeroTickSpacing() public {
+        vm.expectRevert(UniswapV4SwapperAdapter.InvalidTickSpacing.selector);
+        new UniswapV4SwapperAdapter(address(pm), FEE, 0, address(0), address(0), 0, 0, address(0));
+    }
+
+    function test_constructor_revertsOnZeroTickSpacingOutWithBase() public {
+        vm.expectRevert(UniswapV4SwapperAdapter.InvalidTickSpacing.selector);
+        new UniswapV4SwapperAdapter(
+            address(pm), FEE, TICK_SPACING, address(0), address(baseToken), FEE_OUT, 0, address(0)
+        );
+    }
+
+    function test_constructor_allowsZeroBase() public {
+        // base == address(0) is valid — means direct swap
+        UniswapV4SwapperAdapter s =
+            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        assertEq(s.base(), address(0));
+    }
+
+    function test_constructor_allowsZeroTickSpacingOutWhenNoBase() public {
+        // tickSpacingOut == 0 is fine when base == address(0) (second hop not used)
+        UniswapV4SwapperAdapter s =
+            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        assertEq(s.tickSpacingOut(), 0);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — TOKEN VALIDATION
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_revertsOnZeroTokenIn() public {
+        UniswapV4SwapperAdapter s =
+            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        vm.expectRevert(UniswapV4SwapperAdapter.InvalidToken.selector);
+        s.swap(address(0), address(tokenB), 100, 0, receiver);
+    }
+
+    function test_swap_revertsOnZeroTokenOut() public {
+        UniswapV4SwapperAdapter s =
+            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+        vm.expectRevert(UniswapV4SwapperAdapter.InvalidToken.selector);
+        s.swap(address(tokenA), address(0), 100, 0, receiver);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — UNAUTHORIZED CALLBACK
+    // ═══════════════════════════════════════════════════════════
+
+    function test_unlockCallback_revertsUnauthorized() public {
+        UniswapV4SwapperAdapter s =
+            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+
+        // Call unlockCallback directly (not from poolManager)
+        vm.expectRevert(UniswapV4SwapperAdapter.UnauthorizedCallback.selector);
+        s.unlockCallback(abi.encode(address(tokenA), address(tokenB), uint256(100), uint256(0), receiver));
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — SINGLE-HOP (no base)
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_singleHop_noBase() public {
+        UniswapV4SwapperAdapter s =
+            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+
+        uint256 amountIn = 1000e18;
+        tokenA.mint(address(s), amountIn);
+
+        pm.setOutputToken(address(tokenB));
+
+        uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "Single-hop should return 1:1 from mock");
+        assertEq(tokenB.balanceOf(receiver), amountOut, "Receiver should have output");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — SINGLE-HOP (tokenOut == base)
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_singleHop_tokenOutIsBase() public {
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm), FEE, TICK_SPACING, address(0), address(baseToken), FEE_OUT, TICK_SPACING_OUT, address(0)
+        );
+
+        uint256 amountIn = 500e18;
+        tokenA.mint(address(s), amountIn);
+        pm.setOutputToken(address(baseToken));
+
+        uint256 amountOut = s.swap(address(tokenA), address(baseToken), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "tokenOut==base: single-hop 1:1");
+        assertEq(baseToken.balanceOf(receiver), amountOut);
+        // Verify pool config used is first-hop (fee, tickSpacing, hooks)
+        assertEq(pm.lastPoolFee(), FEE, "Should use fee when tokenOut==base");
+        assertEq(pm.lastPoolTickSpacing(), TICK_SPACING, "Should use tickSpacing when tokenOut==base");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — SINGLE-HOP (tokenIn == base)
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_singleHop_tokenInIsBase() public {
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm), FEE, TICK_SPACING, address(0), address(baseToken), FEE_OUT, TICK_SPACING_OUT, address(0)
+        );
+
+        uint256 amountIn = 500e18;
+        baseToken.mint(address(s), amountIn);
+        pm.setOutputToken(address(tokenB));
+
+        uint256 amountOut = s.swap(address(baseToken), address(tokenB), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "tokenIn==base: single-hop 1:1");
+        assertEq(tokenB.balanceOf(receiver), amountOut);
+        // Verify pool config used is second-hop (feeOut, tickSpacingOut, hooksOut)
+        assertEq(pm.lastPoolFee(), FEE_OUT, "Should use feeOut when tokenIn==base");
+        assertEq(pm.lastPoolTickSpacing(), TICK_SPACING_OUT, "Should use tickSpacingOut when tokenIn==base");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — MULTI-HOP
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_multiHop() public {
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm), FEE, TICK_SPACING, address(0), address(baseToken), FEE_OUT, TICK_SPACING_OUT, address(0)
+        );
+
+        uint256 amountIn = 1000e18;
+        tokenA.mint(address(s), amountIn);
+        pm.setOutputToken(address(tokenB));
+
+        uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "Multi-hop should return 1:1 from mock");
+        assertEq(tokenB.balanceOf(receiver), amountOut);
+        assertEq(pm.swapCallCount(), 2, "Should have called swap twice for multi-hop");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — INSUFFICIENT OUTPUT
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_revertsOnInsufficientOutput() public {
+        UniswapV4SwapperAdapter s =
+            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+
+        uint256 amountIn = 1000e18;
+        tokenA.mint(address(s), amountIn);
+        pm.setOutputToken(address(tokenB));
+        pm.setOutputRate(5e17); // 50% output rate
+
+        vm.expectRevert(abi.encodeWithSelector(UniswapV4SwapperAdapter.InsufficientOutput.selector, amountIn, 500e18));
+        s.swap(address(tokenA), address(tokenB), amountIn, amountIn, receiver);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — DIRECTION CORRECTNESS (zeroForOne)
+    // ═══════════════════════════════════════════════════════════
+
+    function test_swap_correctZeroForOne() public {
+        UniswapV4SwapperAdapter s =
+            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+
+        uint256 amountIn = 100e18;
+
+        // Ensure tokenA < tokenB for deterministic zeroForOne
+        address low = address(tokenA) < address(tokenB) ? address(tokenA) : address(tokenB);
+        address high = address(tokenA) < address(tokenB) ? address(tokenB) : address(tokenA);
+
+        ERC20Mock(low).mint(address(s), amountIn);
+        pm.setOutputToken(high);
+
+        s.swap(low, high, amountIn, 0, receiver);
+
+        assertTrue(pm.lastZeroForOne(), "tokenIn < tokenOut should be zeroForOne=true");
+    }
+
+    function test_swap_correctNotZeroForOne() public {
+        UniswapV4SwapperAdapter s =
+            new UniswapV4SwapperAdapter(address(pm), FEE, TICK_SPACING, address(0), address(0), 0, 0, address(0));
+
+        uint256 amountIn = 100e18;
+
+        address low = address(tokenA) < address(tokenB) ? address(tokenA) : address(tokenB);
+        address high = address(tokenA) < address(tokenB) ? address(tokenB) : address(tokenA);
+
+        ERC20Mock(high).mint(address(s), amountIn);
+        pm.setOutputToken(low);
+
+        s.swap(high, low, amountIn, 0, receiver);
+
+        assertFalse(pm.lastZeroForOne(), "tokenIn > tokenOut should be zeroForOne=false");
+    }
+}
+
+// ═══════════════════════════════════════════════════════════
+// MOCK UNISWAP V4 POOL MANAGER
+// ═══════════════════════════════════════════════════════════
+
+/// @dev Mock PoolManager that simulates the V4 unlock/callback/swap/settle/take flow.
+///      Uses a configurable output rate (default 1:1) and mints output tokens via take().
+contract MockV4PoolManager {
+    address public outputToken;
+    uint256 public outputRate = 1e18; // 1:1 by default (1e18 = 100%)
+
+    // Tracked for assertions
+    uint24 public lastPoolFee;
+    int24 public lastPoolTickSpacing;
+    bool public lastZeroForOne;
+    uint256 public swapCallCount;
+
+    function setOutputToken(address _token) external {
+        outputToken = _token;
+    }
+
+    function setOutputRate(uint256 _rate) external {
+        outputRate = _rate;
+    }
+
+    function resetSwapCallCount() external {
+        swapCallCount = 0;
+    }
+
+    /// @dev Calls back the sender's unlockCallback, simulating the PM unlock pattern
+    function unlock(bytes calldata data) external returns (bytes memory) {
+        swapCallCount = 0; // reset per unlock
+        return IUnlockCallbackMock(msg.sender).unlockCallback(data);
+    }
+
+    /// @dev Returns a packed BalanceDelta simulating an exact-input swap.
+    ///      For zeroForOne=true:  amount0 (negative, input) | amount1 (positive, output)
+    ///      For zeroForOne=false: amount0 (positive, output) | amount1 (negative, input)
+    function swap(
+        IV4PoolManager.PoolKey memory key,
+        IV4PoolManager.SwapParams memory params,
+        bytes calldata /* hookData */
+    ) external returns (int256) {
+        lastPoolFee = key.fee;
+        lastPoolTickSpacing = key.tickSpacing;
+        lastZeroForOne = params.zeroForOne;
+        swapCallCount++;
+
+        uint256 absAmountIn = uint256(-params.amountSpecified); // amountSpecified is negative for exactInput
+        uint256 amountOut = (absAmountIn * outputRate) / 1e18;
+
+        int128 inputDelta = -int128(int256(absAmountIn)); // negative: caller pays
+        int128 outputDelta = int128(int256(amountOut)); // positive: caller receives
+
+        int128 d0;
+        int128 d1;
+        if (params.zeroForOne) {
+            d0 = inputDelta; // currency0 = input (negative)
+            d1 = outputDelta; // currency1 = output (positive)
+        } else {
+            d0 = outputDelta; // currency0 = output (positive)
+            d1 = inputDelta; // currency1 = input (negative)
+        }
+
+        // Pack as BalanceDelta: upper 128 bits = amount0, lower 128 bits = amount1
+        return (int256(d0) << 128) | int256(uint256(uint128(d1)));
+    }
+
+    /// @dev No-op for mock — balance snapshot
+    function sync(address /* currency */ ) external { }
+
+    /// @dev No-op for mock — settlement accounting
+    function settle() external payable returns (uint256) {
+        return 0;
+    }
+
+    /// @dev Mints output tokens to the recipient, simulating PM token release
+    function take(address /* currency */, address to, uint256 amount) external {
+        ERC20Mock(outputToken).mint(to, amount);
+    }
+}
+
+interface IUnlockCallbackMock {
+    function unlockCallback(bytes calldata data) external returns (bytes memory);
+}

--- a/verification/kontrol/MockForwarderStrategy.k.sol
+++ b/verification/kontrol/MockForwarderStrategy.k.sol
@@ -13,6 +13,10 @@ pragma solidity ^0.8.0;
  *        slot 2: mockAsset          -- returned by asset()
  *        slot 3: lastRedeemReceiver -- captures receiver arg from redeem()
  *        slot 4: lastRedeemShares   -- captures shares arg from redeem()
+ *        slot 5: lastReportCaller   -- captures msg.sender from report()
+ *        slot 6: expectedBalanceOfAccount -- only this account has shares
+ *        slot 7: lastRedeemOwner    -- captures owner arg from redeem()
+ *        slot 8: lastRedeemMaxLoss  -- captures maxLoss arg from redeem()
  */
 contract MockForwarderStrategy {
     uint256 public mockShareBalance;
@@ -20,23 +24,32 @@ contract MockForwarderStrategy {
     address public mockAsset;
     address public lastRedeemReceiver;
     uint256 public lastRedeemShares;
+    address public lastReportCaller;
+    address public expectedBalanceOfAccount;
+    address public lastRedeemOwner;
+    uint256 public lastRedeemMaxLoss;
 
-    /// @notice No-op report; strategy report logic is verified by existing YD/YS Kontrol proofs
-    /// @dev Self-assignment prevents pure/view optimization to match real IReportable mutability
+    /// @notice No-op report that still records the caller
     function report() external returns (uint256, uint256) {
-        mockShareBalance = mockShareBalance;
+        lastReportCaller = msg.sender;
         return (0, 0);
     }
 
-    /// @notice Returns the controllable mock share balance for any address
-    function balanceOf(address) external view returns (uint256) {
+    /// @notice Returns shares only for the configured forwarder account
+    function balanceOf(address account) external view returns (uint256) {
+        if (account != expectedBalanceOfAccount) {
+            return 0;
+        }
+
         return mockShareBalance;
     }
 
     /// @notice Mock redeem that captures arguments and zeroes share balance
-    function redeem(uint256 shares, address receiver, address, uint256) external returns (uint256) {
+    function redeem(uint256 shares, address receiver, address owner, uint256 maxLoss) external returns (uint256) {
         lastRedeemShares = shares;
         lastRedeemReceiver = receiver;
+        lastRedeemOwner = owner;
+        lastRedeemMaxLoss = maxLoss;
         mockShareBalance = 0;
         return mockRedeemReturn;
     }

--- a/verification/kontrol/MockForwarderStrategy.k.sol
+++ b/verification/kontrol/MockForwarderStrategy.k.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title MockForwarderStrategy
+ * @notice Minimal mock for Kontrol formal verification of YieldForwarder contracts
+ * @dev Implements IReportable, IRedeemable, IERC20.balanceOf, and IERC4626Asset.asset()
+ *      with controllable return values. Does not interact with any external contracts.
+ *
+ *      Storage layout (all plain slots, no ERC-7201):
+ *        slot 0: mockShareBalance   -- returned by balanceOf()
+ *        slot 1: mockRedeemReturn   -- returned by redeem()
+ *        slot 2: mockAsset          -- returned by asset()
+ *        slot 3: lastRedeemReceiver -- captures receiver arg from redeem()
+ *        slot 4: lastRedeemShares   -- captures shares arg from redeem()
+ */
+contract MockForwarderStrategy {
+    uint256 public mockShareBalance;
+    uint256 public mockRedeemReturn;
+    address public mockAsset;
+    address public lastRedeemReceiver;
+    uint256 public lastRedeemShares;
+
+    /// @notice No-op report; strategy report logic is verified by existing YD/YS Kontrol proofs
+    /// @dev Self-assignment prevents pure/view optimization to match real IReportable mutability
+    function report() external returns (uint256, uint256) {
+        mockShareBalance = mockShareBalance;
+        return (0, 0);
+    }
+
+    /// @notice Returns the controllable mock share balance for any address
+    function balanceOf(address) external view returns (uint256) {
+        return mockShareBalance;
+    }
+
+    /// @notice Mock redeem that captures arguments and zeroes share balance
+    function redeem(uint256 shares, address receiver, address, uint256) external returns (uint256) {
+        lastRedeemShares = shares;
+        lastRedeemReceiver = receiver;
+        mockShareBalance = 0;
+        return mockRedeemReturn;
+    }
+
+    /// @notice Returns the mock underlying asset address
+    function asset() external view returns (address) {
+        return mockAsset;
+    }
+}

--- a/verification/kontrol/MockForwarderSwapper.k.sol
+++ b/verification/kontrol/MockForwarderSwapper.k.sol
@@ -12,6 +12,7 @@ pragma solidity ^0.8.0;
  *        slot 2: lastTokenIn       -- captures tokenIn arg
  *        slot 3: lastTokenOut      -- captures tokenOut arg
  *        slot 4: lastAmountIn      -- captures amountIn arg
+ *        slot 5: lastMinAmountOut  -- captures minAmountOut arg
  */
 contract MockForwarderSwapper {
     uint256 public mockSwapReturn;
@@ -19,18 +20,20 @@ contract MockForwarderSwapper {
     address public lastTokenIn;
     address public lastTokenOut;
     uint256 public lastAmountIn;
+    uint256 public lastMinAmountOut;
 
     /// @notice Mock swap that captures arguments and returns controllable output
     function swap(
         address tokenIn,
         address tokenOut,
         uint256 amountIn,
-        uint256,
+        uint256 minAmountOut,
         address receiver
     ) external returns (uint256) {
         lastTokenIn = tokenIn;
         lastTokenOut = tokenOut;
         lastAmountIn = amountIn;
+        lastMinAmountOut = minAmountOut;
         lastSwapReceiver = receiver;
         return mockSwapReturn;
     }

--- a/verification/kontrol/MockForwarderSwapper.k.sol
+++ b/verification/kontrol/MockForwarderSwapper.k.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title MockForwarderSwapper
+ * @notice Minimal ISwapper mock for Kontrol formal verification of SwappingYieldForwarder
+ * @dev Controllable swap return value with argument capture for property assertions.
+ *
+ *      Storage layout (all plain slots, no ERC-7201):
+ *        slot 0: mockSwapReturn    -- returned by swap()
+ *        slot 1: lastSwapReceiver  -- captures receiver arg
+ *        slot 2: lastTokenIn       -- captures tokenIn arg
+ *        slot 3: lastTokenOut      -- captures tokenOut arg
+ *        slot 4: lastAmountIn      -- captures amountIn arg
+ */
+contract MockForwarderSwapper {
+    uint256 public mockSwapReturn;
+    address public lastSwapReceiver;
+    address public lastTokenIn;
+    address public lastTokenOut;
+    uint256 public lastAmountIn;
+
+    /// @notice Mock swap that captures arguments and returns controllable output
+    function swap(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256,
+        address receiver
+    ) external returns (uint256) {
+        lastTokenIn = tokenIn;
+        lastTokenOut = tokenOut;
+        lastAmountIn = amountIn;
+        lastSwapReceiver = receiver;
+        return mockSwapReturn;
+    }
+}

--- a/verification/kontrol/SYFSetup.k.sol
+++ b/verification/kontrol/SYFSetup.k.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { SwappingYieldForwarder } from "src/core/SwappingYieldForwarder.sol";
+
+import { KontrolTest } from "test/kontrol/KontrolTest.k.sol";
+import { TestERC20 } from "test/kontrol/TestERC20.k.sol";
+import { MockForwarderStrategy } from "test/kontrol/MockForwarderStrategy.k.sol";
+import { MockForwarderSwapper } from "test/kontrol/MockForwarderSwapper.k.sol";
+import "test/kontrol/SharedStateSlots.k.sol";
+
+/**
+ * @title SYFSetup
+ * @notice Symbolic setup for formal verification of SwappingYieldForwarder
+ * @dev Deploys SwappingYieldForwarder with concrete role addresses, a MockForwarderStrategy
+ *      with symbolic storage, a MockForwarderSwapper with symbolic swap return, and a real
+ *      TestERC20 for the underlying asset (required for safeTransfer in the swap path).
+ *
+ *      The forwarder's ERC20 balance is pre-loaded to simulate tokens received from redeem().
+ *      The mock redeem() does not actually transfer tokens, so we write the balance directly.
+ */
+contract SYFSetup is KontrolTest {
+    SwappingYieldForwarder public syfForwarder;
+    MockForwarderStrategy public mockStrategy;
+    MockForwarderSwapper public mockSwapper;
+    TestERC20 public sourceAsset;
+    TestERC20 public targetAsset;
+
+    address internal _receiver;
+    address internal _keeper;
+
+    function setUp() public virtual {
+        // Concrete role addresses
+        _receiver = makeAddr("RECEIVER");
+        _keeper = makeAddr("KEEPER");
+
+        // Deploy real ERC20s (needed for safeTransfer in swap path)
+        sourceAsset = new TestERC20();
+        targetAsset = new TestERC20();
+
+        // Deploy mocks
+        mockStrategy = new MockForwarderStrategy();
+        mockSwapper = new MockForwarderSwapper();
+
+        // Deploy SwappingYieldForwarder with concrete immutables
+        syfForwarder = new SwappingYieldForwarder(_receiver, _keeper, address(targetAsset), address(mockSwapper));
+
+        // ============================================
+        // MAKE MOCK STRATEGY STORAGE SYMBOLIC
+        // ============================================
+        kevm.symbolicStorage(address(mockStrategy));
+
+        // Restore concrete asset address to the real ERC20
+        _storeAddress(address(mockStrategy), MFS_ASSET_SLOT, address(sourceAsset));
+
+        // Set symbolic share balance and redeem return
+        uint256 shareBalance = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, shareBalance);
+
+        uint256 redeemReturn = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, redeemReturn);
+
+        // Clear argument capture slots
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);
+        _storeAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT, address(0));
+
+        // ============================================
+        // MAKE MOCK SWAPPER STORAGE SYMBOLIC
+        // ============================================
+        kevm.symbolicStorage(address(mockSwapper));
+
+        // Set symbolic swap return
+        uint256 swapReturn = freshUInt256Bounded();
+        _storeUInt256(address(mockSwapper), MSWP_RETURN_SLOT, swapReturn);
+
+        // Clear argument capture slots
+        _storeAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT, address(0));
+        _storeAddress(address(mockSwapper), MSWP_LAST_TOKEN_IN_SLOT, address(0));
+        _storeAddress(address(mockSwapper), MSWP_LAST_TOKEN_OUT_SLOT, address(0));
+        _storeUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT, 0);
+
+        // ============================================
+        // PRE-LOAD FORWARDER ERC20 BALANCE
+        // ============================================
+        // The mock redeem() doesn't transfer actual tokens, so we pre-load the
+        // forwarder's balance in sourceAsset to equal redeemReturn. This simulates
+        // the tokens the forwarder would receive from a real redeem() call.
+        //
+        // Also set totalSupply >= balance to satisfy ERC20 invariants.
+        _storeMappingUInt256(
+            address(sourceAsset),
+            ERC20_BALANCES_SLOT,
+            uint256(uint160(address(syfForwarder))),
+            0,
+            redeemReturn
+        );
+        // Set totalSupply to redeemReturn (slot 2 for OZ ERC20)
+        _storeUInt256(address(sourceAsset), 2, redeemReturn);
+
+        // ============================================
+        // SET FORWARDER REENTRANCY GUARD TO NOT_ENTERED
+        // ============================================
+        _storeUInt256(address(syfForwarder), RG_STATUS_SLOT, RG_NOT_ENTERED);
+    }
+}

--- a/verification/kontrol/SYFSetup.k.sol
+++ b/verification/kontrol/SYFSetup.k.sol
@@ -52,6 +52,7 @@ contract SYFSetup is KontrolTest {
 
         // Restore concrete asset address to the real ERC20
         _storeAddress(address(mockStrategy), MFS_ASSET_SLOT, address(sourceAsset));
+        _storeAddress(address(mockStrategy), MFS_EXPECTED_BALANCE_OF_ACCOUNT_SLOT, address(syfForwarder));
 
         // Set symbolic share balance and redeem return
         uint256 shareBalance = freshUInt256Bounded();
@@ -63,6 +64,9 @@ contract SYFSetup is KontrolTest {
         // Clear argument capture slots
         _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);
         _storeAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT, address(0));
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
+        _storeAddress(address(mockStrategy), MFS_LAST_OWNER_SLOT, address(0));
+        _storeUInt256(address(mockStrategy), MFS_LAST_MAX_LOSS_SLOT, 0);
 
         // ============================================
         // MAKE MOCK SWAPPER STORAGE SYMBOLIC
@@ -78,6 +82,7 @@ contract SYFSetup is KontrolTest {
         _storeAddress(address(mockSwapper), MSWP_LAST_TOKEN_IN_SLOT, address(0));
         _storeAddress(address(mockSwapper), MSWP_LAST_TOKEN_OUT_SLOT, address(0));
         _storeUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT, 0);
+        _storeUInt256(address(mockSwapper), MSWP_LAST_MIN_AMOUNT_OUT_SLOT, 0);
 
         // ============================================
         // PRE-LOAD FORWARDER ERC20 BALANCE

--- a/verification/kontrol/SYFTest.k.sol
+++ b/verification/kontrol/SYFTest.k.sol
@@ -61,10 +61,11 @@ contract SYFTest is SYFSetup {
         assertEq(forwarderBalance, 0);
     }
 
-    /// @notice When shares == 0, returns 0 without calling swap or redeem
+    /// @notice When shares == 0, report still runs and the function returns 0 without swap or redeem
     function testReportSwapAndForwardZeroSharesPassthrough() public {
         // Set shares to 0
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
 
         // Write sentinels to detect any call to redeem or swap, including
         // redeem(0, ...) which would be indistinguishable from "never called"
@@ -78,6 +79,10 @@ contract SYFTest is SYFSetup {
 
         // Assert: returned 0
         assertEq(assetsOut, 0);
+
+        // Assert: report still ran before the zero-share early return
+        address lastReportCaller = _loadAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT);
+        assertEq(lastReportCaller, address(syfForwarder));
 
         // Assert: swap was never called (sentinel preserved)
         uint256 lastAmountIn = _loadUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT);
@@ -116,9 +121,11 @@ contract SYFTest is SYFSetup {
         vm.assume(shares > 0);
         uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
         vm.assume(redeemReturn > 0);
+        uint256 maxLoss = freshUInt256Bounded();
+        uint256 minAmountOut = freshUInt256Bounded();
 
         vm.prank(_keeper);
-        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), maxLoss, minAmountOut);
 
         // Assert: tokenIn == sourceAsset (strategy's underlying)
         address lastTokenIn = _loadAddress(address(mockSwapper), MSWP_LAST_TOKEN_IN_SLOT);
@@ -131,6 +138,20 @@ contract SYFTest is SYFSetup {
         // Assert: amountIn == redeemReturn
         uint256 lastAmountIn = _loadUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT);
         assertEq(lastAmountIn, redeemReturn);
+
+        // Assert: minAmountOut is forwarded unchanged to the swapper
+        uint256 lastMinAmountOut = _loadUInt256(address(mockSwapper), MSWP_LAST_MIN_AMOUNT_OUT_SLOT);
+        assertEq(lastMinAmountOut, minAmountOut);
+
+        // Assert: redeem is executed on behalf of and back into the forwarder
+        address lastRedeemReceiver = _loadAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT);
+        assertEq(lastRedeemReceiver, address(syfForwarder));
+
+        address lastRedeemOwner = _loadAddress(address(mockStrategy), MFS_LAST_OWNER_SLOT);
+        assertEq(lastRedeemOwner, address(syfForwarder));
+
+        uint256 lastRedeemMaxLoss = _loadUInt256(address(mockStrategy), MFS_LAST_MAX_LOSS_SLOT);
+        assertEq(lastRedeemMaxLoss, maxLoss);
     }
 
     /// @notice Inherited reportAndForward() on SwappingYieldForwarder still enforces keeper check

--- a/verification/kontrol/SYFTest.k.sol
+++ b/verification/kontrol/SYFTest.k.sol
@@ -66,19 +66,26 @@ contract SYFTest is SYFSetup {
         // Set shares to 0
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
 
+        // Write sentinels to detect any call to redeem or swap, including
+        // redeem(0, ...) which would be indistinguishable from "never called"
+        // if the default were 0.
+        uint256 sentinel = type(uint256).max;
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, sentinel);
+        _storeUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT, sentinel);
+
         vm.prank(_keeper);
         uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
 
         // Assert: returned 0
         assertEq(assetsOut, 0);
 
-        // Assert: swap was never called (lastSwapReceiver still address(0))
-        address lastSwapReceiver = _loadAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT);
-        assertEq(lastSwapReceiver, address(0));
+        // Assert: swap was never called (sentinel preserved)
+        uint256 lastAmountIn = _loadUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT);
+        assertEq(lastAmountIn, sentinel);
 
-        // Assert: redeem was never called
+        // Assert: redeem was never called (sentinel preserved)
         uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
-        assertEq(lastShares, 0);
+        assertEq(lastShares, sentinel);
     }
 
     /// @notice When redeem returns 0 assets (but shares > 0), returns 0 without swap

--- a/verification/kontrol/SYFTest.k.sol
+++ b/verification/kontrol/SYFTest.k.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+import { SYFSetup } from "test/kontrol/SYFSetup.k.sol";
+import "test/kontrol/SharedStateSlots.k.sol";
+
+/**
+ * @title SYFTest
+ * @notice Kontrol formal verification proofs for SwappingYieldForwarder
+ * @dev Proves 7 behavioral properties of the SwappingYieldForwarder contract:
+ *      1. Access control on reportSwapAndForward
+ *      2. Swap output routed to hardcoded receiver
+ *      3. No residual source asset after swap
+ *      4. Zero-share passthrough (no swap/redeem)
+ *      5. Zero-redeem passthrough (no swap when redeem returns 0)
+ *      6. Correct token routing through swapper
+ *      7. Inherited reportAndForward access control still works
+ */
+contract SYFTest is SYFSetup {
+    /// @notice Non-keeper address always reverts with OnlyKeeper on reportSwapAndForward
+    function testReportSwapAndForwardOnlyKeeper() public {
+        address nonKeeper = makeAddr("NON_KEEPER");
+
+        vm.prank(nonKeeper);
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+    }
+
+    /// @notice swap() is always called with the hardcoded receiver as output recipient
+    function testReportSwapAndForwardReceiverGuarantee() public {
+        // Pre-conditions: shares exist and redeem returns non-zero
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+        uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
+        vm.assume(redeemReturn > 0);
+
+        vm.prank(_keeper);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+
+        // Assert: swap was called with receiver == forwarder.receiver()
+        address lastReceiver = _loadAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT);
+        assertEq(lastReceiver, _receiver);
+    }
+
+    /// @notice After reportSwapAndForward, forwarder holds 0 of source asset
+    function testReportSwapAndForwardNoResidualSourceAsset() public {
+        // Pre-conditions: shares exist and redeem returns non-zero
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+        uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
+        vm.assume(redeemReturn > 0);
+
+        vm.prank(_keeper);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+
+        // Assert: forwarder's source asset balance is 0 (all transferred to swapper)
+        uint256 forwarderBalance = sourceAsset.balanceOf(address(syfForwarder));
+        assertEq(forwarderBalance, 0);
+    }
+
+    /// @notice When shares == 0, returns 0 without calling swap or redeem
+    function testReportSwapAndForwardZeroSharesPassthrough() public {
+        // Set shares to 0
+        _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
+
+        vm.prank(_keeper);
+        uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+
+        // Assert: returned 0
+        assertEq(assetsOut, 0);
+
+        // Assert: swap was never called (lastSwapReceiver still address(0))
+        address lastSwapReceiver = _loadAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT);
+        assertEq(lastSwapReceiver, address(0));
+
+        // Assert: redeem was never called
+        uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastShares, 0);
+    }
+
+    /// @notice When redeem returns 0 assets (but shares > 0), returns 0 without swap
+    function testReportSwapAndForwardZeroRedeemPassthrough() public {
+        // Set shares > 0 but redeem return to 0
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+        _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, 0);
+
+        // Also zero out the forwarder's pre-loaded ERC20 balance (matches 0 redeem)
+        _storeMappingUInt256(address(sourceAsset), ERC20_BALANCES_SLOT, uint256(uint160(address(syfForwarder))), 0, 0);
+
+        vm.prank(_keeper);
+        uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+
+        // Assert: returned 0
+        assertEq(assetsOut, 0);
+
+        // Assert: swap was never called
+        address lastSwapReceiver = _loadAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT);
+        assertEq(lastSwapReceiver, address(0));
+    }
+
+    /// @notice swap() is called with tokenIn = strategy.asset() and tokenOut = targetAsset
+    function testReportSwapAndForwardCorrectTokenRouting() public {
+        // Pre-conditions: shares exist and redeem returns non-zero
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+        uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
+        vm.assume(redeemReturn > 0);
+
+        vm.prank(_keeper);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+
+        // Assert: tokenIn == sourceAsset (strategy's underlying)
+        address lastTokenIn = _loadAddress(address(mockSwapper), MSWP_LAST_TOKEN_IN_SLOT);
+        assertEq(lastTokenIn, address(sourceAsset));
+
+        // Assert: tokenOut == targetAsset (forwarder's configured target)
+        address lastTokenOut = _loadAddress(address(mockSwapper), MSWP_LAST_TOKEN_OUT_SLOT);
+        assertEq(lastTokenOut, address(targetAsset));
+
+        // Assert: amountIn == redeemReturn
+        uint256 lastAmountIn = _loadUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT);
+        assertEq(lastAmountIn, redeemReturn);
+    }
+
+    /// @notice Inherited reportAndForward() on SwappingYieldForwarder still enforces keeper check
+    function testInheritedReportAndForwardAccessControl() public {
+        address nonKeeper = makeAddr("NON_KEEPER");
+
+        vm.prank(nonKeeper);
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        syfForwarder.reportAndForward(address(mockStrategy), 0);
+    }
+}

--- a/verification/kontrol/SharedStateSlots.k.sol
+++ b/verification/kontrol/SharedStateSlots.k.sol
@@ -128,6 +128,10 @@ uint256 constant MFS_REDEEM_RETURN_SLOT = 1;
 uint256 constant MFS_ASSET_SLOT = 2;
 uint256 constant MFS_LAST_RECEIVER_SLOT = 3;
 uint256 constant MFS_LAST_SHARES_SLOT = 4;
+uint256 constant MFS_LAST_REPORT_CALLER_SLOT = 5;
+uint256 constant MFS_EXPECTED_BALANCE_OF_ACCOUNT_SLOT = 6;
+uint256 constant MFS_LAST_OWNER_SLOT = 7;
+uint256 constant MFS_LAST_MAX_LOSS_SLOT = 8;
 
 // ============================================
 // MockForwarderSwapper (MSWP_) constants
@@ -138,3 +142,4 @@ uint256 constant MSWP_LAST_RECEIVER_SLOT = 1;
 uint256 constant MSWP_LAST_TOKEN_IN_SLOT = 2;
 uint256 constant MSWP_LAST_TOKEN_OUT_SLOT = 3;
 uint256 constant MSWP_LAST_AMOUNT_IN_SLOT = 4;
+uint256 constant MSWP_LAST_MIN_AMOUNT_OUT_SLOT = 5;

--- a/verification/kontrol/SharedStateSlots.k.sol
+++ b/verification/kontrol/SharedStateSlots.k.sol
@@ -110,3 +110,31 @@ uint256 constant MOCK_YS_EXCHANGE_RATE_DECIMALS_SLOT = 3;
 // TestERC20 (OZ ERC20 v5) constants
 // ============================================
 uint256 constant ERC20_BALANCES_SLOT = 0;
+
+// ============================================
+// ReentrancyGuard (OZ v5.3.0, plain storage slot 0)
+// ============================================
+// YieldForwarder / SwappingYieldForwarder inherit ReentrancyGuard
+// which stores _status at slot 0 (NOT ERC-7201 namespaced)
+uint256 constant RG_STATUS_SLOT = 0;
+uint256 constant RG_NOT_ENTERED = 1;
+
+// ============================================
+// MockForwarderStrategy (MFS_) constants
+// ============================================
+// Plain storage slots for the mock strategy used in YieldForwarder Kontrol proofs
+uint256 constant MFS_SHARE_BALANCE_SLOT = 0;
+uint256 constant MFS_REDEEM_RETURN_SLOT = 1;
+uint256 constant MFS_ASSET_SLOT = 2;
+uint256 constant MFS_LAST_RECEIVER_SLOT = 3;
+uint256 constant MFS_LAST_SHARES_SLOT = 4;
+
+// ============================================
+// MockForwarderSwapper (MSWP_) constants
+// ============================================
+// Plain storage slots for the mock swapper used in SwappingYieldForwarder Kontrol proofs
+uint256 constant MSWP_RETURN_SLOT = 0;
+uint256 constant MSWP_LAST_RECEIVER_SLOT = 1;
+uint256 constant MSWP_LAST_TOKEN_IN_SLOT = 2;
+uint256 constant MSWP_LAST_TOKEN_OUT_SLOT = 3;
+uint256 constant MSWP_LAST_AMOUNT_IN_SLOT = 4;

--- a/verification/kontrol/YFSetup.k.sol
+++ b/verification/kontrol/YFSetup.k.sol
@@ -41,6 +41,7 @@ contract YFSetup is KontrolTest {
         // Restore concrete asset address (needed for SYF safeTransfer path)
         // Using address(0xA55E7) as a deterministic mock asset address
         _storeAddress(address(mockStrategy), MFS_ASSET_SLOT, address(0xA55E7));
+        _storeAddress(address(mockStrategy), MFS_EXPECTED_BALANCE_OF_ACCOUNT_SLOT, address(forwarder));
 
         // Set symbolic share balance and redeem return
         uint256 shareBalance = freshUInt256Bounded();
@@ -52,6 +53,9 @@ contract YFSetup is KontrolTest {
         // Clear argument capture slots (so we can detect if redeem was called)
         _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);
         _storeAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT, address(0));
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
+        _storeAddress(address(mockStrategy), MFS_LAST_OWNER_SLOT, address(0));
+        _storeUInt256(address(mockStrategy), MFS_LAST_MAX_LOSS_SLOT, 0);
 
         // ============================================
         // SET FORWARDER REENTRANCY GUARD TO NOT_ENTERED

--- a/verification/kontrol/YFSetup.k.sol
+++ b/verification/kontrol/YFSetup.k.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+import { KontrolTest } from "test/kontrol/KontrolTest.k.sol";
+import { MockForwarderStrategy } from "test/kontrol/MockForwarderStrategy.k.sol";
+import "test/kontrol/SharedStateSlots.k.sol";
+
+/**
+ * @title YFSetup
+ * @notice Symbolic setup for formal verification of YieldForwarder
+ * @dev Deploys YieldForwarder with concrete role addresses and a MockForwarderStrategy
+ *      with symbolic storage. Unlike strategy proofs (where the CUT's storage is symbolic),
+ *      here the forwarder is stateless (immutables + ReentrancyGuard) and the mock
+ *      dependency is made symbolic to verify behavioral guarantees across all input states.
+ */
+contract YFSetup is KontrolTest {
+    YieldForwarder public forwarder;
+    MockForwarderStrategy public mockStrategy;
+
+    address internal _receiver;
+    address internal _keeper;
+
+    function setUp() public virtual {
+        // Concrete role addresses (avoid symbolic branching on prank)
+        _receiver = makeAddr("RECEIVER");
+        _keeper = makeAddr("KEEPER");
+
+        // Deploy mock strategy
+        mockStrategy = new MockForwarderStrategy();
+
+        // Deploy YieldForwarder with concrete immutables
+        forwarder = new YieldForwarder(_receiver, _keeper);
+
+        // ============================================
+        // MAKE MOCK STRATEGY STORAGE SYMBOLIC
+        // ============================================
+        kevm.symbolicStorage(address(mockStrategy));
+
+        // Restore concrete asset address (needed for SYF safeTransfer path)
+        // Using address(0xA55E7) as a deterministic mock asset address
+        _storeAddress(address(mockStrategy), MFS_ASSET_SLOT, address(0xA55E7));
+
+        // Set symbolic share balance and redeem return
+        uint256 shareBalance = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, shareBalance);
+
+        uint256 redeemReturn = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, redeemReturn);
+
+        // Clear argument capture slots (so we can detect if redeem was called)
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);
+        _storeAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT, address(0));
+
+        // ============================================
+        // SET FORWARDER REENTRANCY GUARD TO NOT_ENTERED
+        // ============================================
+        _storeUInt256(address(forwarder), RG_STATUS_SLOT, RG_NOT_ENTERED);
+    }
+}

--- a/verification/kontrol/YFTest.k.sol
+++ b/verification/kontrol/YFTest.k.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+import { YFSetup } from "test/kontrol/YFSetup.k.sol";
+import "test/kontrol/SharedStateSlots.k.sol";
+
+/**
+ * @title YFTest
+ * @notice Kontrol formal verification proofs for YieldForwarder
+ * @dev Proves 5 behavioral properties of the YieldForwarder contract:
+ *      1. Access control: only keeper can call reportAndForward
+ *      2. Receiver guarantee: redeem always targets the hardcoded receiver
+ *      3. No residual shares: forwarder holds 0 shares after execution
+ *      4. Zero-share passthrough: returns 0 without calling redeem when no shares
+ *      5. Return value correctness: return matches mock redeem output
+ */
+contract YFTest is YFSetup {
+    /// @notice Non-keeper address always reverts with OnlyKeeper
+    function testReportAndForwardOnlyKeeper() public {
+        address nonKeeper = makeAddr("NON_KEEPER");
+
+        vm.prank(nonKeeper);
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        forwarder.reportAndForward(address(mockStrategy), 0);
+    }
+
+    /// @notice redeem() is always called with the hardcoded receiver as recipient
+    function testReportAndForwardReceiverGuarantee() public {
+        // Pre-condition: shares exist to trigger the redeem path
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+
+        vm.prank(_keeper);
+        forwarder.reportAndForward(address(mockStrategy), 0);
+
+        // Assert: redeem was called with receiver == forwarder.receiver()
+        address lastReceiver = _loadAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT);
+        assertEq(lastReceiver, _receiver);
+    }
+
+    /// @notice After reportAndForward, forwarder holds 0 shares on the strategy
+    function testReportAndForwardNoResidualShares() public {
+        // Pre-condition: shares exist
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+
+        vm.prank(_keeper);
+        forwarder.reportAndForward(address(mockStrategy), 0);
+
+        // Assert: mock share balance is 0 (set to 0 by mock's redeem)
+        uint256 postShares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        assertEq(postShares, 0);
+    }
+
+    /// @notice When shares == 0, returns 0 and redeem is never called
+    function testReportAndForwardZeroSharesPassthrough() public {
+        // Set shares to 0
+        _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
+
+        vm.prank(_keeper);
+        uint256 assets = forwarder.reportAndForward(address(mockStrategy), 0);
+
+        // Assert: returned 0
+        assertEq(assets, 0);
+
+        // Assert: redeem was never called (lastRedeemShares still 0)
+        uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastShares, 0);
+    }
+
+    /// @notice Return value of reportAndForward equals the value returned by redeem
+    function testReportAndForwardReturnsRedeemAssets() public {
+        // Pre-condition: shares exist
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+
+        uint256 expectedReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
+
+        vm.prank(_keeper);
+        uint256 assets = forwarder.reportAndForward(address(mockStrategy), 0);
+
+        assertEq(assets, expectedReturn);
+    }
+}

--- a/verification/kontrol/YFTest.k.sol
+++ b/verification/kontrol/YFTest.k.sol
@@ -59,15 +59,22 @@ contract YFTest is YFSetup {
         // Set shares to 0
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
 
+        // Write sentinel to detect any redeem call, including redeem(0, ...).
+        // Without this, a regression removing the early return guard would call
+        // redeem(0, ...) which writes lastRedeemShares = 0, indistinguishable
+        // from the "never called" default.
+        uint256 sentinel = type(uint256).max;
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, sentinel);
+
         vm.prank(_keeper);
         uint256 assets = forwarder.reportAndForward(address(mockStrategy), 0);
 
         // Assert: returned 0
         assertEq(assets, 0);
 
-        // Assert: redeem was never called (lastRedeemShares still 0)
+        // Assert: redeem was never called (sentinel preserved)
         uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
-        assertEq(lastShares, 0);
+        assertEq(lastShares, sentinel);
     }
 
     /// @notice Return value of reportAndForward equals the value returned by redeem

--- a/verification/kontrol/YFTest.k.sol
+++ b/verification/kontrol/YFTest.k.sol
@@ -31,13 +31,20 @@ contract YFTest is YFSetup {
         // Pre-condition: shares exist to trigger the redeem path
         uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
         vm.assume(shares > 0);
+        uint256 maxLoss = freshUInt256Bounded();
 
         vm.prank(_keeper);
-        forwarder.reportAndForward(address(mockStrategy), 0);
+        forwarder.reportAndForward(address(mockStrategy), maxLoss);
 
-        // Assert: redeem was called with receiver == forwarder.receiver()
+        // Assert: redeem was called with the expected receiver, owner, and maxLoss.
         address lastReceiver = _loadAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT);
         assertEq(lastReceiver, _receiver);
+
+        address lastOwner = _loadAddress(address(mockStrategy), MFS_LAST_OWNER_SLOT);
+        assertEq(lastOwner, address(forwarder));
+
+        uint256 lastMaxLoss = _loadUInt256(address(mockStrategy), MFS_LAST_MAX_LOSS_SLOT);
+        assertEq(lastMaxLoss, maxLoss);
     }
 
     /// @notice After reportAndForward, forwarder holds 0 shares on the strategy
@@ -54,10 +61,11 @@ contract YFTest is YFSetup {
         assertEq(postShares, 0);
     }
 
-    /// @notice When shares == 0, returns 0 and redeem is never called
+    /// @notice When shares == 0, report still runs, returns 0, and redeem is never called
     function testReportAndForwardZeroSharesPassthrough() public {
         // Set shares to 0
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
 
         // Write sentinel to detect any redeem call, including redeem(0, ...).
         // Without this, a regression removing the early return guard would call
@@ -71,6 +79,10 @@ contract YFTest is YFSetup {
 
         // Assert: returned 0
         assertEq(assets, 0);
+
+        // Assert: report still ran before the zero-share early return
+        address lastReportCaller = _loadAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT);
+        assertEq(lastReportCaller, address(forwarder));
 
         // Assert: redeem was never called (sentinel preserved)
         uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);


### PR DESCRIPTION
## Summary

Adds a pluggable swap layer to the yield forwarding pipeline so that strategy profits can be automatically converted to a different target asset (e.g., USDC -> USDT, USDC -> USDS) before being forwarded to the receiver.

### Core contracts

- **`SwappingYieldForwarder`** — Inherits `YieldForwarder` and adds `reportSwapAndForward()`, which redeems to self, swaps via a pluggable `ISwapper`, then forwards the target asset. The inherited `reportAndForward()` remains available as a no-swap circuit breaker.
- **`ISwapper`** — Minimal interface (`swap(tokenIn, tokenOut, amountIn, minAmountOut, receiver)`) for stateless swap adapters.

### Swap adapters

| Adapter | Route | Notes |
|---|---|---|
| `PSMSwapper` | Sky PSM (SELL_GEM, BUY_GEM) and DaiUsds converter (DAI<->USDS) | Handles PSM fee calculation (tout), 4 routes in one contract |
| `CurveSwapper` | Curve StableSwap `exchange()` | Balance-measurement approach for legacy pools that don't return output amount |
| `UniswapV3SwapperAdapter` | Uniswap V3 single-hop and multi-hop | Immutable routing config with optional base token for two-hop paths (e.g., USDC -> WETH -> DAI) |
| `UniswapV4SwapperAdapter` | Uniswap V4 via PoolManager | Supports `zeroForOne` direction config with BalanceDelta extraction for output measurement |

### Design decisions

- **Fully immutable**: All contracts are immutable with no admin functions, upgrades, or sweep. Assets can only flow to the hardcoded receiver.
- **Dual-mode forwarding**: Keeper chooses swap vs. no-swap at call-time. If the swap protocol is down, the keeper falls back to `reportAndForward()`.
- **Push-based ISwapper**: Caller transfers tokens to the swapper before calling `swap()`. This keeps adapters stateless and composable.
- **Strategy as call-time parameter**: Avoids circular deployment dependencies between strategy and forwarder.