### PR TITLE
feat(osu-1354): implement advance rewards on RegenStakerBase

### DIFF
--- a/src/regen/RegenStakerBase.sol
+++ b/src/regen/RegenStakerBase.sol
@@ -33,6 +33,7 @@ import { NotInAllowset } from "src/errors.sol";
 /// @notice Provides shared functionality including:
 ///         - Variable reward duration (7-3000 days, configurable by admin)
 ///         - Earning power management with external bumping incentivized by tips (up to maxBumpTip)
+///         - Earning power calculator updates (blocked during active reward periods for governance protection)
 ///         - Adjustable minimum stake amount (existing deposits grandfathered with restrictions)
 ///         - Access control for stakers and allocation mechanisms
 ///         - Reward compounding (when REWARD_TOKEN == STAKE_TOKEN)
@@ -85,6 +86,10 @@ import { NotInAllowset } from "src/errors.sol";
 /// @dev Integer division causes ~1 wei precision loss, negligible due to SCALE_FACTOR (1e36).
 /// @dev This base is abstract, with variants implementing token-specific behaviors (e.g., delegation surrogates).
 /// @dev Earning power updates are required after balance changes; some are automatic, others via bumpEarningPower.
+///
+/// @dev ACCESS CONTROL:
+///      - admin: Admin operations (protocol parameters, pause, access control) from base Staker
+///      - rewardManager: Can manage reward notifiers (operational role, separation of duties)
 abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, StakerPermitAndStake, StakerOnBehalf {
     using SafeCast for uint256;
 
@@ -135,13 +140,22 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
 
     /// @notice Error thrown when attempting to change earning power calculator during active reward
     error CannotChangeEarningPowerCalculatorDuringActiveReward();
-
     error ZeroOperation();
     error NoOperation();
     error DisablingAllocationMechanismAllowsetNotAllowed();
     /// @param expected Address of REWARD_TOKEN
     /// @param actual Address of token expected by allocation mechanism
     error AssetMismatch(address expected, address actual);
+    /// @param depositId Deposit with an active commitment lock
+    error ActiveCommitmentExists(DepositIdentifier depositId);
+    /// @param depositId Deposit that is locked
+    /// @param lockEnd Timestamp when the lock expires
+    error CommitmentLockActive(DepositIdentifier depositId, uint64 lockEnd);
+    /// @param pct Percentage that was out of the 1-5 range
+    error InvalidAdvanceRewardsPct(uint256 pct);
+    /// @param requested Amount requested for contribution
+    /// @param available Earmarked amount available
+    error InsufficientAdvanceRewards(uint256 requested, uint256 available);
 
     // === State Variables ===
     /// @notice Shared configuration state instance
@@ -169,6 +183,15 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
 
     /// @notice Cached metadata for the most recent reward schedule.
     RewardSchedule public latestRewardSchedule;
+
+    /// @notice Info about a deposit's advance reward earmark and commitment lock
+    struct AdvanceRewardInfo {
+        uint96 amount; // earmarked stake tokens (decreases as contributed)
+        uint64 lockEnd; // withdrawal lock timestamp (0 = no lock)
+    }
+
+    /// @notice Per-deposit advance reward earmarks
+    mapping(DepositIdentifier => AdvanceRewardInfo) public advanceRewards;
 
     // === Events ===
     /// @notice Emitted when the staker allowset is updated
@@ -698,6 +721,87 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         return amountContributedToAllocationMechanism;
     }
 
