### PR TITLE
feat(osu-1354): merge advance-rewards into existing contribute flow

### DIFF
--- a/src/regen/RegenStakerBase.sol
+++ b/src/regen/RegenStakerBase.sol
@@ -33,6 +33,7 @@ import { NotInAllowset } from "src/errors.sol";
 /// @notice Provides shared functionality including:
 ///         - Variable reward duration (7-3000 days, configurable by admin)
 ///         - Earning power management with external bumping incentivized by tips (up to maxBumpTip)
+///         - Earning power calculator updates (blocked during active reward periods for governance protection)
 ///         - Adjustable minimum stake amount (existing deposits grandfathered with restrictions)
 ///         - Access control for stakers and allocation mechanisms
 ///         - Reward compounding (when REWARD_TOKEN == STAKE_TOKEN)
@@ -85,6 +86,10 @@ import { NotInAllowset } from "src/errors.sol";
 /// @dev Integer division causes ~1 wei precision loss, negligible due to SCALE_FACTOR (1e36).
 /// @dev This base is abstract, with variants implementing token-specific behaviors (e.g., delegation surrogates).
 /// @dev Earning power updates are required after balance changes; some are automatic, others via bumpEarningPower.
+///
+/// @dev ACCESS CONTROL:
+///      - admin: Admin operations (protocol parameters, pause, access control) from base Staker
+///      - rewardManager: Can manage reward notifiers (operational role, separation of duties)
 abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, StakerPermitAndStake, StakerOnBehalf {
     using SafeCast for uint256;
 
@@ -135,13 +140,22 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
 
     /// @notice Error thrown when attempting to change earning power calculator during active reward
     error CannotChangeEarningPowerCalculatorDuringActiveReward();
-
     error ZeroOperation();
     error NoOperation();
     error DisablingAllocationMechanismAllowsetNotAllowed();
     /// @param expected Address of REWARD_TOKEN
     /// @param actual Address of token expected by allocation mechanism
     error AssetMismatch(address expected, address actual);
+    /// @param depositId Deposit with an active commitment lock
+    error ActiveCommitmentExists(DepositIdentifier depositId);
+    /// @param depositId Deposit that is locked
+    /// @param lockEnd Timestamp when the lock expires
+    error CommitmentLockActive(DepositIdentifier depositId, uint64 lockEnd);
+    /// @param pct Percentage that was out of the 1-5 range
+    error InvalidAdvanceRewardsPct(uint256 pct);
+    /// @param requested Amount requested for contribution
+    /// @param available Earmarked amount available
+    error InsufficientAdvanceRewards(uint256 requested, uint256 available);
 
     // === State Variables ===
     /// @notice Shared configuration state instance
@@ -169,6 +183,15 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
 
     /// @notice Cached metadata for the most recent reward schedule.
     RewardSchedule public latestRewardSchedule;
+
+    /// @notice Info about a deposit's advance reward earmark and commitment lock
+    struct AdvanceRewardInfo {
+        uint96 amount; // earmarked stake tokens (decreases as contributed)
+        uint64 lockEnd; // withdrawal lock timestamp (0 = no lock)
+    }
+
+    /// @notice Per-deposit advance reward earmarks
+    mapping(DepositIdentifier => AdvanceRewardInfo) public advanceRewards;
 
     // === Events ===
     /// @notice Emitted when the staker allowset is updated
@@ -698,6 +721,87 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         return amountContributedToAllocationMechanism;
     }
 
+    /// @notice Earmarks a percentage of staked capital as advance rewards and locks the deposit.
+    /// @dev Lock duration = pct x 30 days. Tokens stay in place; no transfers occur on this call.
+    /// @dev Only callable while not paused. Reverts if an active lock already exists.
+    /// @param _depositId Deposit to earmark
+    /// @param _pct Percentage of current balance to earmark (1 to 5 inclusive)
+    function setAdvanceRewards(DepositIdentifier _depositId, uint256 _pct) external whenNotPaused {
+        if (_pct == 0 || _pct > 5) revert InvalidAdvanceRewardsPct(_pct);
+
+        Deposit storage deposit = deposits[_depositId];
+        if (deposit.owner != msg.sender) revert Staker__Unauthorized("not owner", msg.sender);
+
+        AdvanceRewardInfo storage sr = advanceRewards[_depositId];
+        if (sr.lockEnd > block.timestamp) revert ActiveCommitmentExists(_depositId);
+
+        uint256 amount = (deposit.balance * _pct) / 100;
+        require(amount > 0, ZeroOperation());
+
+        uint64 lockEnd = uint64(block.timestamp + _pct * 30 days);
+        advanceRewards[_depositId] = AdvanceRewardInfo(amount.toUint96(), lockEnd);
+    }
+
+    /// @notice Consumes earmarked advance rewards and transfers stake tokens to caller.
+    /// @dev NOTE: Caller is responsible for any subsequent contribution flow.
+    /// @dev Reduces deposit.balance and earning power; lock persists until expiry even if amount reaches zero.
+    /// @param _depositId Deposit the advance amount originates from
+    /// @param _amount Amount to consume (must be <= current earmarked amount)
+    /// @param _deadline Unused (kept for backwards compatibility)
+    /// @param _v Unused (kept for backwards compatibility)
+    /// @param _r Unused (kept for backwards compatibility)
+    /// @param _s Unused (kept for backwards compatibility)
+    function contributeFromAdvanceRewards(
+        DepositIdentifier _depositId,
+        address,
+        uint256 _amount,
+        uint256 _deadline,
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s
+    ) external whenNotPaused nonReentrant {
+        // Silence compatibility parameters in a low-cost way.
+        (_deadline, _v, _r, _s);
+
+        Deposit storage deposit = deposits[_depositId];
+        if (deposit.claimer != msg.sender && deposit.owner != msg.sender) {
+            revert Staker__Unauthorized("not claimer or owner", msg.sender);
+        }
+
+        AdvanceRewardInfo storage sr = advanceRewards[_depositId];
+        require(_amount > 0, ZeroOperation());
+        if (_amount > sr.amount) revert InsufficientAdvanceRewards(_amount, sr.amount);
+
+        _checkpointGlobalReward();
+        _checkpointReward(deposit);
+
+        deposit.balance -= _amount.toUint96();
+        _updateEarningPower(deposit);
+        totalStaked -= _amount;
+        depositorTotalStaked[deposit.owner] -= _amount;
+        sr.amount -= _amount.toUint96();
+        _stakeTokenSafeTransferFrom(address(surrogates(deposit.delegatee)), msg.sender, _amount);
+    }
+
+    /// @notice Updates earning power for a deposit after a balance change.
+    /// @dev Extracted to reduce stack depth in contributeFromAdvanceRewards.
+    /// @param deposit Deposit storage reference (balance must already be updated before calling)
+    function _updateEarningPower(Deposit storage deposit) private {
+        uint256 _oldEarningPower = deposit.earningPower;
+        uint256 _newEarningPower = earningPowerCalculator.getEarningPower(
+            deposit.balance,
+            deposit.owner,
+            deposit.delegatee
+        );
+        totalEarningPower = _calculateTotalEarningPower(_oldEarningPower, _newEarningPower, totalEarningPower);
+        depositorTotalEarningPower[deposit.owner] = _calculateTotalEarningPower(
+            _oldEarningPower,
+            _newEarningPower,
+            depositorTotalEarningPower[deposit.owner]
+        );
+        deposit.earningPower = _newEarningPower.toUint96();
+    }
+
     /// @notice Compounds rewards by claiming them and immediately restaking them into the same deposit
     /// @dev REQUIREMENT: Only works when REWARD_TOKEN == STAKE_TOKEN, otherwise reverts.
     /// @dev EARNING POWER: Compounding updates earning power based on new total balance.
@@ -862,7 +966,8 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         _revertIfMinimumStakeAmountNotMet(_depositId);
     }
 
-    /// @notice Prevents withdrawing 0; prevents withdrawals that drop balance below minimum.
+    /// @notice Prevents withdrawing 0; prevents withdrawals that drop balance below minimum;
+    ///         enforces advance rewards commitment lock.
     /// @dev USER PROTECTION: Withdrawals remain enabled even when contract is paused to ensure
     ///      users can always access their principal funds.
     /// @dev Uses reentrancy guard
