### PR TITLE
Feature/osu 1516 a report on the technical side for what we can accomplish

### DIFF
--- a/test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol
@@ -1,0 +1,358 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import { ERC4626Strategy } from "src/strategies/yieldDonating/ERC4626Strategy.sol";
+import { ERC4626StrategyFactory } from "src/factories/ERC4626StrategyFactory.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
+import { BaseYieldDonatingIntegrationTest } from "./base/BaseYieldDonatingIntegrationTest.sol";
+import { KpkTestConfig } from "../config/KpkTestConfig.sol";
+
+/// @title KPK ERC4626 Yield Donating Test
+/// @author Octant
+/// @notice Integration tests for ERC4626Strategy against KPK (karpatkey) MetaMorpho vaults on mainnet
+/// @dev KPK vaults are standard ERC-4626 MetaMorpho vaults curated by karpatkey on Morpho.
+///      This test uses the generic ERC4626Strategy since no protocol-specific adapter is needed.
+///      Defaults to USDC configuration; override config getters for other assets (e.g., WETH).
+contract KpkERC4626StrategyTest is BaseYieldDonatingIntegrationTest {
+    // ========== STATE VARIABLES ==========
+
+    ERC4626Strategy public strategy;
+    ERC4626StrategyFactory public factory;
+
+    // ========== CONFIGURATION OVERRIDES ==========
+
+    function _asset() internal pure virtual override returns (address) {
+        return KpkTestConfig.USDC;
+    }
+
+    function _strategyName() internal pure virtual override returns (string memory) {
+        return KpkTestConfig.USDC_STRATEGY_NAME;
+    }
+
+    function _strategySymbol() internal pure virtual override returns (string memory) {
+        return KpkTestConfig.USDC_STRATEGY_SYMBOL;
+    }
+
+    function _initialDeposit() internal pure virtual override returns (uint256) {
+        return KpkTestConfig.USDC_INITIAL_DEPOSIT;
+    }
+
+    function _compounderVault() internal pure virtual override returns (address) {
+        return KpkTestConfig.USDC_KPK_VAULT;
+    }
+
+    function _minDeposit() internal pure virtual override returns (uint256) {
+        return KpkTestConfig.USDC_MIN_DEPOSIT;
+    }
+
+    function _maxDeposit() internal pure virtual override returns (uint256) {
+        return KpkTestConfig.USDC_MAX_DEPOSIT;
+    }
+
+    function _decimals() internal pure virtual override returns (uint8) {
+        return KpkTestConfig.USDC_DECIMALS;
+    }
+
+    // ========== TEST-SPECIFIC CONFIGURATION ==========
+
+    function _depositCapMaxCheck() internal pure virtual returns (uint256) {
+        return KpkTestConfig.USDC_DEPOSIT_CAP_MAX_CHECK;
+    }
+
+    function _depositCapExcess() internal pure virtual returns (uint256) {
+        return KpkTestConfig.USDC_DEPOSIT_CAP_EXCESS;
+    }
+
+    function _multiUserDeposit1() internal pure virtual returns (uint256) {
+        return KpkTestConfig.USDC_MULTI_USER_DEPOSIT_1;
+    }
+
+    function _multiUserDeposit2() internal pure virtual returns (uint256) {
+        return KpkTestConfig.USDC_MULTI_USER_DEPOSIT_2;
+    }
+
+    // ========== SETUP ==========
+
+    function _etchImplementation() internal override {
+        implementation = new YieldDonatingTokenizedStrategy{ salt: keccak256("OCT_YIELD_DONATING_STRATEGY_V1") }();
+        bytes memory tokenizedStrategyBytecode = address(implementation).code;
+        vm.etch(KpkTestConfig.TOKENIZED_STRATEGY_ADDRESS, tokenizedStrategyBytecode);
+    }
+
+    function _deployStrategy() internal override returns (address) {
+        _etchImplementation();
+
+        factory = new ERC4626StrategyFactory{ salt: keccak256("OCT_ERC4626_STRATEGY_FACTORY_V1") }();
+
+        vm.startPrank(management);
+        address strategyAddress = factory.createStrategy(
+            _compounderVault(),
+            _asset(),
+            _strategyName(),
+            _strategySymbol(),
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false, // enableBurning
+            address(implementation)
+        );
+        vm.stopPrank();
+
+        strategy = ERC4626Strategy(strategyAddress);
+        return strategyAddress;
+    }
+
+    function _labelAddresses() internal virtual override {
+        vm.label(address(strategy), "KpkERC4626Donating");
+        vm.label(address(factory), "ERC4626StrategyFactory");
+        vm.label(_compounderVault(), "KPK Vault");
+        vm.label(_asset(), "Asset");
+        vm.label(management, "Management");
+        vm.label(keeper, "Keeper");
+        vm.label(emergencyAdmin, "Emergency Admin");
+        vm.label(donationAddress, "Donation Address");
+        vm.label(user, "Test User");
+    }
+
+    function setUp() public {
+        _baseSetUp();
+    }
+
+    // ========== TESTS - Delegating to base implementations ==========
+
+    function testInitializationKpk() public view {
+        _testInitialization();
+    }
+
+    function testFuzzDepositKpk(uint256 depositAmount) public {
+        _testFuzzDeposit(depositAmount);
+    }
+
+    function testFuzzWithdrawKpk(uint256 depositAmount, uint256 withdrawFraction) public {
+        _testFuzzWithdraw(depositAmount, withdrawFraction);
+    }
+
+    function testFuzzHarvestWithProfitDonationKpk(uint256 depositAmount, uint256 profitAmount) public {
+        depositAmount = bound(depositAmount, _minDeposit(), _maxDeposit());
+        profitAmount = bound(profitAmount, 1e5, depositAmount);
+
+        if (ERC20(_asset()).balanceOf(user) < depositAmount) {
+            airdrop(ERC20(_asset()), user, depositAmount);
+        }
+
+        vm.startPrank(user);
+        ERC20(_asset()).approve(address(vault), depositAmount);
+        IERC4626(address(vault)).deposit(depositAmount, user);
+        vm.stopPrank();
+
+        uint256 totalAssetsBefore = IERC4626(address(vault)).totalAssets();
+        uint256 userSharesBefore = IERC4626(address(vault)).balanceOf(user);
+        uint256 donationBalanceBefore = ERC20(address(vault)).balanceOf(donationAddress);
+
+        // Mock profit by mocking KPK vault return value
+        uint256 balanceOfKpkVault = IERC4626(_compounderVault()).balanceOf(address(strategy));
+        vm.mockCall(
+            address(IERC4626(_compounderVault())),
+            abi.encodeWithSelector(IERC4626.convertToAssets.selector, balanceOfKpkVault),
+            abi.encode(depositAmount + profitAmount)
+        );
+
+        vm.startPrank(keeper);
+        (uint256 profit, uint256 loss) = IMockStrategy(address(strategy)).report();
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+
+        // Airdrop profit to simulate the actual profit
+        airdrop(ERC20(_asset()), address(strategy), profitAmount);
+
+        assertGt(profit, 0, "Should have captured profit from yield");
+        assertEq(loss, 0, "Should have no loss");
+
+        // User shares should remain the same (no dilution)
+        assertEq(IERC4626(address(vault)).balanceOf(user), userSharesBefore, "User shares should not change");
+
+        // Donation address should have received the profit
+        uint256 donationBalanceAfter = ERC20(address(vault)).balanceOf(donationAddress);
+        assertGt(donationBalanceAfter, donationBalanceBefore, "Donation address should receive profit");
+
+        // Total assets should increase by the profit amount
+        assertGt(IERC4626(address(vault)).totalAssets(), totalAssetsBefore, "Total assets should increase");
+    }
+
+    function testFuzzEmergencyWithdrawKpk(uint256 depositAmount, uint256 withdrawFraction) public {
+        depositAmount = bound(depositAmount, _minDeposit(), _maxDeposit());
+        withdrawFraction = bound(withdrawFraction, 1, 100);
+
+        if (ERC20(_asset()).balanceOf(user) < depositAmount) {
+            airdrop(ERC20(_asset()), user, depositAmount);
+        }
+
+        vm.startPrank(user);
+        ERC20(_asset()).approve(address(vault), depositAmount);
+        IERC4626(address(vault)).deposit(depositAmount, user);
+        vm.stopPrank();
+
+        uint256 emergencyWithdrawAmount = (depositAmount * withdrawFraction) / 100;
+        vm.assume(emergencyWithdrawAmount > 0);
+
+        // Cap emergency withdraw to what's available in KPK vault
+        uint256 maxWithdrawableFromKpk = IERC4626(_compounderVault()).maxWithdraw(address(strategy));
+        if (emergencyWithdrawAmount > maxWithdrawableFromKpk) {
+            emergencyWithdrawAmount = maxWithdrawableFromKpk;
+        }
+
+        vm.startPrank(emergencyAdmin);
+        vault.shutdownStrategy();
+        vault.emergencyWithdraw(emergencyWithdrawAmount);
+        vm.stopPrank();
+
+        // User should still be able to withdraw up to maxRedeem
+        vm.startPrank(user);
+        uint256 maxRedeem = vault.maxRedeem(user);
+        if (maxRedeem > 0) {
+            uint256 assetsReceived = vault.redeem(maxRedeem, user, user);
+            assertGt(assetsReceived, 0, "User should receive some assets");
+        }
+        vm.stopPrank();
+    }
+
+    // ========== ERC4626 STRATEGY TESTS ==========
+
+    /// @notice Test that strategy uses the correct target vault and asset
+    function testBasicConfiguration() public view {
+        assertEq(IERC4626(address(strategy)).asset(), _asset(), "Asset should be correct");
+        assertEq(strategy.targetVault(), _compounderVault(), "Target vault should be correct");
+    }
+
+    /// @notice Test available deposit limit without idle assets
+    function testAvailableDepositLimitWithoutIdleAssets() public view {
+        uint256 limit = strategy.availableDepositLimit(user);
+        uint256 kpkLimit = IERC4626(_compounderVault()).maxDeposit(address(strategy));
+        uint256 idleBalance = ERC20(_asset()).balanceOf(address(strategy));
+
+        assertEq(idleBalance, 0, "Strategy should have no idle assets initially");
+        assertEq(limit, kpkLimit, "Available deposit limit should match KPK vault limit when no idle assets");
+    }
+
+    /// @notice Test available deposit limit with idle assets
+    function testAvailableDepositLimitWithIdleAssets() public {
+        uint256 idleAmount = 1000 * 10 ** uint256(_decimals());
+
+        airdrop(ERC20(_asset()), address(strategy), idleAmount);
+
+        uint256 limit = strategy.availableDepositLimit(user);
+        uint256 kpkLimit = IERC4626(_compounderVault()).maxDeposit(address(strategy));
+        uint256 idleBalance = ERC20(_asset()).balanceOf(address(strategy));
+
+        assertEq(idleBalance, idleAmount, "Strategy should have idle assets");
+
+        uint256 expectedLimit = kpkLimit > idleAmount ? kpkLimit - idleAmount : 0;
+        assertEq(limit, expectedLimit, "Available deposit limit should account for idle assets");
+        assertLt(limit, kpkLimit, "Available deposit limit should be less than KPK limit when idle assets exist");
+    }
+
+    /// @notice Test deposit cap handling
+    function testDepositCap() public {
+        uint256 depositCap = IERC4626(_compounderVault()).maxDeposit(address(strategy));
+
+        uint256 maxCheckAmount = _depositCapMaxCheck();
+        if (depositCap > maxCheckAmount) {
+            return;
+        }
+
+        uint256 excessAmount = depositCap + _depositCapExcess();
+
+        airdrop(ERC20(_asset()), user, excessAmount);
+
+        vm.startPrank(user);
+        ERC20(_asset()).approve(address(vault), excessAmount);
+
+        vm.expectRevert();
+        IERC4626(address(vault)).deposit(excessAmount, user);
+        vm.stopPrank();
+    }
+
+    /// @notice Test multiple users depositing and withdrawing
+    function testMultiUserFlow() public {
+        address user2 = address(0x9876);
+        uint256 deposit1 = _multiUserDeposit1();
+        uint256 deposit2 = _multiUserDeposit2();
+
+        airdrop(ERC20(_asset()), user, deposit1);
+        airdrop(ERC20(_asset()), user2, deposit2);
+
+        vm.prank(user);
+        ERC20(_asset()).approve(address(vault), deposit1);
+        vm.prank(user2);
+        ERC20(_asset()).approve(address(vault), deposit2);
+
+        vm.prank(user);
+        uint256 shares1 = IERC4626(address(vault)).deposit(deposit1, user);
+
+        vm.prank(user2);
+        uint256 shares2 = IERC4626(address(vault)).deposit(deposit2, user2);
+
+        assertEq(IERC4626(address(vault)).balanceOf(user), shares1);
+        assertEq(IERC4626(address(vault)).balanceOf(user2), shares2);
+
+        vm.prank(user);
+        IERC4626(address(vault)).redeem(shares1 / 2, user, user);
+
+        assertEq(IERC4626(address(vault)).balanceOf(user), shares1 / 2);
+        assertGt(ERC20(_asset()).balanceOf(user), 0);
+    }
+
+    // ========== AVAILABLE WITHDRAW LIMIT OVERFLOW TESTS ==========
+
+    function testAvailableWithdrawLimitNoOverflowKpk() public {
+        _testAvailableWithdrawLimitOverflow();
+    }
+
+    function testAvailableWithdrawLimitNormalCaseKpk() public {
+        _testAvailableWithdrawLimitNormal();
+    }
+
+    function testAvailableWithdrawLimitZeroIdleMaxVaultKpk() public {
+        _testAvailableWithdrawLimitZeroIdleMaxVault();
+    }
+
+    function testAvailableWithdrawLimitExactBoundaryKpk() public {
+        _testAvailableWithdrawLimitExactBoundary();
+    }
+
+    function testFuzzAvailableWithdrawLimitNeverRevertsKpk(uint256 a, uint256 b) public {
+        _testFuzzAvailableWithdrawLimitNeverReverts(a, b);
+    }
+
+    // ========== HARVEST OVERFLOW TESTS ==========
+
+    function testHarvestOverflowFromVaultKpk() public {
+        _testHarvestOverflowFromVault();
+    }
+
+    // ========== CONSTRUCTOR TESTS ==========
+
+    /// @notice Test constructor asset validation rejects wrong asset
+    function testConstructorAssetValidation() public {
+        // Use USDT (a real contract but wrong asset for the vault) to trigger the asset mismatch check
+        address wrongAsset = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+        vm.expectRevert("Asset mismatch with target vault");
+        new ERC4626Strategy(
+            _compounderVault(),
+            wrongAsset,
+            _strategyName(),
+            _strategySymbol(),
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            true,
+            address(implementation)
+        );
+    }
+}