+    /// @notice Earmarks a percentage of staked capital as advance rewards and locks the deposit.
+    /// @dev Lock duration = pct x 30 days. Tokens stay in place; no transfers occur on this call.
+    /// @dev Only callable while not paused. Reverts if an active lock already exists.
+    /// @param _depositId Deposit to earmark
+    /// @param _pct Percentage of current balance to earmark (1 to 5 inclusive)
+    function setAdvanceRewards(DepositIdentifier _depositId, uint256 _pct) external whenNotPaused {
+        if (_pct == 0 || _pct > 5) revert InvalidAdvanceRewardsPct(_pct);
+
+        Deposit storage deposit = deposits[_depositId];
+        if (deposit.owner != msg.sender) revert Staker__Unauthorized("not owner", msg.sender);
+
+        AdvanceRewardInfo storage sr = advanceRewards[_depositId];
+        if (sr.lockEnd > block.timestamp) revert ActiveCommitmentExists(_depositId);
+
+        uint256 amount = (deposit.balance * _pct) / 100;
+        require(amount > 0, ZeroOperation());
+
+        uint64 lockEnd = uint64(block.timestamp + _pct * 30 days);
+        advanceRewards[_depositId] = AdvanceRewardInfo(amount.toUint96(), lockEnd);
+    }
+
+    /// @notice Consumes earmarked advance rewards and transfers stake tokens to caller.
+    /// @dev NOTE: Caller is responsible for any subsequent contribution flow.
+    /// @dev Reduces deposit.balance and earning power; lock persists until expiry even if amount reaches zero.
+    /// @param _depositId Deposit the advance amount originates from
+    /// @param _amount Amount to consume (must be <= current earmarked amount)
+    /// @param _deadline Unused (kept for backwards compatibility)
+    /// @param _v Unused (kept for backwards compatibility)
+    /// @param _r Unused (kept for backwards compatibility)
+    /// @param _s Unused (kept for backwards compatibility)
+    function contributeFromAdvanceRewards(
+        DepositIdentifier _depositId,
+        address,
+        uint256 _amount,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) external whenNotPaused nonReentrant {
+        // Silence compatibility parameters in a low-cost way.
+        (_deadline, _v, _r, _s);
+
+        Deposit storage deposit = deposits[_depositId];
+        if (deposit.claimer != msg.sender && deposit.owner != msg.sender) {
+            revert Staker__Unauthorized("not claimer or owner", msg.sender);
+        }
+
+        AdvanceRewardInfo storage sr = advanceRewards[_depositId];
+        require(_amount > 0, ZeroOperation());
+        if (_amount > sr.amount) revert InsufficientAdvanceRewards(_amount, sr.amount);
+
+        _checkpointGlobalReward();
+        _checkpointReward(deposit);
+
+        deposit.balance -= _amount.toUint96();
+        _updateEarningPower(deposit);
+        totalStaked -= _amount;
+        depositorTotalStaked[deposit.owner] -= _amount;
+        sr.amount -= _amount.toUint96();
+        _stakeTokenSafeTransferFrom(address(surrogates(deposit.delegatee)), msg.sender, _amount);
+    }
+
+    /// @notice Updates earning power for a deposit after a balance change.
+    /// @dev Extracted to reduce stack depth in contributeFromAdvanceRewards.
+    /// @param deposit Deposit storage reference (balance must already be updated before calling)
+    function _updateEarningPower(Deposit storage deposit) private {
+        uint256 _oldEarningPower = deposit.earningPower;
+        uint256 _newEarningPower = earningPowerCalculator.getEarningPower(
+            deposit.balance,
+            deposit.owner,
+            deposit.delegatee
+        );
+        totalEarningPower = _calculateTotalEarningPower(_oldEarningPower, _newEarningPower, totalEarningPower);
+        depositorTotalEarningPower[deposit.owner] = _calculateTotalEarningPower(
+            _oldEarningPower,
+            _newEarningPower,
+            depositorTotalEarningPower[deposit.owner]
+        );
+        deposit.earningPower = _newEarningPower.toUint96();
+    }
+
     /// @notice Compounds rewards by claiming them and immediately restaking them into the same deposit
     /// @dev REQUIREMENT: Only works when REWARD_TOKEN == STAKE_TOKEN, otherwise reverts.
     /// @dev EARNING POWER: Compounding updates earning power based on new total balance.
@@ -862,7 +966,8 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         _revertIfMinimumStakeAmountNotMet(_depositId);
     }
 
-    /// @notice Prevents withdrawing 0; prevents withdrawals that drop balance below minimum.
+    /// @notice Prevents withdrawing 0; prevents withdrawals that drop balance below minimum;
+    ///         enforces advance rewards commitment lock.
     /// @dev USER PROTECTION: Withdrawals remain enabled even when contract is paused to ensure
     ///      users can always access their principal funds.
     /// @dev Uses reentrancy guard