@@ -874,6 +979,12 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         DepositIdentifier _depositId,
         uint256 _amount
     ) internal virtual override nonReentrant {
+        // Enforce advance rewards commitment lock
+        AdvanceRewardInfo storage sr = advanceRewards[_depositId];
+        if (sr.lockEnd > block.timestamp) revert CommitmentLockActive(_depositId, sr.lockEnd);
+        // Lock expired: clear stale earmark
+        if (sr.lockEnd != 0) delete advanceRewards[_depositId];
+
         require(_amount > 0, ZeroOperation());
         super._withdraw(deposit, _depositId, _amount);
         _revertIfMinimumStakeAmountNotMet(_depositId);

--- a/src/regen/RegenStakerBase.sol
+++ b/src/regen/RegenStakerBase.sol
@@ -596,12 +596,12 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
     /// @dev Requires contract not paused and uses reentrancy guard
     /// @param _depositId Deposit identifier to contribute from
     /// @param _allocationMechanismAddress Approved allocation mechanism to receive contribution
-    /// @param _amount Amount of unclaimed rewards to contribute (must be <= available rewards)
+    /// @param _amount Amount requested to contribute, consumed from rewards first then advance rewards
     /// @param _deadline Signature expiration timestamp
     /// @param _v Signature component v
     /// @param _r Signature component r
     /// @param _s Signature component s
-    /// @return amountContributedToAllocationMechanism Actual amount contributed
+    /// @return amountContributedToAllocationMechanism Actual amount contributed to allocation mechanism (reward leg only)
     function contribute(
         DepositIdentifier _depositId,
         address _allocationMechanismAddress,
@@ -611,53 +611,45 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         bytes32 _r,
         bytes32 _s
     ) public virtual whenNotPaused nonReentrant returns (uint256 amountContributedToAllocationMechanism) {
-        _revertIfAddressZero(_allocationMechanismAddress);
-        require(
-            sharedState.allocationMechanismAllowset.contains(_allocationMechanismAddress),
-            NotInAllowset(_allocationMechanismAddress)
-        );
-
-        // Validate asset compatibility to fail fast and provide clear error
-        {
-            address expectedAsset = address(TokenizedAllocationMechanism(_allocationMechanismAddress).asset());
-            if (address(REWARD_TOKEN) != expectedAsset) {
-                revert AssetMismatch(address(REWARD_TOKEN), expectedAsset);
-            }
-        }
-
         Deposit storage deposit = deposits[_depositId];
         if (deposit.claimer != msg.sender && deposit.owner != msg.sender) {
             revert Staker__Unauthorized("not claimer or owner", msg.sender);
-        }
-
-        // Defense-in-depth dual-check architecture (Cantina Finding #127 fix):
-        // 1. TAM checks msg.sender (claimer/contributor) via beforeSignupHook - receives voting power
-        // 2. RegenStaker checks deposit.owner (fund source) must also be eligible (defense-in-depth)
-        // This prevents delisted owners from using allowlisted claimers as proxies
-        //
-        // IMPORTANT: Voting power goes to msg.sender (claimer), NOT deposit.owner
-        // Per documented permission model (see lines 56-64), the contributor (msg.sender) receives
-        // voting power, preserving claimer autonomy. The owner check here is an additional security
-        // layer to ensure fund sources are also eligible, closing the bypass vector identified in
-        // Cantina Finding #127 where delisted owners could use allowlisted claimers as proxies.
-
-        // Explicit fund source check: Verify deposit owner is also eligible for this mechanism
-        // Assumes mechanism implements canSignup() (OctantQFMechanism interface)
-        bool ownerCanSignup = OctantQFMechanism(payable(_allocationMechanismAddress)).canSignup(deposit.owner);
-        if (!ownerCanSignup) {
-            revert DepositOwnerNotEligibleForMechanism(_allocationMechanismAddress, deposit.owner);
         }
 
         _checkpointGlobalReward();
         _checkpointReward(deposit);
 
         uint256 unclaimedAmount = deposit.scaledUnclaimedRewardCheckpoint / SCALE_FACTOR;
-        require(_amount <= unclaimedAmount, CantAfford(_amount, unclaimedAmount));
+        uint256 rewardToContribute = _amount <= unclaimedAmount ? _amount : unclaimedAmount;
+        uint256 advanceToContribute = _amount - rewardToContribute;
 
         // Special case: Allow zero-amount contributions to enable users to register for voting
         // without contributing funds. This is useful for participation-only scenarios where
         // users want to signal support without financial commitment.
         if (_amount == 0) {
+            _revertIfAddressZero(_allocationMechanismAddress);
+            require(
+                sharedState.allocationMechanismAllowset.contains(_allocationMechanismAddress),
+                NotInAllowset(_allocationMechanismAddress)
+            );
+
+            // Validate asset compatibility to fail fast and provide clear error
+            {
+                address expectedAsset = address(TokenizedAllocationMechanism(_allocationMechanismAddress).asset());
+                if (address(REWARD_TOKEN) != expectedAsset) {
+                    revert AssetMismatch(address(REWARD_TOKEN), expectedAsset);
+                }
+            }
+
+            // Defense-in-depth dual-check architecture (Cantina Finding #127 fix):
+            // 1. TAM checks msg.sender (claimer/contributor) via beforeSignupHook - receives voting power
+            // 2. RegenStaker checks deposit.owner (fund source) must also be eligible (defense-in-depth)
+            // This prevents delisted owners from using allowlisted claimers as proxies.
+            bool ownerCanSignup = OctantQFMechanism(payable(_allocationMechanismAddress)).canSignup(deposit.owner);
+            if (!ownerCanSignup) {
+                revert DepositOwnerNotEligibleForMechanism(_allocationMechanismAddress, deposit.owner);
+            }
+
             emit RewardContributed(_depositId, msg.sender, _allocationMechanismAddress, 0);
             TokenizedAllocationMechanism(_allocationMechanismAddress).signupOnBehalfWithSignature(
                 msg.sender, // Claimer/contributor receives voting power and provides signature
@@ -670,53 +662,73 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
             return 0;
         }
 
-        amountContributedToAllocationMechanism = _amount;
-        _consumeRewards(deposit, _amount);
+        if (rewardToContribute > 0) {
+            _revertIfAddressZero(_allocationMechanismAddress);
+            require(
+                sharedState.allocationMechanismAllowset.contains(_allocationMechanismAddress),
+                NotInAllowset(_allocationMechanismAddress)
+            );
 
-        // Defensive earning power update - maintaining consistency with base Staker pattern
-        uint256 _oldEarningPower = deposit.earningPower;
-        uint256 _newEarningPower = earningPowerCalculator.getEarningPower(
-            deposit.balance,
-            deposit.owner,
-            deposit.delegatee
-        );
+            // Validate asset compatibility to fail fast and provide clear error
+            {
+                address expectedAsset = address(TokenizedAllocationMechanism(_allocationMechanismAddress).asset());
+                if (address(REWARD_TOKEN) != expectedAsset) {
+                    revert AssetMismatch(address(REWARD_TOKEN), expectedAsset);
+                }
+            }
 
-        // Update earning power totals before modifying deposit state
-        totalEarningPower = _calculateTotalEarningPower(_oldEarningPower, _newEarningPower, totalEarningPower);
-        depositorTotalEarningPower[deposit.owner] = _calculateTotalEarningPower(
-            _oldEarningPower,
-            _newEarningPower,
-            depositorTotalEarningPower[deposit.owner]
-        );
-        deposit.earningPower = _newEarningPower.toUint96();
+            // Defense-in-depth dual-check architecture (Cantina Finding #127 fix):
+            // 1. TAM checks msg.sender (claimer/contributor) via beforeSignupHook - receives voting power
+            // 2. RegenStaker checks deposit.owner (fund source) must also be eligible (defense-in-depth)
+            // This prevents delisted owners from using allowlisted claimers as proxies.
+            bool ownerCanSignup = OctantQFMechanism(payable(_allocationMechanismAddress)).canSignup(deposit.owner);
+            if (!ownerCanSignup) {
+                revert DepositOwnerNotEligibleForMechanism(_allocationMechanismAddress, deposit.owner);
+            }
 
-        emit RewardClaimed(_depositId, msg.sender, amountContributedToAllocationMechanism, _newEarningPower);
+            amountContributedToAllocationMechanism = rewardToContribute;
+            _consumeRewards(deposit, rewardToContribute);
+            _updateEarningPower(deposit);
+            emit RewardClaimed(_depositId, msg.sender, amountContributedToAllocationMechanism, deposit.earningPower);
 
-        // approve the allocation mechanism to spend the rewards
-        SafeERC20.safeIncreaseAllowance(
-            REWARD_TOKEN,
-            _allocationMechanismAddress,
-            amountContributedToAllocationMechanism
-        );
+            // approve the allocation mechanism to spend the rewards
+            SafeERC20.safeIncreaseAllowance(
+                REWARD_TOKEN,
+                _allocationMechanismAddress,
+                amountContributedToAllocationMechanism
+            );
 
-        emit RewardContributed(
-            _depositId,
-            msg.sender,
-            _allocationMechanismAddress,
-            amountContributedToAllocationMechanism
-        );
+            emit RewardContributed(
+                _depositId,
+                msg.sender,
+                _allocationMechanismAddress,
+                amountContributedToAllocationMechanism
+            );
 
-        TokenizedAllocationMechanism(_allocationMechanismAddress).signupOnBehalfWithSignature(
-            msg.sender, // Claimer/contributor receives voting power and provides signature
-            amountContributedToAllocationMechanism,
-            _deadline,
-            _v,
-            _r,
-            _s
-        );
+            TokenizedAllocationMechanism(_allocationMechanismAddress).signupOnBehalfWithSignature(
+                msg.sender, // Claimer/contributor receives voting power and provides signature
+                amountContributedToAllocationMechanism,
+                _deadline,
+                _v,
+                _r,
+                _s
+            );
 
-        // check that allowance is zero
-        require(REWARD_TOKEN.allowance(address(this), _allocationMechanismAddress) == 0, "allowance not zero");
+            // check that allowance is zero
+            require(
+                REWARD_TOKEN.allowance(address(this), _allocationMechanismAddress) == 0,
+                "allowance not zero"
+            );
+        }
+
+        if (advanceToContribute > 0) {
+            _applyAdvanceContributeFromExistingRewards(
+                deposit,
+                _depositId,
+                msg.sender,
+                advanceToContribute
+            );
+        }
 
         return amountContributedToAllocationMechanism;
     }
@@ -742,49 +754,47 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         advanceRewards[_depositId] = AdvanceRewardInfo(amount.toUint96(), lockEnd);
     }
 
-    /// @notice Consumes earmarked advance rewards and transfers stake tokens to caller.
-    /// @dev NOTE: Caller is responsible for any subsequent contribution flow.
-    /// @dev Reduces deposit.balance and earning power; lock persists until expiry even if amount reaches zero.
-    /// @param _depositId Deposit the advance amount originates from
-    /// @param _amount Amount to consume (must be <= current earmarked amount)
-    /// @param _deadline Unused (kept for backwards compatibility)
-    /// @param _v Unused (kept for backwards compatibility)
-    /// @param _r Unused (kept for backwards compatibility)
-    /// @param _s Unused (kept for backwards compatibility)
-    function contributeFromAdvanceRewards(
+    /// @notice Applies the advance-rewards leg of contribute.
+    /// @dev Reduces principal balance and earning power; active commitment locks block calls.
+    /// @param deposit Deposit storage reference
+    /// @param _depositId Deposit identifier
+    /// @param _recipient Recipient receiving stake payout (owner or claimer)
+    /// @param _amount Amount to pay from advance rewards
+    function _applyAdvanceContributeFromExistingRewards(
+        Deposit storage deposit,
         DepositIdentifier _depositId,
-        address,
-        uint256 _amount,
-        uint256 _deadline,
-        uint8 _v,
-        bytes32 _r,
-        bytes32 _s
-    ) external whenNotPaused nonReentrant {
-        // Silence compatibility parameters in a low-cost way.
-        (_deadline, _v, _r, _s);
-
-        Deposit storage deposit = deposits[_depositId];
-        if (deposit.claimer != msg.sender && deposit.owner != msg.sender) {
-            revert Staker__Unauthorized("not claimer or owner", msg.sender);
-        }
+        address _recipient,
+        uint256 _amount
+    ) private {
+        require(_amount > 0, ZeroOperation());
 
         AdvanceRewardInfo storage sr = advanceRewards[_depositId];
-        require(_amount > 0, ZeroOperation());
-        if (_amount > sr.amount) revert InsufficientAdvanceRewards(_amount, sr.amount);
+        if (sr.lockEnd > block.timestamp) {
+            revert CommitmentLockActive(_depositId, sr.lockEnd);
+        }
+        // Lock expired: clear stale lock metadata while preserving earmarked amount
+        // so advance payout can be consumed post-expiry.
+        if (sr.lockEnd != 0) {
+            sr.lockEnd = 0;
+        }
 
-        _checkpointGlobalReward();
-        _checkpointReward(deposit);
+        if (_amount > sr.amount) {
+            revert InsufficientAdvanceRewards(_amount, sr.amount);
+        }
+        if (_amount > deposit.balance) {
+            revert CantAfford(_amount, deposit.balance);
+        }
 
         deposit.balance -= _amount.toUint96();
         _updateEarningPower(deposit);
         totalStaked -= _amount;
         depositorTotalStaked[deposit.owner] -= _amount;
         sr.amount -= _amount.toUint96();
-        _stakeTokenSafeTransferFrom(address(surrogates(deposit.delegatee)), msg.sender, _amount);
+        _stakeTokenSafeTransferFrom(address(surrogates(deposit.delegatee)), _recipient, _amount);
     }
 
     /// @notice Updates earning power for a deposit after a balance change.
-    /// @dev Extracted to reduce stack depth in contributeFromAdvanceRewards.
+    /// @dev Shared helper for balance/earning-power updates across contribution flows.
     /// @param deposit Deposit storage reference (balance must already be updated before calling)
     function _updateEarningPower(Deposit storage deposit) private {
         uint256 _oldEarningPower = deposit.earningPower;

--- a/test/integration/regen/RegenIntegration.t.sol
+++ b/test/integration/regen/RegenIntegration.t.sol
@@ -2547,9 +2547,10 @@ contract RegenIntegrationTest is Test {
         // Notify rewards
         vm.prank(ADMIN);
         regenStaker.notifyRewardAmount(rewardAmount);
-        vm.warp(block.timestamp + regenStaker.rewardDuration());
+        vm.warp(block.timestamp + 2 days);
 
         uint256 unclaimedAmount = regenStaker.unclaimedReward(depositId);
+        uint256 advanceTopUpNeeded = contributeAmount - unclaimedAmount;
 
         // Create signature
         uint256 nonce = TokenizedAllocationMechanism(allocationMechanism).nonces(alice);
@@ -2559,7 +2560,7 @@ contract RegenIntegrationTest is Test {
             allocationMechanism,
             alice,
             address(regenStaker),
-            contributeAmount,
+            unclaimedAmount,
             nonce,
             deadline
         );
@@ -2570,8 +2571,10 @@ contract RegenIntegrationTest is Test {
         vm.startPrank(alice);
         rewardToken.approve(allocationMechanism, contributeAmount);
 
-        // Should revert with CantAfford
-        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.CantAfford.selector, contributeAmount, unclaimedAmount));
+        // Reward leg can execute up to `unclaimedAmount`; remaining top-up requires advance rewards.
+        vm.expectRevert(
+            abi.encodeWithSelector(RegenStakerBase.InsufficientAdvanceRewards.selector, advanceTopUpNeeded, 0)
+        );
         regenStaker.contribute(depositId, allocationMechanism, contributeAmount, deadline, v, r, s);
         vm.stopPrank();
     }

--- a/test/regen/RegenStakerGovernanceProtection.t.sol
+++ b/test/regen/RegenStakerGovernanceProtection.t.sol
@@ -29,6 +29,7 @@ contract RegenStakerGovernanceProtectionTest is Test {
     uint256 public constant INITIAL_REWARD_AMOUNT = 100 ether;
     uint256 public constant REWARD_DURATION = 30 days;
     uint256 public constant INITIAL_MIN_STAKE = 1 ether;
+    uint256 public constant INITIAL_MAX_BUMP_TIP = 1000;
 
     function setUp() public {
         rewardToken = new MockERC20(18);
@@ -169,5 +170,312 @@ contract RegenStakerGovernanceProtectionTest is Test {
         vm.stopPrank();
 
         assertGt(regenStaker.rewardEndTime(), block.timestamp);
+    }
+
+    /**
+     * @dev Test setEarningPowerCalculator reverts during active reward period
+     */
+    function test_setEarningPowerCalculator_revertsDuringActiveReward() public {
+        // Deploy alternative calculator
+        RegenEarningPowerCalculator newCalculator = new RegenEarningPowerCalculator(
+            admin,
+            allowset,
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
+
+        // Start reward period
+        vm.startPrank(rewardNotifier);
+        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT);
+        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT);
+        vm.stopPrank();
+
+        // Verify we're in active reward period
+        assertGt(regenStaker.rewardEndTime(), block.timestamp, "Should be in active reward period");
+
+        // Try to change calculator during active rewards - should revert
+        vm.prank(admin);
+        vm.expectRevert(RegenStakerBase.CannotChangeEarningPowerCalculatorDuringActiveReward.selector);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+    }
+
+    /**
+     * @dev Test setEarningPowerCalculator succeeds after reward period ends
+     */
+    function test_setEarningPowerCalculator_succeedsAfterRewardPeriod() public {
+        // Deploy alternative calculator
+        RegenEarningPowerCalculator newCalculator = new RegenEarningPowerCalculator(
+            admin,
+            allowset,
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
+
+        // Start reward period
+        vm.startPrank(rewardNotifier);
+        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT);
+        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT);
+        vm.stopPrank();
+
+        // Fast forward past reward end time
+        vm.warp(regenStaker.rewardEndTime() + 1);
+
+        // Now setEarningPowerCalculator should succeed
+        vm.prank(admin);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+
+        // Verify change was applied
+        assertEq(address(regenStaker.earningPowerCalculator()), address(newCalculator), "Calculator should be updated");
+    }
+
+    /**
+     * @dev Test setEarningPowerCalculator works before any rewards are notified
+     */
+    function test_setEarningPowerCalculator_worksBeforeFirstReward() public {
+        // Deploy alternative calculator
+        RegenEarningPowerCalculator newCalculator = new RegenEarningPowerCalculator(
+            admin,
+            allowset,
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
+
+        // No rewards notified yet, rewardEndTime should be 0
+        assertEq(regenStaker.rewardEndTime(), 0, "No active reward period");
+
+        // setEarningPowerCalculator should work
+        vm.prank(admin);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+
+        assertEq(address(regenStaker.earningPowerCalculator()), address(newCalculator), "Calculator should be updated");
+    }
+
+    /**
+     * @dev Test only admin can call setEarningPowerCalculator (existing access control still works)
+     */
+    function test_setEarningPowerCalculator_onlyAdmin() public {
+        // Deploy alternative calculator
+        RegenEarningPowerCalculator newCalculator = new RegenEarningPowerCalculator(
+            admin,
+            allowset,
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
+
+        // Fast forward past any potential reward period
+        vm.warp(block.timestamp + REWARD_DURATION + 1);
+
+        // Non-admin should fail
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(Staker.Staker__Unauthorized.selector, bytes32("not admin"), user));
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+
+        // Admin should succeed
+        vm.prank(admin);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+        assertEq(
+            address(regenStaker.earningPowerCalculator()),
+            address(newCalculator),
+            "Admin should be able to set calculator"
+        );
+    }
+
+    /**
+     * @dev Test governance protection consistency includes setEarningPowerCalculator
+     */
+    function test_setEarningPowerCalculator_governanceProtectionConsistency() public {
+        // Deploy alternative calculator
+        RegenEarningPowerCalculator newCalculator = new RegenEarningPowerCalculator(
+            admin,
+            allowset,
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
+
+        // Start reward period
+        vm.startPrank(rewardNotifier);
+        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT);
+        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT);
+        vm.stopPrank();
+
+        uint256 rewardEndTime = regenStaker.rewardEndTime();
+        assertGt(rewardEndTime, block.timestamp, "Should be in active reward period");
+
+        // All governance functions should be protected during active rewards
+        vm.startPrank(admin);
+
+        // setEarningPowerCalculator protection
+        vm.expectRevert(RegenStakerBase.CannotChangeEarningPowerCalculatorDuringActiveReward.selector);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+
+        // setMaxBumpTip protection (increases revert)
+        vm.expectRevert(RegenStakerBase.CannotRaiseMaxBumpTipDuringActiveReward.selector);
+        regenStaker.setMaxBumpTip(INITIAL_MAX_BUMP_TIP + 1);
+
+        // setMinimumStakeAmount protection (increases revert)
+        vm.expectRevert(RegenStakerBase.CannotRaiseMinimumStakeAmountDuringActiveReward.selector);
+        regenStaker.setMinimumStakeAmount(2 ether);
+
+        vm.stopPrank();
+
+        // Fast forward past reward period
+        vm.warp(rewardEndTime + 1);
+
+        // All should work after reward period
+        vm.startPrank(admin);
+
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+        assertEq(
+            address(regenStaker.earningPowerCalculator()),
+            address(newCalculator),
+            "Calculator should update after reward period"
+        );
+
+        regenStaker.setMaxBumpTip(10000);
+        assertEq(regenStaker.maxBumpTip(), 10000, "MaxBumpTip should update after reward period");
+
+        regenStaker.setMinimumStakeAmount(1 ether);
+        assertEq(regenStaker.minimumStakeAmount(), 1 ether, "MinimumStake should update after reward period");
+
+        vm.stopPrank();
+    }
+
+    /**
+     * @dev Fuzz test: setEarningPowerCalculator protection across various time points
+     */
+    function testFuzz_setEarningPowerCalculator_protectionTiming(uint256 timeOffset) public {
+        // Deploy alternative calculator
+        RegenEarningPowerCalculator newCalculator = new RegenEarningPowerCalculator(
+            admin,
+            allowset,
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
+
+        // Start reward period
+        vm.startPrank(rewardNotifier);
+        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT);
+        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT);
+        vm.stopPrank();
+
+        uint256 rewardEndTime = regenStaker.rewardEndTime();
+
+        // Bound time offset to be within or after reward period
+        timeOffset = bound(timeOffset, 0, REWARD_DURATION + 1 days);
+        vm.warp(block.timestamp + timeOffset);
+
+        vm.prank(admin);
+        if (block.timestamp <= rewardEndTime) {
+            // During reward period - should revert
+            vm.expectRevert(RegenStakerBase.CannotChangeEarningPowerCalculatorDuringActiveReward.selector);
+            regenStaker.setEarningPowerCalculator(address(newCalculator));
+        } else {
+            // After reward period - should succeed
+            regenStaker.setEarningPowerCalculator(address(newCalculator));
+            assertEq(
+                address(regenStaker.earningPowerCalculator()),
+                address(newCalculator),
+                "Should update after reward period"
+            );
+        }
+    }
+
+    /**
+     * @dev Test multiple reward cycles with setEarningPowerCalculator protection
+     */
+    function test_setEarningPowerCalculator_multipleRewardCycles() public {
+        // Deploy alternative calculators
+        RegenEarningPowerCalculator calculator2 = new RegenEarningPowerCalculator(
+            admin,
+            allowset,
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
+
+        RegenEarningPowerCalculator calculator3 = new RegenEarningPowerCalculator(
+            admin,
+            allowset,
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
+
+        // First reward cycle
+        vm.startPrank(rewardNotifier);
+        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT / 2);
+        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT / 2);
+        vm.stopPrank();
+
+        // Cannot change during first cycle
+        vm.prank(admin);
+        vm.expectRevert(RegenStakerBase.CannotChangeEarningPowerCalculatorDuringActiveReward.selector);
+        regenStaker.setEarningPowerCalculator(address(calculator2));
+
+        // Fast forward to between cycles
+        vm.warp(regenStaker.rewardEndTime() + 1);
+
+        // Can change between cycles
+        vm.prank(admin);
+        regenStaker.setEarningPowerCalculator(address(calculator2));
+        assertEq(address(regenStaker.earningPowerCalculator()), address(calculator2), "Should update between cycles");
+
+        // Second reward cycle
+        vm.startPrank(rewardNotifier);
+        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT / 2);
+        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT / 2);
+        vm.stopPrank();
+
+        // Cannot change during second cycle
+        vm.prank(admin);
+        vm.expectRevert(RegenStakerBase.CannotChangeEarningPowerCalculatorDuringActiveReward.selector);
+        regenStaker.setEarningPowerCalculator(address(calculator3));
+
+        // Fast forward past second cycle
+        vm.warp(regenStaker.rewardEndTime() + 1);
+
+        // Can change after all cycles
+        vm.prank(admin);
+        regenStaker.setEarningPowerCalculator(address(calculator3));
+        assertEq(address(regenStaker.earningPowerCalculator()), address(calculator3), "Should update after all cycles");
+    }
+
+    /**
+     * @dev Test setEarningPowerCalculator protection with edge case timing (exactly at rewardEndTime)
+     */
+    function test_setEarningPowerCalculator_exactlyAtRewardEndTime() public {
+        // Deploy alternative calculator
+        RegenEarningPowerCalculator newCalculator = new RegenEarningPowerCalculator(
+            admin,
+            allowset,
+            IAddressSet(address(0)),
+            AccessMode.ALLOWSET
+        );
+
+        // Start reward period
+        vm.startPrank(rewardNotifier);
+        rewardToken.transfer(address(regenStaker), INITIAL_REWARD_AMOUNT);
+        regenStaker.notifyRewardAmount(INITIAL_REWARD_AMOUNT);
+        vm.stopPrank();
+
+        uint256 rewardEndTime = regenStaker.rewardEndTime();
+
+        // Warp to exactly rewardEndTime (boundary condition)
+        vm.warp(rewardEndTime);
+
+        // At rewardEndTime, should still revert (require is block.timestamp > rewardEndTime)
+        vm.prank(admin);
+        vm.expectRevert(RegenStakerBase.CannotChangeEarningPowerCalculatorDuringActiveReward.selector);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+
+        // Move 1 second past rewardEndTime
+        vm.warp(rewardEndTime + 1);
+
+        // Now should succeed
+        vm.prank(admin);
+        regenStaker.setEarningPowerCalculator(address(newCalculator));
+        assertEq(
+            address(regenStaker.earningPowerCalculator()),
+            address(newCalculator),
+            "Should succeed after rewardEndTime"
+        );
     }
 }