--- a/test/integration/strategies/YieldDonating/kpk/KpkETHPrimeStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/kpk/KpkETHPrimeStrategy.t.sol
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { KpkERC4626StrategyTest } from "../KpkERC4626Strategy.t.sol";
+import { KpkTestConfig } from "../../config/KpkTestConfig.sol";
+
+/// @title KPK ETH Prime Strategy Test
+/// @author Octant
+/// @notice Integration tests for ERC4626Strategy with KPK ETH Prime vault on Morpho
+/// @dev Extends KpkERC4626StrategyTest with WETH-specific configuration
+contract KpkETHPrimeStrategyTest is KpkERC4626StrategyTest {
+    // ========== WETH CONFIGURATION OVERRIDES ==========
+
+    function _asset() internal pure override returns (address) {
+        return KpkTestConfig.WETH;
+    }
+
+    function _strategyName() internal pure override returns (string memory) {
+        return KpkTestConfig.WETH_STRATEGY_NAME;
+    }
+
+    function _strategySymbol() internal pure override returns (string memory) {
+        return KpkTestConfig.WETH_STRATEGY_SYMBOL;
+    }
+
+    function _initialDeposit() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_INITIAL_DEPOSIT;
+    }
+
+    function _compounderVault() internal pure override returns (address) {
+        return KpkTestConfig.WETH_KPK_VAULT;
+    }
+
+    function _minDeposit() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_MIN_DEPOSIT;
+    }
+
+    function _maxDeposit() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_MAX_DEPOSIT;
+    }
+
+    function _decimals() internal pure override returns (uint8) {
+        return KpkTestConfig.WETH_DECIMALS;
+    }
+
+    // ========== WETH TEST-SPECIFIC CONFIGURATION OVERRIDES ==========
+
+    function _depositCapMaxCheck() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_DEPOSIT_CAP_MAX_CHECK;
+    }
+
+    function _depositCapExcess() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_DEPOSIT_CAP_EXCESS;
+    }
+
+    function _multiUserDeposit1() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_MULTI_USER_DEPOSIT_1;
+    }
+
+    function _multiUserDeposit2() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_MULTI_USER_DEPOSIT_2;
+    }
+}