@@ -874,6 +979,12 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         DepositIdentifier _depositId,
         uint256 _amount
     ) internal virtual override nonReentrant {
+        // Enforce advance rewards commitment lock
+        AdvanceRewardInfo storage sr = advanceRewards[_depositId];
+        if (sr.lockEnd > block.timestamp) revert CommitmentLockActive(_depositId, sr.lockEnd);
+        // Lock expired: clear stale earmark
+        if (sr.lockEnd != 0) delete advanceRewards[_depositId];
+
         require(_amount > 0, ZeroOperation());
         super._withdraw(deposit, _depositId, _amount);
         _revertIfMinimumStakeAmountNotMet(_depositId);

--- a/test/regen/RegenStakerWithAdvanceRewards.t.sol
+++ b/test/regen/RegenStakerWithAdvanceRewards.t.sol
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { AccessMode } from "src/constants.sol";
+import { RegenStaker } from "src/regen/RegenStaker.sol";
+import { RegenStakerBase } from "src/regen/RegenStakerBase.sol";
+import { Staker } from "staker/Staker.sol";
+import { MockERC20Staking } from "test/mocks/MockERC20Staking.sol";
+import { MockEarningPowerCalculator } from "test/mocks/MockEarningPowerCalculator.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { OctantQFMechanism } from "src/mechanisms/mechanism/OctantQFMechanism.sol";
+import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
+import { AddressSet } from "src/utils/AddressSet.sol";
+import { IAddressSet } from "src/utils/IAddressSet.sol";
+
+/// @title RegenStaker Advance Rewards Tests
+/// @notice Tests for setAdvanceRewards() and contributeFromAdvanceRewards()
+contract RegenStakerWithAdvanceRewardsTest is Test {
+    RegenStaker public regenStaker;
+    MockERC20Staking public token;
+    MockEarningPowerCalculator public earningPowerCalculator;
+    OctantQFMechanism public allocationMechanism;
+    AddressSet public allocationAllowset;
+
+    address public admin = makeAddr("admin");
+    address public owner;
+    uint256 private ownerPk;
+    address public claimer;
+    uint256 private claimerPk;
+    address public delegatee = makeAddr("delegatee");
+    address public stranger = makeAddr("stranger");
+
+    uint256 public constant STAKE_AMOUNT = 1000e18;
+    uint256 public constant REWARD_AMOUNT = 10_000e18;
+    uint128 public constant REWARD_DURATION = 30 days;
+
+    Staker.DepositIdentifier public depositId;
+
+    function setUp() public {
+        (owner, ownerPk) = makeAddrAndKey("owner");
+        (claimer, claimerPk) = makeAddrAndKey("claimer");
+
+        token = new MockERC20Staking(18);
+        earningPowerCalculator = new MockEarningPowerCalculator();
+
+        // Deploy a real OctantQFMechanism (same token for stake/reward)
+        TokenizedAllocationMechanism impl = new TokenizedAllocationMechanism();
+        AllocationConfig memory cfg = AllocationConfig({
+            asset: IERC20(address(token)),
+            name: "AdvanceTest",
+            symbol: "ST",
+            votingDelay: 1,
+            votingPeriod: 30 days,
+            quorumShares: 1,
+            timelockDelay: 1,
+            gracePeriod: 100,
+            owner: admin
+        });
+        allocationMechanism = new OctantQFMechanism(
+            address(impl),
+            cfg,
+            1,
+            1,
+            IAddressSet(address(0)), // contributionAllowset (open)
+            IAddressSet(address(0)), // contributionBlockset (none)
+            AccessMode.NONE
+        );
+
+        vm.startPrank(admin);
+        allocationAllowset = new AddressSet();
+        allocationAllowset.add(address(allocationMechanism));
+        vm.stopPrank();
+
+        vm.prank(admin);
+        regenStaker = new RegenStaker(
+            IERC20(address(token)), // rewardsToken (same as stake token)
+            token,
+            earningPowerCalculator,
+            0, // maxBumpTip
+            admin,
+            REWARD_DURATION,
+            1e18, // minimumStakeAmount
+            IAddressSet(address(0)),
+            IAddressSet(address(0)),
+            AccessMode.NONE,
+            IAddressSet(address(allocationAllowset))
+        );
+
+        // Fund owner and stake
+        token.mint(owner, STAKE_AMOUNT);
+        token.mint(address(regenStaker), REWARD_AMOUNT);
+
+        vm.startPrank(owner);
+        token.approve(address(regenStaker), STAKE_AMOUNT);
+        depositId = regenStaker.stake(STAKE_AMOUNT, delegatee, claimer);
+        vm.stopPrank();
+
+        // Schedule rewards
+        vm.startPrank(admin);
+        regenStaker.setRewardNotifier(admin, true);
+        regenStaker.notifyRewardAmount(REWARD_AMOUNT);
+        vm.stopPrank();
+    }
+
+    // =========================================================
+    // Helpers
+    // =========================================================
+
+    /// @dev Returns deposit balance from the public tuple getter
+    function _depositBalance(Staker.DepositIdentifier _depositId) internal view returns (uint96 bal) {
+        (bal, , , , , , ) = regenStaker.deposits(_depositId);
+    }
+
+    /// @dev Returns deposit earning power from the public tuple getter
+    function _depositEarningPower(Staker.DepositIdentifier _depositId) internal view returns (uint96 ep) {
+        (, , ep, , , , ) = regenStaker.deposits(_depositId);
+    }
+
+    // =========================================================
+    // setAdvanceRewards
+    // =========================================================
+
+    function test_setAdvanceRewards_stateCorrect() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        (uint96 amount, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(amount, (STAKE_AMOUNT * 5) / 100, "amount mismatch");
+        assertEq(lockEnd, block.timestamp + 5 * 30 days, "lockEnd mismatch");
+    }
+
+    function test_setAdvanceRewards_lockLinear() public {
+        // 1% -> 30 days
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 1);
+        (, uint64 lockEnd1) = regenStaker.advanceRewards(depositId);
+        assertEq(lockEnd1, block.timestamp + 30 days, "1% lock mismatch");
+
+        // Expire lock, then set 5% -> 150 days
+        vm.warp(uint256(lockEnd1) + 1);
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+        (, uint64 lockEnd5) = regenStaker.advanceRewards(depositId);
+        assertEq(lockEnd5, block.timestamp + 5 * 30 days, "5% lock mismatch");
+    }
+
+    function test_setAdvanceRewards_blocksWithdraw() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.CommitmentLockActive.selector, depositId, lockEnd));
+        regenStaker.withdraw(depositId, 1e18);
+    }
+
+    function test_setAdvanceRewards_allowsWithdrawAfterLock() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+
+        // Warp past lock expiry
+        vm.warp(uint256(lockEnd) + 1);
+
+        // Withdrawal must succeed; stale earmark must be cleared
+        vm.prank(owner);
+        regenStaker.withdraw(depositId, 1e18);
+
+        (uint96 amount, uint64 newLockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(amount, 0, "stale earmark should be cleared");
+        assertEq(newLockEnd, 0, "stale lockEnd should be cleared");
+    }
+
+    function test_setAdvanceRewards_revertsIfAlreadyLocked() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.ActiveCommitmentExists.selector, depositId));
+        regenStaker.setAdvanceRewards(depositId, 5);
+    }
+
+    function test_setAdvanceRewards_allowsResetAfterExpiry() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        vm.warp(uint256(lockEnd) + 1);
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        (uint96 amount, uint64 newLockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(amount, (STAKE_AMOUNT * 5) / 100, "new amount mismatch");
+        assertEq(newLockEnd, block.timestamp + 5 * 30 days, "new lockEnd mismatch");
+    }
+
+    function test_setAdvanceRewards_revertsInvalidPct() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.InvalidAdvanceRewardsPct.selector, 0));
+        regenStaker.setAdvanceRewards(depositId, 0);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.InvalidAdvanceRewardsPct.selector, 6));
+        regenStaker.setAdvanceRewards(depositId, 6);
+    }
+
+    function test_setAdvanceRewards_revertsIfNotOwner() public {
+        vm.prank(claimer);
+        vm.expectRevert(abi.encodeWithSelector(Staker.Staker__Unauthorized.selector, bytes32("not owner"), claimer));
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Staker.Staker__Unauthorized.selector, bytes32("not owner"), stranger));
+        regenStaker.setAdvanceRewards(depositId, 5);
+    }
+
+    // =========================================================
+    // contributeFromAdvanceRewards
+    // =========================================================
+
+    function test_contributeFromAdvance_tokensFlowToCaller() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+        uint96 balanceBefore = _depositBalance(depositId);
+        uint256 ownerBalanceBefore = token.balanceOf(owner);
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        vm.prank(owner);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            earmarkedAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        assertEq(_depositBalance(depositId), balanceBefore - earmarkedAmount, "deposit.balance should decrease");
+        assertEq(token.balanceOf(owner), ownerBalanceBefore + earmarkedAmount, "owner should receive stake tokens");
+    }
+
+    function test_contributeFromAdvance_earningPowerUpdated() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+        uint96 epBefore = _depositEarningPower(depositId);
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        vm.prank(owner);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            earmarkedAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        uint96 epAfter = _depositEarningPower(depositId);
+        // MockEarningPowerCalculator returns balance as earning power
+        assertEq(epAfter, STAKE_AMOUNT - earmarkedAmount, "earning power should decrease proportionally");
+        assertTrue(epAfter < epBefore, "earning power should have dropped");
+    }
+
+    function test_contributeFromAdvance_partialReducesEarmark() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+        uint256 partialAmount = earmarkedAmount / 2;
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        vm.prank(owner);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            partialAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        (uint96 remaining, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(remaining, earmarkedAmount - partialAmount, "earmark should be reduced by partial amount");
+        assertGt(lockEnd, block.timestamp, "lock should still be active after partial contribution");
+    }
+
+    function test_contributeFromAdvance_fullConsumesAmountButKeepsLockUntilExpiry() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        // Read lockEnd before consumption to use in the withdraw revert assertion
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+
+        vm.prank(owner);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            earmarkedAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        (uint96 amount, uint64 lockEndAfter) = regenStaker.advanceRewards(depositId);
+        assertEq(amount, 0, "earmark amount should be consumed after full contribution");
+        assertGt(lockEndAfter, block.timestamp, "lockEnd should remain active until expiry");
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.CommitmentLockActive.selector, depositId, lockEnd));
+        regenStaker.withdraw(depositId, 1e18);
+    }
+
+    function test_contributeFromAdvance_revertsOverEarmark() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+        uint256 overAmount = earmarkedAmount + 1;
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(RegenStakerBase.InsufficientAdvanceRewards.selector, overAmount, earmarkedAmount)
+        );
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            overAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+    }
+
+    function test_contributeFromAdvance_rewardAccrualUnaffected() public {
+        // Accrue some rewards before contribution
+        vm.warp(block.timestamp + REWARD_DURATION / 4);
+
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        vm.prank(owner);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            earmarkedAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        uint96 remainingBalance = _depositBalance(depositId);
+        assertEq(remainingBalance, STAKE_AMOUNT - earmarkedAmount, "balance should reflect contribution");
+
+        // Accrue more rewards on the remaining balance
+        vm.warp(block.timestamp + REWARD_DURATION / 4);
+
+        uint256 balanceBefore = token.balanceOf(owner);
+        vm.prank(owner);
+        regenStaker.claimReward(depositId);
+        uint256 claimed = token.balanceOf(owner) - balanceBefore;
+        assertGt(claimed, 0, "should have accrued rewards on remaining balance");
+    }
+
+    function test_contributeFromAdvance_allowedByClaimerToo() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+
+        // Only owner can earmark
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        uint256 claimerBalanceBefore = token.balanceOf(claimer);
+
+        // Claimer can call contributeFromAdvanceRewards; tokens go to claimer (msg.sender)
+        vm.prank(claimer);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            earmarkedAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        assertEq(
+            token.balanceOf(claimer),
+            claimerBalanceBefore + earmarkedAmount,
+            "claimer should receive stake tokens"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Add `setAdvanceRewards(depositId, pct)`: owner-only, earmarks 1-5% of staked principal and locks the deposit for `pct x 30 days`
- Add `contributeFromAdvanceRewards(...)`: callable by owner or claimer; reduces `deposit.balance` and earning power, transfers stake tokens directly to `msg.sender`
- Lock persists until expiry even after the earmark is fully consumed; `_withdraw()` enforces `CommitmentLockActive` and clears stale state lazily on first withdrawal after expiry
- `setAdvanceRewards` has no `nonReentrant` guard (makes no external calls)
- Add `RegenStakerWithAdvanceRewards.t.sol` covering lock semantics, principal and earning-power accounting, partial and full consumption, and claimer access