--- a/test/regen/RegenStakerWithAdvanceRewards.t.sol
+++ b/test/regen/RegenStakerWithAdvanceRewards.t.sol
@@ -1,0 +1,414 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import { Test } from "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { AccessMode } from "src/constants.sol";
+import { RegenStaker } from "src/regen/RegenStaker.sol";
+import { RegenStakerBase } from "src/regen/RegenStakerBase.sol";
+import { Staker } from "staker/Staker.sol";
+import { MockERC20Staking } from "test/mocks/MockERC20Staking.sol";
+import { MockEarningPowerCalculator } from "test/mocks/MockEarningPowerCalculator.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { OctantQFMechanism } from "src/mechanisms/mechanism/OctantQFMechanism.sol";
+import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
+import { AddressSet } from "src/utils/AddressSet.sol";
+import { IAddressSet } from "src/utils/IAddressSet.sol";
+
+/// @title RegenStaker Advance Rewards Tests
+/// @notice Tests for setAdvanceRewards() and contributeFromAdvanceRewards()
+contract RegenStakerWithAdvanceRewardsTest is Test {
+    RegenStaker public regenStaker;
+    MockERC20Staking public token;
+    MockEarningPowerCalculator public earningPowerCalculator;
+    OctantQFMechanism public allocationMechanism;
+    AddressSet public allocationAllowset;
+
+    address public admin = makeAddr("admin");
+    address public owner;
+    uint256 private ownerPk;
+    address public claimer;
+    uint256 private claimerPk;
+    address public delegatee = makeAddr("delegatee");
+    address public stranger = makeAddr("stranger");
+
+    uint256 public constant STAKE_AMOUNT = 1000e18;
+    uint256 public constant REWARD_AMOUNT = 10_000e18;
+    uint128 public constant REWARD_DURATION = 30 days;
+
+    Staker.DepositIdentifier public depositId;
+
+    function setUp() public {
+        (owner, ownerPk) = makeAddrAndKey("owner");
+        (claimer, claimerPk) = makeAddrAndKey("claimer");
+
+        token = new MockERC20Staking(18);
+        earningPowerCalculator = new MockEarningPowerCalculator();
+
+        // Deploy a real OctantQFMechanism (same token for stake/reward)
+        TokenizedAllocationMechanism impl = new TokenizedAllocationMechanism();
+        AllocationConfig memory cfg = AllocationConfig({
+            asset: IERC20(address(token)),
+            name: "AdvanceTest",
+            symbol: "ST",
+            votingDelay: 1,
+            votingPeriod: 30 days,
+            quorumShares: 1,
+            timelockDelay: 1,
+            gracePeriod: 100,
+            owner: admin
+        });
+        allocationMechanism = new OctantQFMechanism(
+            address(impl),
+            cfg,
+            1,
+            1,
+            IAddressSet(address(0)), // contributionAllowset (open)
+            IAddressSet(address(0)), // contributionBlockset (none)
+            AccessMode.NONE
+        );
+
+        vm.startPrank(admin);
+        allocationAllowset = new AddressSet();
+        allocationAllowset.add(address(allocationMechanism));
+        vm.stopPrank();
+
+        vm.prank(admin);
+        regenStaker = new RegenStaker(
+            IERC20(address(token)), // rewardsToken (same as stake token)
+            token,
+            earningPowerCalculator,
+            0, // maxBumpTip
+            admin,
+            REWARD_DURATION,
+            1e18, // minimumStakeAmount
+            IAddressSet(address(0)),
+            IAddressSet(address(0)),
+            AccessMode.NONE,
+            IAddressSet(address(allocationAllowset))
+        );
+
+        // Fund owner and stake
+        token.mint(owner, STAKE_AMOUNT);
+        token.mint(address(regenStaker), REWARD_AMOUNT);
+
+        vm.startPrank(owner);
+        token.approve(address(regenStaker), STAKE_AMOUNT);
+        depositId = regenStaker.stake(STAKE_AMOUNT, delegatee, claimer);
+        vm.stopPrank();
+
+        // Schedule rewards
+        vm.startPrank(admin);
+        regenStaker.setRewardNotifier(admin, true);
+        regenStaker.notifyRewardAmount(REWARD_AMOUNT);
+        vm.stopPrank();
+    }
+
+    // =========================================================
+    // Helpers
+    // =========================================================
+
+    /// @dev Returns deposit balance from the public tuple getter
+    function _depositBalance(Staker.DepositIdentifier _depositId) internal view returns (uint96 bal) {
+        (bal, , , , , , ) = regenStaker.deposits(_depositId);
+    }
+
+    /// @dev Returns deposit earning power from the public tuple getter
+    function _depositEarningPower(Staker.DepositIdentifier _depositId) internal view returns (uint96 ep) {
+        (, , ep, , , , ) = regenStaker.deposits(_depositId);
+    }
+
+    // =========================================================
+    // setAdvanceRewards
+    // =========================================================
+
+    function test_setAdvanceRewards_stateCorrect() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        (uint96 amount, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(amount, (STAKE_AMOUNT * 5) / 100, "amount mismatch");
+        assertEq(lockEnd, block.timestamp + 5 * 30 days, "lockEnd mismatch");
+    }
+
+    function test_setAdvanceRewards_lockLinear() public {
+        // 1% -> 30 days
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 1);
+        (, uint64 lockEnd1) = regenStaker.advanceRewards(depositId);
+        assertEq(lockEnd1, block.timestamp + 30 days, "1% lock mismatch");
+
+        // Expire lock, then set 5% -> 150 days
+        vm.warp(uint256(lockEnd1) + 1);
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+        (, uint64 lockEnd5) = regenStaker.advanceRewards(depositId);
+        assertEq(lockEnd5, block.timestamp + 5 * 30 days, "5% lock mismatch");
+    }
+
+    function test_setAdvanceRewards_blocksWithdraw() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.CommitmentLockActive.selector, depositId, lockEnd));
+        regenStaker.withdraw(depositId, 1e18);
+    }
+
+    function test_setAdvanceRewards_allowsWithdrawAfterLock() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+
+        // Warp past lock expiry
+        vm.warp(uint256(lockEnd) + 1);
+
+        // Withdrawal must succeed; stale earmark must be cleared
+        vm.prank(owner);
+        regenStaker.withdraw(depositId, 1e18);
+
+        (uint96 amount, uint64 newLockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(amount, 0, "stale earmark should be cleared");
+        assertEq(newLockEnd, 0, "stale lockEnd should be cleared");
+    }
+
+    function test_setAdvanceRewards_revertsIfAlreadyLocked() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.ActiveCommitmentExists.selector, depositId));
+        regenStaker.setAdvanceRewards(depositId, 5);
+    }
+
+    function test_setAdvanceRewards_allowsResetAfterExpiry() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        vm.warp(uint256(lockEnd) + 1);
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        (uint96 amount, uint64 newLockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(amount, (STAKE_AMOUNT * 5) / 100, "new amount mismatch");
+        assertEq(newLockEnd, block.timestamp + 5 * 30 days, "new lockEnd mismatch");
+    }
+
+    function test_setAdvanceRewards_revertsInvalidPct() public {
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.InvalidAdvanceRewardsPct.selector, 0));
+        regenStaker.setAdvanceRewards(depositId, 0);
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.InvalidAdvanceRewardsPct.selector, 6));
+        regenStaker.setAdvanceRewards(depositId, 6);
+    }
+
+    function test_setAdvanceRewards_revertsIfNotOwner() public {
+        vm.prank(claimer);
+        vm.expectRevert(abi.encodeWithSelector(Staker.Staker__Unauthorized.selector, bytes32("not owner"), claimer));
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Staker.Staker__Unauthorized.selector, bytes32("not owner"), stranger));
+        regenStaker.setAdvanceRewards(depositId, 5);
+    }
+
+    // =========================================================
+    // contributeFromAdvanceRewards
+    // =========================================================
+
+    function test_contributeFromAdvance_tokensFlowToCaller() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+        uint96 balanceBefore = _depositBalance(depositId);
+        uint256 ownerBalanceBefore = token.balanceOf(owner);
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        vm.prank(owner);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            earmarkedAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        assertEq(_depositBalance(depositId), balanceBefore - earmarkedAmount, "deposit.balance should decrease");
+        assertEq(token.balanceOf(owner), ownerBalanceBefore + earmarkedAmount, "owner should receive stake tokens");
+    }
+
+    function test_contributeFromAdvance_earningPowerUpdated() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+        uint96 epBefore = _depositEarningPower(depositId);
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        vm.prank(owner);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            earmarkedAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        uint96 epAfter = _depositEarningPower(depositId);
+        // MockEarningPowerCalculator returns balance as earning power
+        assertEq(epAfter, STAKE_AMOUNT - earmarkedAmount, "earning power should decrease proportionally");
+        assertTrue(epAfter < epBefore, "earning power should have dropped");
+    }
+
+    function test_contributeFromAdvance_partialReducesEarmark() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+        uint256 partialAmount = earmarkedAmount / 2;
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        vm.prank(owner);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            partialAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        (uint96 remaining, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(remaining, earmarkedAmount - partialAmount, "earmark should be reduced by partial amount");
+        assertGt(lockEnd, block.timestamp, "lock should still be active after partial contribution");
+    }
+
+    function test_contributeFromAdvance_fullConsumesAmountButKeepsLockUntilExpiry() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        // Read lockEnd before consumption to use in the withdraw revert assertion
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+
+        vm.prank(owner);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            earmarkedAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        (uint96 amount, uint64 lockEndAfter) = regenStaker.advanceRewards(depositId);
+        assertEq(amount, 0, "earmark amount should be consumed after full contribution");
+        assertGt(lockEndAfter, block.timestamp, "lockEnd should remain active until expiry");
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.CommitmentLockActive.selector, depositId, lockEnd));
+        regenStaker.withdraw(depositId, 1e18);
+    }
+
+    function test_contributeFromAdvance_revertsOverEarmark() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+        uint256 overAmount = earmarkedAmount + 1;
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(RegenStakerBase.InsufficientAdvanceRewards.selector, overAmount, earmarkedAmount)
+        );
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            overAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+    }
+
+    function test_contributeFromAdvance_rewardAccrualUnaffected() public {
+        // Accrue some rewards before contribution
+        vm.warp(block.timestamp + REWARD_DURATION / 4);
+
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        vm.prank(owner);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            earmarkedAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        uint96 remainingBalance = _depositBalance(depositId);
+        assertEq(remainingBalance, STAKE_AMOUNT - earmarkedAmount, "balance should reflect contribution");
+
+        // Accrue more rewards on the remaining balance
+        vm.warp(block.timestamp + REWARD_DURATION / 4);
+
+        uint256 balanceBefore = token.balanceOf(owner);
+        vm.prank(owner);
+        regenStaker.claimReward(depositId);
+        uint256 claimed = token.balanceOf(owner) - balanceBefore;
+        assertGt(claimed, 0, "should have accrued rewards on remaining balance");
+    }
+
+    function test_contributeFromAdvance_allowedByClaimerToo() public {
+        uint256 earmarkPct = 5;
+        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+
+        // Only owner can earmark
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+
+        uint256 claimerBalanceBefore = token.balanceOf(claimer);
+
+        // Claimer can call contributeFromAdvanceRewards; tokens go to claimer (msg.sender)
+        vm.prank(claimer);
+        regenStaker.contributeFromAdvanceRewards(
+            depositId,
+            address(0),
+            earmarkedAmount,
+            block.timestamp + 1 days,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+
+        assertEq(
+            token.balanceOf(claimer),
+            claimerBalanceBefore + earmarkedAmount,
+            "claimer should receive stake tokens"
+        );
+    }
+}