--- a/test/integration/strategies/YieldDonating/kpk/KpkGearboxWETHStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/kpk/KpkGearboxWETHStrategy.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { KpkERC4626StrategyTest } from "../KpkERC4626Strategy.t.sol";
+import { KpkTestConfig } from "../../config/KpkTestConfig.sol";
+
+/// @title KPK Gearbox WETH Strategy Test
+/// @author Octant
+/// @notice Integration tests for ERC4626Strategy with KPK WETH earn pool on Gearbox V3
+/// @dev Gearbox V3 PoolV3 is ERC-4626 compliant, so the generic ERC4626Strategy works.
+///      Extends KpkERC4626StrategyTest with Gearbox WETH-specific configuration.
+contract KpkGearboxWETHStrategyTest is KpkERC4626StrategyTest {
+    // ========== GEARBOX WETH CONFIGURATION OVERRIDES ==========
+
+    function _asset() internal pure override returns (address) {
+        return KpkTestConfig.WETH;
+    }
+
+    function _strategyName() internal pure override returns (string memory) {
+        return KpkTestConfig.GEARBOX_WETH_STRATEGY_NAME;
+    }
+
+    function _strategySymbol() internal pure override returns (string memory) {
+        return KpkTestConfig.GEARBOX_WETH_STRATEGY_SYMBOL;
+    }
+
+    function _initialDeposit() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_INITIAL_DEPOSIT;
+    }
+
+    function _compounderVault() internal pure override returns (address) {
+        return KpkTestConfig.GEARBOX_WETH_KPK_POOL;
+    }
+
+    function _minDeposit() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_MIN_DEPOSIT;
+    }
+
+    function _maxDeposit() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_MAX_DEPOSIT;
+    }
+
+    function _decimals() internal pure override returns (uint8) {
+        return KpkTestConfig.WETH_DECIMALS;
+    }
+
+    // ========== WETH TEST-SPECIFIC CONFIGURATION OVERRIDES ==========
+
+    function _depositCapMaxCheck() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_DEPOSIT_CAP_MAX_CHECK;
+    }
+
+    function _depositCapExcess() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_DEPOSIT_CAP_EXCESS;
+    }
+
+    function _multiUserDeposit1() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_MULTI_USER_DEPOSIT_1;
+    }
+
+    function _multiUserDeposit2() internal pure override returns (uint256) {
+        return KpkTestConfig.WETH_MULTI_USER_DEPOSIT_2;
+    }
+}

