### PR TITLE
OSU-1513: remove latestRewardSchedule storage/event for bytecode savings

### DIFF
--- a/src/regen/README.md
+++ b/src/regen/README.md
@@ -604,4 +604,3 @@ See main repository for security information.
 **Golem Foundation**
 - Website: https://golem.foundation
 - Security: security@golem.foundation
-

--- a/src/regen/RegenStakerBase.sol
+++ b/src/regen/RegenStakerBase.sol
@@ -156,20 +156,6 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
     /// @dev This includes claims, compounding, contributions, and tips
     uint256 public totalClaimedRewards;
 
-    /// @notice Summary of the most recently scheduled reward cycle.
-    /// @dev Tracks both the new amount and any carried-over rewards for analytics and UX.
-    struct RewardSchedule {
-        uint256 addedAmount;
-        uint256 carryOverAmount;
-        uint256 totalScheduledAmount;
-        uint256 requiredBalance;
-        uint256 duration;
-        uint256 endTime;
-    }
-
-    /// @notice Cached metadata for the most recent reward schedule.
-    RewardSchedule public latestRewardSchedule;
-
     // === Events ===
     /// @notice Emitted when the staker allowset is updated
     /// @param allowset Address of new allowset contract controlling staker access
@@ -419,16 +405,6 @@ abstract contract RegenStakerBase is Staker, Pausable, ReentrancyGuard, EIP712, 
         totalRewards += _amount;
 
         emit RewardNotified(_amount, msg.sender);
-
-        latestRewardSchedule = RewardSchedule({
-            addedAmount: _amount,
-            carryOverAmount: carryOverAmount,
-            totalScheduledAmount: totalScheduledAmount,
-            requiredBalance: _requiredBalance,
-            duration: sharedState.rewardDuration,
-            endTime: rewardEndTime
-        });
-
         emit RewardScheduleUpdated(
             _amount,
             carryOverAmount,

--- a/test/proof-of-fixes/cantina-competition-september-2025/Finding359Fix.t.sol
+++ b/test/proof-of-fixes/cantina-competition-september-2025/Finding359Fix.t.sol
@@ -6,12 +6,12 @@ import { RegenStakerBase } from "src/regen/RegenStakerBase.sol";
 import { Staker } from "staker/Staker.sol";
 
 /// @title Cantina Competition September 2025 – Finding 359 Fix
-/// @notice Proves that reward schedule metadata is surfaced after notifying new rewards.
+/// @notice Proves reward schedule metadata is emitted for call-free indexing.
 contract Cantina359Fix is OctantTestBase {
     uint256 internal constant FIRST_REWARD = 100 ether;
     uint256 internal constant SECOND_REWARD = 40 ether;
 
-    function testFix_TracksAndEmitsRewardScheduleMetadata() public {
+    function testFix_EmitsRewardScheduleMetadata() public {
         // Fund the notifier for both reward notifications.
         rewardToken.mint(rewardNotifier, FIRST_REWARD + SECOND_REWARD);
 
@@ -34,21 +34,6 @@ contract Cantina359Fix is OctantTestBase {
         regenStaker.notifyRewardAmount(FIRST_REWARD);
         vm.stopPrank();
 
-        (
-            uint256 addedFirst,
-            uint256 carryFirst,
-            uint256 totalScheduledFirst,
-            uint256 requiredFirst,
-            uint256 durationFirst,
-            uint256 endTimeFirst
-        ) = regenStaker.latestRewardSchedule();
-        assertEq(addedFirst, FIRST_REWARD, "first added amount mismatch");
-        assertEq(carryFirst, 0, "first carry-over mismatch");
-        assertEq(totalScheduledFirst, FIRST_REWARD, "first total scheduled mismatch");
-        assertEq(requiredFirst, FIRST_REWARD, "first required balance mismatch");
-        assertEq(durationFirst, REWARD_DURATION, "first duration mismatch");
-        assertEq(endTimeFirst, expectedEndTimeFirst, "first end time mismatch");
-
         // --- Second reward notification: full carry-over from first cycle ---
         vm.startPrank(rewardNotifier);
         rewardToken.transfer(address(regenStaker), SECOND_REWARD);
@@ -67,20 +52,5 @@ contract Cantina359Fix is OctantTestBase {
         );
         regenStaker.notifyRewardAmount(SECOND_REWARD);
         vm.stopPrank();
-
-        (
-            uint256 addedSecond,
-            uint256 carrySecond,
-            uint256 totalScheduledSecond,
-            uint256 requiredSecond,
-            uint256 durationSecond,
-            uint256 endTimeSecond
-        ) = regenStaker.latestRewardSchedule();
-        assertEq(addedSecond, SECOND_REWARD, "second added amount mismatch");
-        assertEq(carrySecond, FIRST_REWARD, "second carry-over mismatch");
-        assertEq(totalScheduledSecond, FIRST_REWARD + SECOND_REWARD, "second total scheduled mismatch");
-        assertEq(requiredSecond, FIRST_REWARD + SECOND_REWARD, "second required balance mismatch");
-        assertEq(durationSecond, REWARD_DURATION, "second duration mismatch");
-        assertEq(endTimeSecond, expectedEndTimeSecond, "second end time mismatch");
     }
 }

--- a/test/unit/regen/RegenBranchCoverage.t.sol
+++ b/test/unit/regen/RegenBranchCoverage.t.sol
@@ -807,9 +807,8 @@ contract RegenStakerBaseBranchCoverageTest is Test {
         // Notify more rewards (should carry over remaining)
         _notifyReward(5000e18);
 
-        // Verify schedule was updated
-        (uint256 addedAmount, , , , , ) = regenStaker.latestRewardSchedule();
-        assertEq(addedAmount, 5000e18);
+        // Verify cumulative rewards include the carry-over path update
+        assertEq(regenStaker.totalRewards(), 15000e18);
     }
 
     // ===== _checkpointGlobalReward: totalEarningPower == 0 extends rewardEndTime =====


### PR DESCRIPTION
Removes `latestRewardSchedule` storage/getter for bytecode savings while keeping `RewardScheduleUpdated` so indexers can stay event-only.

Changes:
- delete `RewardSchedule` struct storage and `latestRewardSchedule()` getter
- keep and emit `RewardScheduleUpdated` with full schedule metadata
- keep `notifyRewardAmount` validation + pass through `requiredBalance` for event payload
- update affected tests/docs

Tests:
- `forge test --match-path test/unit/regen/RegenBranchCoverage.t.sol --match-test test_notifyReward_carryOver_path`
- `forge test --match-path test/proof-of-fixes/cantina-competition-september-2025/Finding359Fix.t.sol`