--- a/test/regen/RegenStakerWithAdvanceRewards.t.sol
+++ b/test/regen/RegenStakerWithAdvanceRewards.t.sol
@@ -16,7 +16,7 @@ import { AddressSet } from "src/utils/AddressSet.sol";
 import { IAddressSet } from "src/utils/IAddressSet.sol";
 
 /// @title RegenStaker Advance Rewards Tests
-/// @notice Tests for setAdvanceRewards() and contributeFromAdvanceRewards()
+/// @notice Tests for setAdvanceRewards() and contribution split flow through contribute()
 contract RegenStakerWithAdvanceRewardsTest is Test {
     RegenStaker public regenStaker;
     MockERC20Staking public token;
@@ -116,6 +116,25 @@ contract RegenStakerWithAdvanceRewardsTest is Test {
     /// @dev Returns deposit earning power from the public tuple getter
     function _depositEarningPower(Staker.DepositIdentifier _depositId) internal view returns (uint96 ep) {
         (, , ep, , , , ) = regenStaker.deposits(_depositId);
+    }
+
+    function _contributeSignatureFor(
+        address _contributor,
+        uint256 _contributorPk,
+        uint256 _amount
+    ) internal returns (uint256 deadline, uint8 v, bytes32 r, bytes32 s) {
+        bytes32 domainSeparator = TokenizedAllocationMechanism(address(allocationMechanism)).DOMAIN_SEPARATOR();
+        uint256 nonce = TokenizedAllocationMechanism(address(allocationMechanism)).nonces(_contributor);
+        deadline = block.timestamp + 1 days;
+
+        bytes32 typeHash = keccak256(
+            bytes("Signup(address user,address payer,uint256 deposit,uint256 nonce,uint256 deadline)")
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(typeHash, _contributor, address(regenStaker), _amount, nonce, deadline)
+        );
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+        (v, r, s) = vm.sign(_contributorPk, digest);
     }
 
     // =========================================================
@@ -220,195 +239,319 @@ contract RegenStakerWithAdvanceRewardsTest is Test {
     }
 
     // =========================================================
-    // contributeFromAdvanceRewards
+    // contribute split flow
     // =========================================================
 
-    function test_contributeFromAdvance_tokensFlowToCaller() public {
-        uint256 earmarkPct = 5;
-        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
+    function test_contribute_usesRewardsOnly_whenAvailable() public {
+        vm.warp(block.timestamp + REWARD_DURATION / 4);
+
+        uint256 rewardAvailable = regenStaker.unclaimedReward(depositId);
+        uint256 rewardToContribute = rewardAvailable / 2;
+        require(rewardToContribute > 0, "reward-to-contribute should be > 0");
+
+        (uint256 deadline, uint8 v, bytes32 r, bytes32 s) = _contributeSignatureFor(
+            owner,
+            ownerPk,
+            rewardToContribute
+        );
+
+        uint256 mechanismBalanceBefore = token.balanceOf(address(allocationMechanism));
         uint96 balanceBefore = _depositBalance(depositId);
+        uint256 totalStakedBefore = regenStaker.totalStaked();
+
+        vm.prank(owner);
+        uint256 contributed = regenStaker.contribute(
+            depositId,
+            address(allocationMechanism),
+            rewardToContribute,
+            deadline,
+            v,
+            r,
+            s
+        );
+
+        assertEq(contributed, rewardToContribute, "contributed amount mismatch");
+        assertEq(
+            token.balanceOf(address(allocationMechanism)) - mechanismBalanceBefore,
+            rewardToContribute,
+            "all contribution should hit mechanism"
+        );
+        assertEq(_depositBalance(depositId), balanceBefore, "deposit balance should not reduce");
+        assertEq(regenStaker.totalStaked(), totalStakedBefore, "total staked should not change");
+    }
+
+    function test_contribute_usesAdvanceRewardsOnly_whenNoRewardsAvailable() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+        uint256 earmarkAmount = (STAKE_AMOUNT * 5) / 100;
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        vm.warp(uint256(lockEnd) + 1);
+
+        vm.prank(owner);
+        regenStaker.claimReward(depositId);
+
+        assertEq(regenStaker.unclaimedReward(depositId), 0, "should have zero unclaimed reward");
+
+        uint96 balanceBefore = _depositBalance(depositId);
+        uint256 totalStakedBefore = regenStaker.totalStaked();
+        uint256 ownerTotalStakedBefore = regenStaker.depositorTotalStaked(owner);
         uint256 ownerBalanceBefore = token.balanceOf(owner);
-
-        vm.prank(owner);
-        regenStaker.setAdvanceRewards(depositId, earmarkPct);
-
-        vm.prank(owner);
-        regenStaker.contributeFromAdvanceRewards(
-            depositId,
-            address(0),
-            earmarkedAmount,
-            block.timestamp + 1 days,
-            0,
-            bytes32(0),
-            bytes32(0)
-        );
-
-        assertEq(_depositBalance(depositId), balanceBefore - earmarkedAmount, "deposit.balance should decrease");
-        assertEq(token.balanceOf(owner), ownerBalanceBefore + earmarkedAmount, "owner should receive stake tokens");
-    }
-
-    function test_contributeFromAdvance_earningPowerUpdated() public {
-        uint256 earmarkPct = 5;
-        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
         uint96 epBefore = _depositEarningPower(depositId);
+        uint256 mechanismBalanceBefore = token.balanceOf(address(allocationMechanism));
 
         vm.prank(owner);
-        regenStaker.setAdvanceRewards(depositId, earmarkPct);
-
-        vm.prank(owner);
-        regenStaker.contributeFromAdvanceRewards(
+        uint256 contributed = regenStaker.contribute(
             depositId,
             address(0),
-            earmarkedAmount,
-            block.timestamp + 1 days,
+            earmarkAmount,
+            0,
             0,
             bytes32(0),
             bytes32(0)
         );
 
-        uint96 epAfter = _depositEarningPower(depositId);
-        // MockEarningPowerCalculator returns balance as earning power
-        assertEq(epAfter, STAKE_AMOUNT - earmarkedAmount, "earning power should decrease proportionally");
-        assertTrue(epAfter < epBefore, "earning power should have dropped");
+        assertEq(contributed, 0, "contributed-to-mechanism amount should be zero");
+        assertEq(token.balanceOf(address(allocationMechanism)), mechanismBalanceBefore, "mechanism should not receive tokens");
+        assertEq(token.balanceOf(owner), ownerBalanceBefore + earmarkAmount, "owner should receive stake payout");
+        assertEq(_depositBalance(depositId), balanceBefore - earmarkAmount, "deposit balance should reduce by advance amount");
+        assertEq(regenStaker.totalStaked(), totalStakedBefore - earmarkAmount, "global total staked should reduce");
+        assertEq(
+            regenStaker.depositorTotalStaked(owner),
+            ownerTotalStakedBefore - earmarkAmount,
+            "depositor total staked should reduce"
+        );
+        assertEq(_depositEarningPower(depositId), epBefore - uint96(earmarkAmount), "earning power should reduce");
+        (uint96 remaining, uint64 currentLockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(remaining, 0, "advance rewards should be consumed");
+        assertEq(currentLockEnd, 0, "stale lock should be cleared on advance consumption");
     }
 
-    function test_contributeFromAdvance_partialReducesEarmark() public {
-        uint256 earmarkPct = 5;
-        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
-        uint256 partialAmount = earmarkedAmount / 2;
-
+    function test_contribute_mixedRewardAndAdvanceFlow() public {
         vm.prank(owner);
-        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+        regenStaker.setAdvanceRewards(depositId, 1);
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        vm.warp(uint256(lockEnd) + 1);
 
-        vm.prank(owner);
-        regenStaker.contributeFromAdvanceRewards(
-            depositId,
-            address(0),
-            partialAmount,
-            block.timestamp + 1 days,
-            0,
-            bytes32(0),
-            bytes32(0)
+        uint256 rewardToContribute = regenStaker.unclaimedReward(depositId);
+        require(rewardToContribute > 0, "reward should have accrued");
+        uint256 advanceAmount = ((STAKE_AMOUNT * 1) / 100) / 2;
+
+        (uint256 deadline, uint8 v, bytes32 r, bytes32 s) = _contributeSignatureFor(
+            owner,
+            ownerPk,
+            rewardToContribute
         );
 
-        (uint96 remaining, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
-        assertEq(remaining, earmarkedAmount - partialAmount, "earmark should be reduced by partial amount");
-        assertGt(lockEnd, block.timestamp, "lock should still be active after partial contribution");
+        vm.prank(owner);
+        uint256 contributed = regenStaker.contribute(
+            depositId,
+            address(allocationMechanism),
+            rewardToContribute + advanceAmount,
+            deadline,
+            v,
+            r,
+            s
+        );
+
+        assertEq(contributed, rewardToContribute, "reward portion should be returned");
+        assertEq(token.balanceOf(address(allocationMechanism)), rewardToContribute, "mechanism should only receive reward portion");
+        assertEq(token.balanceOf(owner), advanceAmount, "owner should receive advance payout");
+        assertEq(_depositBalance(depositId), STAKE_AMOUNT - advanceAmount, "deposit should reduce by advance portion only");
+        assertEq(regenStaker.totalStaked(), STAKE_AMOUNT - advanceAmount, "global total staked should reduce only by advance");
+        assertEq(regenStaker.depositorTotalStaked(owner), STAKE_AMOUNT - advanceAmount, "depositor total staked should reduce only by advance");
+        (uint96 remaining, uint64 currentLockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(remaining, ((STAKE_AMOUNT * 1) / 100) - advanceAmount, "advance reward marking should reduce by payout");
+        assertEq(currentLockEnd, 0, "stale lock should be cleared on mixed advance consumption");
     }
 
-    function test_contributeFromAdvance_fullConsumesAmountButKeepsLockUntilExpiry() public {
-        uint256 earmarkPct = 5;
-        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
-
+    function test_contribute_rewardOnlyLegStillWorksDuringActiveLock() public {
+        vm.warp(block.timestamp + REWARD_DURATION / 4);
         vm.prank(owner);
-        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+        regenStaker.setAdvanceRewards(depositId, 5);
 
-        // Read lockEnd before consumption to use in the withdraw revert assertion
         (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
 
-        vm.prank(owner);
-        regenStaker.contributeFromAdvanceRewards(
-            depositId,
-            address(0),
-            earmarkedAmount,
-            block.timestamp + 1 days,
-            0,
-            bytes32(0),
-            bytes32(0)
+        uint256 rewardAvailable = regenStaker.unclaimedReward(depositId);
+        uint256 rewardToContribute = rewardAvailable / 2;
+        require(rewardToContribute > 0, "reward-to-contribute should be > 0");
+
+        (uint256 deadline, uint8 v, bytes32 r, bytes32 s) = _contributeSignatureFor(
+            owner,
+            ownerPk,
+            rewardToContribute
         );
 
-        (uint96 amount, uint64 lockEndAfter) = regenStaker.advanceRewards(depositId);
-        assertEq(amount, 0, "earmark amount should be consumed after full contribution");
-        assertGt(lockEndAfter, block.timestamp, "lockEnd should remain active until expiry");
+        uint256 mechanismBalanceBefore = token.balanceOf(address(allocationMechanism));
+        vm.prank(owner);
+        uint256 contributed = regenStaker.contribute(
+            depositId,
+            address(allocationMechanism),
+            rewardToContribute,
+            deadline,
+            v,
+            r,
+            s
+        );
+
+        assertEq(contributed, rewardToContribute);
+        assertEq(token.balanceOf(address(allocationMechanism)) - mechanismBalanceBefore, rewardToContribute);
+        (uint96 remainingAdvance, uint64 currentLockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(remainingAdvance, (STAKE_AMOUNT * 5) / 100);
+        assertEq(currentLockEnd, lockEnd);
+    }
+
+    function test_contribute_mixedLegBlockedWhenActiveCommitmentLock() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+        (uint96 earmark, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        assertGt(earmark, 0, "earmark should exist");
+
+        vm.warp(block.timestamp + REWARD_DURATION / 4);
+        uint256 rewardAvailable = regenStaker.unclaimedReward(depositId);
+
+        uint256 totalToContribute = rewardAvailable + 1;
+        (uint256 deadline, uint8 v, bytes32 r, bytes32 s) = _contributeSignatureFor(
+            owner,
+            ownerPk,
+            rewardAvailable
+        );
 
         vm.prank(owner);
         vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.CommitmentLockActive.selector, depositId, lockEnd));
-        regenStaker.withdraw(depositId, 1e18);
+        regenStaker.contribute(
+            depositId,
+            address(allocationMechanism),
+            totalToContribute,
+            deadline,
+            v,
+            r,
+            s
+        );
     }
 
-    function test_contributeFromAdvance_revertsOverEarmark() public {
-        uint256 earmarkPct = 5;
-        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
-        uint256 overAmount = earmarkedAmount + 1;
+    function test_contribute_staleAdvanceLockIsClearedAndCanBeReset() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+        (uint96 earmarkAmount, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        require(earmarkAmount > 0, "earmark should exist");
+        vm.warp(uint256(lockEnd) + 1);
 
         vm.prank(owner);
-        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+        regenStaker.claimReward(depositId);
+        assertEq(regenStaker.unclaimedReward(depositId), 0, "rewards should be zeroed before advance leg");
+
+        uint96 balanceBefore = _depositBalance(depositId);
+        vm.prank(owner);
+        uint256 contributed = regenStaker.contribute(
+            depositId,
+            address(0),
+            1,
+            0,
+            0,
+            bytes32(0),
+            bytes32(0)
+        );
+        assertEq(contributed, 0, "advance-only call should return mechanism contribution of 0");
+        assertEq(_depositBalance(depositId), balanceBefore - 1, "advance should reduce principal");
+        (uint96 remainingAfterConsume, uint64 lockAfterConsume) = regenStaker.advanceRewards(depositId);
+        assertEq(remainingAfterConsume, earmarkAmount - 1, "advance amount should remain after stale-lock cleanup");
+        assertEq(lockAfterConsume, 0, "lock should be cleared after expiry");
+
+        uint96 balanceBeforeReset = _depositBalance(depositId);
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+        (uint96 refreshedAmount, uint64 refreshedLockEnd) = regenStaker.advanceRewards(depositId);
+        assertEq(refreshedAmount, (uint256(balanceBeforeReset) * 5) / 100, "stale lock should allow full reset");
+        assertEq(refreshedLockEnd, block.timestamp + 5 * 30 days, "new lock should be active");
+    }
+
+    function test_contribute_overconsumedAdvanceAmount_reverts() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+        uint256 earmarkAmount = (STAKE_AMOUNT * 5) / 100;
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        vm.warp(uint256(lockEnd) + 1);
+
+        vm.prank(owner);
+        regenStaker.claimReward(depositId);
+        assertEq(regenStaker.unclaimedReward(depositId), 0, "rewards should be zeroed before advance leg");
 
         vm.prank(owner);
         vm.expectRevert(
-            abi.encodeWithSelector(RegenStakerBase.InsufficientAdvanceRewards.selector, overAmount, earmarkedAmount)
+            abi.encodeWithSelector(RegenStakerBase.InsufficientAdvanceRewards.selector, earmarkAmount + 1, earmarkAmount)
         );
-        regenStaker.contributeFromAdvanceRewards(
+        regenStaker.contribute(
             depositId,
             address(0),
-            overAmount,
-            block.timestamp + 1 days,
+            earmarkAmount + 1,
+            0,
             0,
             bytes32(0),
             bytes32(0)
         );
     }
 
-    function test_contributeFromAdvance_rewardAccrualUnaffected() public {
-        // Accrue some rewards before contribution
+    function test_contribute_zeroAmountStillAllowedForContributionSignup() public {
         vm.warp(block.timestamp + REWARD_DURATION / 4);
+        uint256 rewardAvailable = regenStaker.unclaimedReward(depositId);
+        require(rewardAvailable > 0, "reward should be available");
 
-        uint256 earmarkPct = 5;
-        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
-
-        vm.prank(owner);
-        regenStaker.setAdvanceRewards(depositId, earmarkPct);
+        (uint256 deadline, uint8 v, bytes32 r, bytes32 s) = _contributeSignatureFor(owner, ownerPk, 0);
 
         vm.prank(owner);
-        regenStaker.contributeFromAdvanceRewards(
+        uint256 contributed = regenStaker.contribute(
             depositId,
-            address(0),
-            earmarkedAmount,
-            block.timestamp + 1 days,
+            address(allocationMechanism),
             0,
-            bytes32(0),
-            bytes32(0)
+            deadline,
+            v,
+            r,
+            s
         );
+        assertEq(contributed, 0, "zero amount should still be a valid signup path");
+    }
 
-        uint96 remainingBalance = _depositBalance(depositId);
-        assertEq(remainingBalance, STAKE_AMOUNT - earmarkedAmount, "balance should reflect contribution");
+    function test_contribute_fromAdvanceRewards_allowedForClaimerToo() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+        (, uint64 lockEnd) = regenStaker.advanceRewards(depositId);
+        vm.warp(uint256(lockEnd) + 1);
 
-        // Accrue more rewards on the remaining balance
-        vm.warp(block.timestamp + REWARD_DURATION / 4);
-
-        uint256 balanceBefore = token.balanceOf(owner);
         vm.prank(owner);
         regenStaker.claimReward(depositId);
-        uint256 claimed = token.balanceOf(owner) - balanceBefore;
-        assertGt(claimed, 0, "should have accrued rewards on remaining balance");
-    }
+        assertEq(regenStaker.unclaimedReward(depositId), 0, "rewards should be zeroed before advance leg");
 
-    function test_contributeFromAdvance_allowedByClaimerToo() public {
-        uint256 earmarkPct = 5;
-        uint256 earmarkedAmount = (STAKE_AMOUNT * earmarkPct) / 100;
-
-        // Only owner can earmark
-        vm.prank(owner);
-        regenStaker.setAdvanceRewards(depositId, earmarkPct);
-
+        uint256 earmarkAmount = (STAKE_AMOUNT * 5) / 100;
         uint256 claimerBalanceBefore = token.balanceOf(claimer);
 
-        // Claimer can call contributeFromAdvanceRewards; tokens go to claimer (msg.sender)
         vm.prank(claimer);
-        regenStaker.contributeFromAdvanceRewards(
+        uint256 contributed = regenStaker.contribute(
             depositId,
             address(0),
-            earmarkedAmount,
-            block.timestamp + 1 days,
+            earmarkAmount,
+            0,
             0,
             bytes32(0),
             bytes32(0)
         );
+        assertEq(contributed, 0, "advance-only call should return contribution portion");
+        assertEq(token.balanceOf(claimer), claimerBalanceBefore + earmarkAmount, "claimer should receive payout");
+    }
 
-        assertEq(
-            token.balanceOf(claimer),
-            claimerBalanceBefore + earmarkedAmount,
-            "claimer should receive stake tokens"
+    function test_contribute_fromAdvanceRewards_revertsUnauthorizedCaller() public {
+        vm.prank(owner);
+        regenStaker.setAdvanceRewards(depositId, 5);
+
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Staker.Staker__Unauthorized.selector, bytes32("not claimer or owner"), stranger));
+        regenStaker.contribute(
+            depositId,
+            address(0),
+            (STAKE_AMOUNT * 5) / 100,
+            0,
+            0,
+            bytes32(0),
+            bytes32(0)
         );
     }
 }

--- a/test/unit/regen/RegenBranchCoverage.t.sol
+++ b/test/unit/regen/RegenBranchCoverage.t.sol
@@ -1516,7 +1516,7 @@ contract RegenStakerBaseBranchCoverageTest is Test {
         vm.clearMockedCalls();
     }
 
-    // ===== contribute: CantAfford reverts =====
+    // ===== contribute: insufficient advance rewards reverts =====
 
     function test_contribute_cantAfford_reverts() public {
         Staker.DepositIdentifier depositId = _stakeFor(staker1, 1000e18);
@@ -1536,7 +1536,7 @@ contract RegenStakerBaseBranchCoverageTest is Test {
         vm.mockCall(fakeMechanism, abi.encodeWithSelector(bytes4(keccak256("canSignup(address)"))), abi.encode(true));
 
         vm.prank(staker1);
-        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.CantAfford.selector, 1e18, 0));
+        vm.expectRevert(abi.encodeWithSelector(RegenStakerBase.InsufficientAdvanceRewards.selector, 1e18, 0));
         regenStaker.contribute(depositId, fakeMechanism, 1e18, block.timestamp + 1 days, 0, bytes32(0), bytes32(0));
 
         vm.clearMockedCalls();
@@ -1587,6 +1587,8 @@ contract RegenStakerBaseBranchCoverageTest is Test {
 
     function test_contribute_ownerNotEligible_reverts() public {
         Staker.DepositIdentifier depositId = _stakeFor(staker1, 1000e18);
+        _notifyReward(10e18);
+        vm.warp(block.timestamp + 7 days);
 
         address fakeMechanism = makeAddr("validMech4");
         vm.mockCall(


### PR DESCRIPTION
Alternative implementation to #390 that removes the separate external advance-rewards entrypoint and routes reward/advance legs through existing `contribute` flow with preconditioned split execution.

Key points:
- No external `contributeFromAdvanceRewards` API
- Rewards-first, optional advance top-up in same call
- Return value remains mechanism-contributed reward amount
- Keeps `setAdvanceRewards` as setup/admin flow
- Updated tests for rewards-only, advance-only, mixed, lock behavior, and integration expectations

Rival to #390 for side-by-side review.