--- a/test/integration/strategies/YieldDonating/kpk/KpkGearboxWstETHStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/kpk/KpkGearboxWstETHStrategy.t.sol
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { KpkERC4626StrategyTest } from "../KpkERC4626Strategy.t.sol";
+import { KpkTestConfig } from "../../config/KpkTestConfig.sol";
+
+/// @title KPK Gearbox wstETH Strategy Test
+/// @author Octant
+/// @notice Integration tests for ERC4626Strategy with KPK wstETH earn pool on Gearbox V3
+/// @dev Gearbox V3 PoolV3 is ERC-4626 compliant, so the generic ERC4626Strategy works.
+///      Extends KpkERC4626StrategyTest with Gearbox wstETH-specific configuration.
+contract KpkGearboxWstETHStrategyTest is KpkERC4626StrategyTest {
+    // ========== GEARBOX WSTETH CONFIGURATION OVERRIDES ==========
+
+    function _asset() internal pure override returns (address) {
+        return KpkTestConfig.WSTETH;
+    }
+
+    function _strategyName() internal pure override returns (string memory) {
+        return KpkTestConfig.GEARBOX_WSTETH_STRATEGY_NAME;
+    }
+
+    function _strategySymbol() internal pure override returns (string memory) {
+        return KpkTestConfig.GEARBOX_WSTETH_STRATEGY_SYMBOL;
+    }
+
+    function _initialDeposit() internal pure override returns (uint256) {
+        return KpkTestConfig.WSTETH_INITIAL_DEPOSIT;
+    }
+
+    function _compounderVault() internal pure override returns (address) {
+        return KpkTestConfig.GEARBOX_WSTETH_KPK_POOL;
+    }
+
+    function _minDeposit() internal pure override returns (uint256) {
+        return KpkTestConfig.WSTETH_MIN_DEPOSIT;
+    }
+
+    function _maxDeposit() internal pure override returns (uint256) {
+        return KpkTestConfig.WSTETH_MAX_DEPOSIT;
+    }
+
+    function _decimals() internal pure override returns (uint8) {
+        return KpkTestConfig.WSTETH_DECIMALS;
+    }
+
+    // ========== WSTETH TEST-SPECIFIC CONFIGURATION OVERRIDES ==========
+
+    function _depositCapMaxCheck() internal pure override returns (uint256) {
+        return KpkTestConfig.WSTETH_DEPOSIT_CAP_MAX_CHECK;
+    }
+
+    function _depositCapExcess() internal pure override returns (uint256) {
+        return KpkTestConfig.WSTETH_DEPOSIT_CAP_EXCESS;
+    }
+
+    function _multiUserDeposit1() internal pure override returns (uint256) {
+        return KpkTestConfig.WSTETH_MULTI_USER_DEPOSIT_1;
+    }
+
+    function _multiUserDeposit2() internal pure override returns (uint256) {
+        return KpkTestConfig.WSTETH_MULTI_USER_DEPOSIT_2;
+    }
+}

--- a/test/integration/strategies/YieldDonating/kpk/KpkUSDCPrimeStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/kpk/KpkUSDCPrimeStrategy.t.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { KpkERC4626StrategyTest } from "../KpkERC4626Strategy.t.sol";
+
+/// @title KPK USDC Prime Strategy Test
+/// @author Octant
+/// @notice Integration tests for ERC4626Strategy with KPK USDC Prime vault on Morpho
+/// @dev Extends KpkERC4626StrategyTest with USDC-specific configuration
+contract KpkUSDCPrimeStrategyTest is KpkERC4626StrategyTest {
+    // USDC configuration is the default in KpkERC4626StrategyTest
+    // No overrides needed - this test validates USDC works with the base configuration
+}

--- a/test/integration/strategies/config/KpkTestConfig.sol
+++ b/test/integration/strategies/config/KpkTestConfig.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+/// @title KpkTestConfig
+/// @notice Configuration constants for KPK (karpatkey) ERC4626 strategy integration tests
+/// @dev KPK vaults are MetaMorpho ERC-4626 vaults curated by karpatkey on Morpho
+library KpkTestConfig {
+    /// @notice USDC token address on mainnet
+    address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
+
+    /// @notice WETH token address on mainnet
+    address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+
+    /// @notice KPK USDC Prime vault address on mainnet (MetaMorpho ERC-4626)
+    address internal constant USDC_KPK_VAULT = 0xe108fbc04852B5df72f9E44d7C29F47e7A993aDd;
+
+    /// @notice KPK ETH Prime vault address on mainnet (MetaMorpho ERC-4626)
+    address internal constant WETH_KPK_VAULT = 0xd564F765F9aD3E7d2d6cA782100795a885e8e7C8;
+
+    /// @notice Tokenized strategy implementation address
+    address internal constant TOKENIZED_STRATEGY_ADDRESS = 0x8cf7246a74704bBE59c9dF614ccB5e3d9717d8Ac;
+
+    // ========== USDC CONFIGURATION ==========
+
+    /// @notice Minimum deposit amount for USDC fuzz tests (6 decimals)
+    uint256 internal constant USDC_MIN_DEPOSIT = 1e6;
+
+    /// @notice Maximum deposit amount for USDC fuzz tests
+    uint256 internal constant USDC_MAX_DEPOSIT = 100000e6;
+
+    /// @notice Initial deposit for USDC setup
+    uint256 internal constant USDC_INITIAL_DEPOSIT = 100000e6;
+
+    /// @notice USDC decimals
+    uint8 internal constant USDC_DECIMALS = 6;
+
+    /// @notice Strategy name for USDC
+    string internal constant USDC_STRATEGY_NAME = "KPK USDC Prime Donating Strategy";
+
+    /// @notice Strategy symbol for USDC
+    string internal constant USDC_STRATEGY_SYMBOL = "osKpkUSDC";
+
+    // ========== WETH CONFIGURATION ==========
+
+    /// @notice Minimum deposit amount for WETH fuzz tests (18 decimals)
+    uint256 internal constant WETH_MIN_DEPOSIT = 1e18;
+
+    /// @notice Maximum deposit amount for WETH fuzz tests
+    uint256 internal constant WETH_MAX_DEPOSIT = 100e18;
+
+    /// @notice Initial deposit for WETH setup
+    uint256 internal constant WETH_INITIAL_DEPOSIT = 100e18;
+
+    /// @notice WETH decimals
+    uint8 internal constant WETH_DECIMALS = 18;
+
+    /// @notice Strategy name for WETH
+    string internal constant WETH_STRATEGY_NAME = "KPK ETH Prime Donating Strategy";
+
+    /// @notice Strategy symbol for WETH
+    string internal constant WETH_STRATEGY_SYMBOL = "osKpkETH";
+
+    // ========== TEST-SPECIFIC AMOUNTS ==========
+
+    /// @notice Deposit cap max check amount for USDC (1 billion)
+    uint256 internal constant USDC_DEPOSIT_CAP_MAX_CHECK = 1000000000e6;
+
+    /// @notice Deposit cap max check amount for WETH (1 million)
+    uint256 internal constant WETH_DEPOSIT_CAP_MAX_CHECK = 1000000e18;
+
+    /// @notice Deposit cap excess amount for USDC
+    uint256 internal constant USDC_DEPOSIT_CAP_EXCESS = 1000e6;
+
+    /// @notice Deposit cap excess amount for WETH
+    uint256 internal constant WETH_DEPOSIT_CAP_EXCESS = 1e18;
+
+    /// @notice Multi-user test first deposit for USDC (5,000)
+    uint256 internal constant USDC_MULTI_USER_DEPOSIT_1 = 5000e6;
+
+    /// @notice Multi-user test second deposit for USDC (3,000)
+    uint256 internal constant USDC_MULTI_USER_DEPOSIT_2 = 3000e6;
+
+    /// @notice Multi-user test first deposit for WETH (5)
+    uint256 internal constant WETH_MULTI_USER_DEPOSIT_1 = 5e18;
+
+    /// @notice Multi-user test second deposit for WETH (3)
+    uint256 internal constant WETH_MULTI_USER_DEPOSIT_2 = 3e18;
+}

--- a/test/integration/strategies/config/KpkTestConfig.sol
+++ b/test/integration/strategies/config/KpkTestConfig.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.25;
 
 /// @title KpkTestConfig
 /// @notice Configuration constants for KPK (karpatkey) ERC4626 strategy integration tests
-/// @dev KPK vaults are MetaMorpho ERC-4626 vaults curated by karpatkey on Morpho
+/// @dev KPK vaults are ERC-4626 vaults curated by karpatkey on Morpho and Gearbox V3
 library KpkTestConfig {
     /// @notice USDC token address on mainnet
     address internal constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
@@ -11,11 +11,24 @@ library KpkTestConfig {
     /// @notice WETH token address on mainnet
     address internal constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
+    /// @notice wstETH token address on mainnet
+    address internal constant WSTETH = 0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0;
+
+    // ========== MORPHO VAULT ADDRESSES ==========
+
     /// @notice KPK USDC Prime vault address on mainnet (MetaMorpho ERC-4626)
     address internal constant USDC_KPK_VAULT = 0xe108fbc04852B5df72f9E44d7C29F47e7A993aDd;
 
     /// @notice KPK ETH Prime vault address on mainnet (MetaMorpho ERC-4626)
     address internal constant WETH_KPK_VAULT = 0xd564F765F9aD3E7d2d6cA782100795a885e8e7C8;
+
+    // ========== GEARBOX V3 POOL ADDRESSES ==========
+
+    /// @notice KPK WETH earn pool on Gearbox V3 (ERC-4626 PoolV3)
+    address internal constant GEARBOX_WETH_KPK_POOL = 0x9396DCbf78fc526bb003665337C5E73b699571EF;
+
+    /// @notice KPK wstETH earn pool on Gearbox V3 (ERC-4626 PoolV3)
+    address internal constant GEARBOX_WSTETH_KPK_POOL = 0xA9d17f6D3285208280a1Fd9B94479c62e0AABa64;
 
     /// @notice Tokenized strategy implementation address
     address internal constant TOKENIZED_STRATEGY_ADDRESS = 0x8cf7246a74704bBE59c9dF614ccB5e3d9717d8Ac;
@@ -60,6 +73,32 @@ library KpkTestConfig {
     /// @notice Strategy symbol for WETH
     string internal constant WETH_STRATEGY_SYMBOL = "osKpkETH";
 
+    // ========== WSTETH CONFIGURATION ==========
+
+    /// @notice Minimum deposit amount for wstETH fuzz tests (18 decimals)
+    uint256 internal constant WSTETH_MIN_DEPOSIT = 1e18;
+
+    /// @notice Maximum deposit amount for wstETH fuzz tests
+    uint256 internal constant WSTETH_MAX_DEPOSIT = 100e18;
+
+    /// @notice Initial deposit for wstETH setup
+    uint256 internal constant WSTETH_INITIAL_DEPOSIT = 100e18;
+
+    /// @notice wstETH decimals
+    uint8 internal constant WSTETH_DECIMALS = 18;
+
+    /// @notice Strategy name for Gearbox WETH
+    string internal constant GEARBOX_WETH_STRATEGY_NAME = "KPK Gearbox WETH Donating Strategy";
+
+    /// @notice Strategy symbol for Gearbox WETH
+    string internal constant GEARBOX_WETH_STRATEGY_SYMBOL = "osKpkGbWETH";
+
+    /// @notice Strategy name for Gearbox wstETH
+    string internal constant GEARBOX_WSTETH_STRATEGY_NAME = "KPK Gearbox wstETH Donating Strategy";
+
+    /// @notice Strategy symbol for Gearbox wstETH
+    string internal constant GEARBOX_WSTETH_STRATEGY_SYMBOL = "osKpkGbWstETH";
+
     // ========== TEST-SPECIFIC AMOUNTS ==========
 
     /// @notice Deposit cap max check amount for USDC (1 billion)
@@ -68,11 +107,17 @@ library KpkTestConfig {
     /// @notice Deposit cap max check amount for WETH (1 million)
     uint256 internal constant WETH_DEPOSIT_CAP_MAX_CHECK = 1000000e18;
 
+    /// @notice Deposit cap max check amount for wstETH (1 million)
+    uint256 internal constant WSTETH_DEPOSIT_CAP_MAX_CHECK = 1000000e18;
+
     /// @notice Deposit cap excess amount for USDC
     uint256 internal constant USDC_DEPOSIT_CAP_EXCESS = 1000e6;
 
     /// @notice Deposit cap excess amount for WETH
     uint256 internal constant WETH_DEPOSIT_CAP_EXCESS = 1e18;
+
+    /// @notice Deposit cap excess amount for wstETH
+    uint256 internal constant WSTETH_DEPOSIT_CAP_EXCESS = 1e18;
 
     /// @notice Multi-user test first deposit for USDC (5,000)
     uint256 internal constant USDC_MULTI_USER_DEPOSIT_1 = 5000e6;
@@ -85,4 +130,10 @@ library KpkTestConfig {
 
     /// @notice Multi-user test second deposit for WETH (3)
     uint256 internal constant WETH_MULTI_USER_DEPOSIT_2 = 3e18;
+
+    /// @notice Multi-user test first deposit for wstETH (5)
+    uint256 internal constant WSTETH_MULTI_USER_DEPOSIT_1 = 5e18;
+
+    /// @notice Multi-user test second deposit for wstETH (3)
+    uint256 internal constant WSTETH_MULTI_USER_DEPOSIT_2 = 3e18;
 }


### PR DESCRIPTION
## Summary

- Add integration fork test suite for KPK (karpatkey) USDC Prime and ETH Prime vaults on Morpho
- KPK vaults are standard ERC-4626 MetaMorpho vaults, so the generic `ERC4626Strategy` works out of the box — no new strategy contract needed
- Tests reuse the existing `BaseYieldDonatingIntegrationTest` infrastructure for maximum DRYness

## What was added

| File | Purpose |
|------|---------|
| `test/integration/strategies/config/KpkTestConfig.sol` | Config library with KPK vault addresses and test constants |
| `test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol` | Main test contract (defaults to USDC) |
| `test/integration/strategies/YieldDonating/kpk/KpkUSDCPrimeStrategy.t.sol` | USDC Prime variant (no overrides) |
| `test/integration/strategies/YieldDonating/kpk/KpkETHPrimeStrategy.t.sol` | ETH Prime variant (WETH config overrides) |

## KPK vault addresses (Ethereum mainnet)

| Vault | Address |
|-------|---------|
| KPK USDC Prime | `0xe108fbc04852B5df72f9E44d7C29F47e7A993aDd` |
| KPK ETH Prime | `0xd564F765F9aD3E7d2d6cA782100795a885e8e7C8` |

## Test coverage (17 tests per vault, 34 total)

- Fuzz deposit / withdraw / emergency withdraw / harvest with profit donation
- Deposit limit edge cases (idle assets, cap exceeded)
- Withdraw limit overflow safety (uint256 boundary)
- Harvest overflow guard
- Multi-user concurrent flow
- Constructor asset validation
- Basic configuration checks

## Key finding

All KPK vaults are ERC-4626 (built on Morpho MetaMorpho). There are **no ERC-7540 vaults** in their ecosystem. The existing `ERC4626Strategy` + `ERC4626StrategyFactory` handles integration completely with zero new production code.

## Test plan

- [x] `forge test --match-contract KpkUSDCPrimeStrategyTest` — 17/17 pass
- [x] `forge test --match-contract KpkETHPrimeStrategyTest` — 17/17 pass