### PR TITLE
feat: Kontrol proofs for YieldForwarder and SwappingYieldForwarder

### DIFF
--- a/kontrol.toml
+++ b/kontrol.toml
@@ -5,7 +5,7 @@ rekompile                  = true
 verbose                    = false
 debug                      = false
 require                    = 'verification/kontrol/octant-lemmas.k'
-module-import              = ['YDStrategyTest:OCTANT-LEMMAS', 'YSStrategyTest:OCTANT-LEMMAS']
+module-import              = ['YDStrategyTest:OCTANT-LEMMAS', 'YSStrategyTest:OCTANT-LEMMAS', 'YFTest:OCTANT-LEMMAS', 'SYFTest:OCTANT-LEMMAS']
 auxiliary-lemmas           = true
 
 [prove.default]
@@ -76,6 +76,24 @@ match-test                 = [
         "YSStrategyTest.testTransferUserToDragon(address,uint256)",
         "YSStrategyTest.testConversionSolventYS(uint256)",
         "YSStrategyTest.testConversionFallbackInsolventYS(uint256)",
+        # ============================================
+        # YieldForwarder proofs (5)
+        # ============================================
+        "YFTest.testReportAndForwardOnlyKeeper()",
+        "YFTest.testReportAndForwardReceiverGuarantee()",
+        "YFTest.testReportAndForwardNoResidualShares()",
+        "YFTest.testReportAndForwardZeroSharesPassthrough()",
+        "YFTest.testReportAndForwardReturnsRedeemAssets()",
+        # ============================================
+        # SwappingYieldForwarder proofs (7)
+        # ============================================
+        "SYFTest.testReportSwapAndForwardOnlyKeeper()",
+        "SYFTest.testReportSwapAndForwardReceiverGuarantee()",
+        "SYFTest.testReportSwapAndForwardNoResidualSourceAsset()",
+        "SYFTest.testReportSwapAndForwardZeroSharesPassthrough()",
+        "SYFTest.testReportSwapAndForwardZeroRedeemPassthrough()",
+        "SYFTest.testReportSwapAndForwardCorrectTokenRouting()",
+        "SYFTest.testInheritedReportAndForwardAccessControl()",
     ]
 
 [show.default]

--- a/verification/kontrol/MockForwarderStrategy.k.sol
+++ b/verification/kontrol/MockForwarderStrategy.k.sol
@@ -13,6 +13,10 @@ pragma solidity ^0.8.0;
  *        slot 2: mockAsset          -- returned by asset()
  *        slot 3: lastRedeemReceiver -- captures receiver arg from redeem()
  *        slot 4: lastRedeemShares   -- captures shares arg from redeem()
+ *        slot 5: lastReportCaller   -- captures msg.sender from report()
+ *        slot 6: expectedBalanceOfAccount -- only this account has shares
+ *        slot 7: lastRedeemOwner    -- captures owner arg from redeem()
+ *        slot 8: lastRedeemMaxLoss  -- captures maxLoss arg from redeem()
  */
 contract MockForwarderStrategy {
     uint256 public mockShareBalance;
@@ -20,23 +24,32 @@ contract MockForwarderStrategy {
     address public mockAsset;
     address public lastRedeemReceiver;
     uint256 public lastRedeemShares;
+    address public lastReportCaller;
+    address public expectedBalanceOfAccount;
+    address public lastRedeemOwner;
+    uint256 public lastRedeemMaxLoss;
 
-    /// @notice No-op report; strategy report logic is verified by existing YD/YS Kontrol proofs
-    /// @dev Self-assignment prevents pure/view optimization to match real IReportable mutability
+    /// @notice No-op report that still records the caller
     function report() external returns (uint256, uint256) {
-        mockShareBalance = mockShareBalance;
+        lastReportCaller = msg.sender;
         return (0, 0);
     }
 
-    /// @notice Returns the controllable mock share balance for any address
-    function balanceOf(address) external view returns (uint256) {
+    /// @notice Returns shares only for the configured forwarder account
+    function balanceOf(address account) external view returns (uint256) {
+        if (account != expectedBalanceOfAccount) {
+            return 0;
+        }
+
         return mockShareBalance;
     }
 
     /// @notice Mock redeem that captures arguments and zeroes share balance
-    function redeem(uint256 shares, address receiver, address, uint256) external returns (uint256) {
+    function redeem(uint256 shares, address receiver, address owner, uint256 maxLoss) external returns (uint256) {
         lastRedeemShares = shares;
         lastRedeemReceiver = receiver;
+        lastRedeemOwner = owner;
+        lastRedeemMaxLoss = maxLoss;
         mockShareBalance = 0;
         return mockRedeemReturn;
     }

--- a/verification/kontrol/MockForwarderStrategy.k.sol
+++ b/verification/kontrol/MockForwarderStrategy.k.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title MockForwarderStrategy
+ * @notice Minimal mock for Kontrol formal verification of YieldForwarder contracts
+ * @dev Implements IReportable, IRedeemable, IERC20.balanceOf, and IERC4626Asset.asset()
+ *      with controllable return values. Does not interact with any external contracts.
+ *
+ *      Storage layout (all plain slots, no ERC-7201):
+ *        slot 0: mockShareBalance   -- returned by balanceOf()
+ *        slot 1: mockRedeemReturn   -- returned by redeem()
+ *        slot 2: mockAsset          -- returned by asset()
+ *        slot 3: lastRedeemReceiver -- captures receiver arg from redeem()
+ *        slot 4: lastRedeemShares   -- captures shares arg from redeem()
+ */
+contract MockForwarderStrategy {
+    uint256 public mockShareBalance;
+    uint256 public mockRedeemReturn;
+    address public mockAsset;
+    address public lastRedeemReceiver;
+    uint256 public lastRedeemShares;
+
+    /// @notice No-op report; strategy report logic is verified by existing YD/YS Kontrol proofs
+    /// @dev Self-assignment prevents pure/view optimization to match real IReportable mutability
+    function report() external returns (uint256, uint256) {
+        mockShareBalance = mockShareBalance;
+        return (0, 0);
+    }
+
+    /// @notice Returns the controllable mock share balance for any address
+    function balanceOf(address) external view returns (uint256) {
+        return mockShareBalance;
+    }
+
+    /// @notice Mock redeem that captures arguments and zeroes share balance
+    function redeem(uint256 shares, address receiver, address, uint256) external returns (uint256) {
+        lastRedeemShares = shares;
+        lastRedeemReceiver = receiver;
+        mockShareBalance = 0;
+        return mockRedeemReturn;
+    }
+
+    /// @notice Returns the mock underlying asset address
+    function asset() external view returns (address) {
+        return mockAsset;
+    }
+}

--- a/verification/kontrol/MockForwarderSwapper.k.sol
+++ b/verification/kontrol/MockForwarderSwapper.k.sol
@@ -12,6 +12,7 @@ pragma solidity ^0.8.0;
  *        slot 2: lastTokenIn       -- captures tokenIn arg
  *        slot 3: lastTokenOut      -- captures tokenOut arg
  *        slot 4: lastAmountIn      -- captures amountIn arg
+ *        slot 5: lastMinAmountOut  -- captures minAmountOut arg
  */
 contract MockForwarderSwapper {
     uint256 public mockSwapReturn;
@@ -19,18 +20,20 @@ contract MockForwarderSwapper {
     address public lastTokenIn;
     address public lastTokenOut;
     uint256 public lastAmountIn;
+    uint256 public lastMinAmountOut;
 
     /// @notice Mock swap that captures arguments and returns controllable output
     function swap(
         address tokenIn,
         address tokenOut,
         uint256 amountIn,
-        uint256,
+        uint256 minAmountOut,
         address receiver
     ) external returns (uint256) {
         lastTokenIn = tokenIn;
         lastTokenOut = tokenOut;
         lastAmountIn = amountIn;
+        lastMinAmountOut = minAmountOut;
         lastSwapReceiver = receiver;
         return mockSwapReturn;
     }

--- a/verification/kontrol/MockForwarderSwapper.k.sol
+++ b/verification/kontrol/MockForwarderSwapper.k.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @title MockForwarderSwapper
+ * @notice Minimal ISwapper mock for Kontrol formal verification of SwappingYieldForwarder
+ * @dev Controllable swap return value with argument capture for property assertions.
+ *
+ *      Storage layout (all plain slots, no ERC-7201):
+ *        slot 0: mockSwapReturn    -- returned by swap()
+ *        slot 1: lastSwapReceiver  -- captures receiver arg
+ *        slot 2: lastTokenIn       -- captures tokenIn arg
+ *        slot 3: lastTokenOut      -- captures tokenOut arg
+ *        slot 4: lastAmountIn      -- captures amountIn arg
+ */
+contract MockForwarderSwapper {
+    uint256 public mockSwapReturn;
+    address public lastSwapReceiver;
+    address public lastTokenIn;
+    address public lastTokenOut;
+    uint256 public lastAmountIn;
+
+    /// @notice Mock swap that captures arguments and returns controllable output
+    function swap(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn,
+        uint256,
+        address receiver
+    ) external returns (uint256) {
+        lastTokenIn = tokenIn;
+        lastTokenOut = tokenOut;
+        lastAmountIn = amountIn;
+        lastSwapReceiver = receiver;
+        return mockSwapReturn;
+    }
+}

--- a/verification/kontrol/SYFSetup.k.sol
+++ b/verification/kontrol/SYFSetup.k.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { SwappingYieldForwarder } from "src/core/SwappingYieldForwarder.sol";
+
+import { KontrolTest } from "test/kontrol/KontrolTest.k.sol";
+import { TestERC20 } from "test/kontrol/TestERC20.k.sol";
+import { MockForwarderStrategy } from "test/kontrol/MockForwarderStrategy.k.sol";
+import { MockForwarderSwapper } from "test/kontrol/MockForwarderSwapper.k.sol";
+import "test/kontrol/SharedStateSlots.k.sol";
+
+/**
+ * @title SYFSetup
+ * @notice Symbolic setup for formal verification of SwappingYieldForwarder
+ * @dev Deploys SwappingYieldForwarder with concrete role addresses, a MockForwarderStrategy
+ *      with symbolic storage, a MockForwarderSwapper with symbolic swap return, and a real
+ *      TestERC20 for the underlying asset (required for safeTransfer in the swap path).
+ *
+ *      The forwarder's ERC20 balance is pre-loaded to simulate tokens received from redeem().
+ *      The mock redeem() does not actually transfer tokens, so we write the balance directly.
+ */
+contract SYFSetup is KontrolTest {
+    SwappingYieldForwarder public syfForwarder;
+    MockForwarderStrategy public mockStrategy;
+    MockForwarderSwapper public mockSwapper;
+    TestERC20 public sourceAsset;
+    TestERC20 public targetAsset;
+
+    address internal _receiver;
+    address internal _keeper;
+
+    function setUp() public virtual {
+        // Concrete role addresses
+        _receiver = makeAddr("RECEIVER");
+        _keeper = makeAddr("KEEPER");
+
+        // Deploy real ERC20s (needed for safeTransfer in swap path)
+        sourceAsset = new TestERC20();
+        targetAsset = new TestERC20();
+
+        // Deploy mocks
+        mockStrategy = new MockForwarderStrategy();
+        mockSwapper = new MockForwarderSwapper();
+
+        // Deploy SwappingYieldForwarder with concrete immutables
+        syfForwarder = new SwappingYieldForwarder(_receiver, _keeper, address(targetAsset), address(mockSwapper));
+
+        // ============================================
+        // MAKE MOCK STRATEGY STORAGE SYMBOLIC
+        // ============================================
+        kevm.symbolicStorage(address(mockStrategy));
+
+        // Restore concrete asset address to the real ERC20
+        _storeAddress(address(mockStrategy), MFS_ASSET_SLOT, address(sourceAsset));
+
+        // Set symbolic share balance and redeem return
+        uint256 shareBalance = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, shareBalance);
+
+        uint256 redeemReturn = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, redeemReturn);
+
+        // Clear argument capture slots
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);
+        _storeAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT, address(0));
+
+        // ============================================
+        // MAKE MOCK SWAPPER STORAGE SYMBOLIC
+        // ============================================
+        kevm.symbolicStorage(address(mockSwapper));
+
+        // Set symbolic swap return
+        uint256 swapReturn = freshUInt256Bounded();
+        _storeUInt256(address(mockSwapper), MSWP_RETURN_SLOT, swapReturn);
+
+        // Clear argument capture slots
+        _storeAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT, address(0));
+        _storeAddress(address(mockSwapper), MSWP_LAST_TOKEN_IN_SLOT, address(0));
+        _storeAddress(address(mockSwapper), MSWP_LAST_TOKEN_OUT_SLOT, address(0));
+        _storeUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT, 0);
+
+        // ============================================
+        // PRE-LOAD FORWARDER ERC20 BALANCE
+        // ============================================
+        // The mock redeem() doesn't transfer actual tokens, so we pre-load the
+        // forwarder's balance in sourceAsset to equal redeemReturn. This simulates
+        // the tokens the forwarder would receive from a real redeem() call.
+        //
+        // Also set totalSupply >= balance to satisfy ERC20 invariants.
+        _storeMappingUInt256(
+            address(sourceAsset),
+            ERC20_BALANCES_SLOT,
+            uint256(uint160(address(syfForwarder))),
+            0,
+            redeemReturn
+        );
+        // Set totalSupply to redeemReturn (slot 2 for OZ ERC20)
+        _storeUInt256(address(sourceAsset), 2, redeemReturn);
+
+        // ============================================
+        // SET FORWARDER REENTRANCY GUARD TO NOT_ENTERED
+        // ============================================
+        _storeUInt256(address(syfForwarder), RG_STATUS_SLOT, RG_NOT_ENTERED);
+    }
+}

--- a/verification/kontrol/SYFSetup.k.sol
+++ b/verification/kontrol/SYFSetup.k.sol
@@ -52,6 +52,7 @@ contract SYFSetup is KontrolTest {
 
         // Restore concrete asset address to the real ERC20
         _storeAddress(address(mockStrategy), MFS_ASSET_SLOT, address(sourceAsset));
+        _storeAddress(address(mockStrategy), MFS_EXPECTED_BALANCE_OF_ACCOUNT_SLOT, address(syfForwarder));
 
         // Set symbolic share balance and redeem return
         uint256 shareBalance = freshUInt256Bounded();
@@ -63,6 +64,9 @@ contract SYFSetup is KontrolTest {
         // Clear argument capture slots
         _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);
         _storeAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT, address(0));
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
+        _storeAddress(address(mockStrategy), MFS_LAST_OWNER_SLOT, address(0));
+        _storeUInt256(address(mockStrategy), MFS_LAST_MAX_LOSS_SLOT, 0);
 
         // ============================================
         // MAKE MOCK SWAPPER STORAGE SYMBOLIC
@@ -78,6 +82,7 @@ contract SYFSetup is KontrolTest {
         _storeAddress(address(mockSwapper), MSWP_LAST_TOKEN_IN_SLOT, address(0));
         _storeAddress(address(mockSwapper), MSWP_LAST_TOKEN_OUT_SLOT, address(0));
         _storeUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT, 0);
+        _storeUInt256(address(mockSwapper), MSWP_LAST_MIN_AMOUNT_OUT_SLOT, 0);
 
         // ============================================
         // PRE-LOAD FORWARDER ERC20 BALANCE

--- a/verification/kontrol/SYFTest.k.sol
+++ b/verification/kontrol/SYFTest.k.sol
@@ -61,10 +61,11 @@ contract SYFTest is SYFSetup {
         assertEq(forwarderBalance, 0);
     }
 
-    /// @notice When shares == 0, returns 0 without calling swap or redeem
+    /// @notice When shares == 0, report still runs and the function returns 0 without swap or redeem
     function testReportSwapAndForwardZeroSharesPassthrough() public {
         // Set shares to 0
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
 
         // Write sentinels to detect any call to redeem or swap, including
         // redeem(0, ...) which would be indistinguishable from "never called"
@@ -78,6 +79,10 @@ contract SYFTest is SYFSetup {
 
         // Assert: returned 0
         assertEq(assetsOut, 0);
+
+        // Assert: report still ran before the zero-share early return
+        address lastReportCaller = _loadAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT);
+        assertEq(lastReportCaller, address(syfForwarder));
 
         // Assert: swap was never called (sentinel preserved)
         uint256 lastAmountIn = _loadUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT);
@@ -116,9 +121,11 @@ contract SYFTest is SYFSetup {
         vm.assume(shares > 0);
         uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
         vm.assume(redeemReturn > 0);
+        uint256 maxLoss = freshUInt256Bounded();
+        uint256 minAmountOut = freshUInt256Bounded();
 
         vm.prank(_keeper);
-        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), maxLoss, minAmountOut);
 
         // Assert: tokenIn == sourceAsset (strategy's underlying)
         address lastTokenIn = _loadAddress(address(mockSwapper), MSWP_LAST_TOKEN_IN_SLOT);
@@ -131,6 +138,20 @@ contract SYFTest is SYFSetup {
         // Assert: amountIn == redeemReturn
         uint256 lastAmountIn = _loadUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT);
         assertEq(lastAmountIn, redeemReturn);
+
+        // Assert: minAmountOut is forwarded unchanged to the swapper
+        uint256 lastMinAmountOut = _loadUInt256(address(mockSwapper), MSWP_LAST_MIN_AMOUNT_OUT_SLOT);
+        assertEq(lastMinAmountOut, minAmountOut);
+
+        // Assert: redeem is executed on behalf of and back into the forwarder
+        address lastRedeemReceiver = _loadAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT);
+        assertEq(lastRedeemReceiver, address(syfForwarder));
+
+        address lastRedeemOwner = _loadAddress(address(mockStrategy), MFS_LAST_OWNER_SLOT);
+        assertEq(lastRedeemOwner, address(syfForwarder));
+
+        uint256 lastRedeemMaxLoss = _loadUInt256(address(mockStrategy), MFS_LAST_MAX_LOSS_SLOT);
+        assertEq(lastRedeemMaxLoss, maxLoss);
     }
 
     /// @notice Inherited reportAndForward() on SwappingYieldForwarder still enforces keeper check

--- a/verification/kontrol/SYFTest.k.sol
+++ b/verification/kontrol/SYFTest.k.sol
@@ -66,19 +66,26 @@ contract SYFTest is SYFSetup {
         // Set shares to 0
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
 
+        // Write sentinels to detect any call to redeem or swap, including
+        // redeem(0, ...) which would be indistinguishable from "never called"
+        // if the default were 0.
+        uint256 sentinel = type(uint256).max;
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, sentinel);
+        _storeUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT, sentinel);
+
         vm.prank(_keeper);
         uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
 
         // Assert: returned 0
         assertEq(assetsOut, 0);
 
-        // Assert: swap was never called (lastSwapReceiver still address(0))
-        address lastSwapReceiver = _loadAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT);
-        assertEq(lastSwapReceiver, address(0));
+        // Assert: swap was never called (sentinel preserved)
+        uint256 lastAmountIn = _loadUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT);
+        assertEq(lastAmountIn, sentinel);
 
-        // Assert: redeem was never called
+        // Assert: redeem was never called (sentinel preserved)
         uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
-        assertEq(lastShares, 0);
+        assertEq(lastShares, sentinel);
     }
 
     /// @notice When redeem returns 0 assets (but shares > 0), returns 0 without swap

--- a/verification/kontrol/SYFTest.k.sol
+++ b/verification/kontrol/SYFTest.k.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+import { SYFSetup } from "test/kontrol/SYFSetup.k.sol";
+import "test/kontrol/SharedStateSlots.k.sol";
+
+/**
+ * @title SYFTest
+ * @notice Kontrol formal verification proofs for SwappingYieldForwarder
+ * @dev Proves 7 behavioral properties of the SwappingYieldForwarder contract:
+ *      1. Access control on reportSwapAndForward
+ *      2. Swap output routed to hardcoded receiver
+ *      3. No residual source asset after swap
+ *      4. Zero-share passthrough (no swap/redeem)
+ *      5. Zero-redeem passthrough (no swap when redeem returns 0)
+ *      6. Correct token routing through swapper
+ *      7. Inherited reportAndForward access control still works
+ */
+contract SYFTest is SYFSetup {
+    /// @notice Non-keeper address always reverts with OnlyKeeper on reportSwapAndForward
+    function testReportSwapAndForwardOnlyKeeper() public {
+        address nonKeeper = makeAddr("NON_KEEPER");
+
+        vm.prank(nonKeeper);
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+    }
+
+    /// @notice swap() is always called with the hardcoded receiver as output recipient
+    function testReportSwapAndForwardReceiverGuarantee() public {
+        // Pre-conditions: shares exist and redeem returns non-zero
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+        uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
+        vm.assume(redeemReturn > 0);
+
+        vm.prank(_keeper);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+
+        // Assert: swap was called with receiver == forwarder.receiver()
+        address lastReceiver = _loadAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT);
+        assertEq(lastReceiver, _receiver);
+    }
+
+    /// @notice After reportSwapAndForward, forwarder holds 0 of source asset
+    function testReportSwapAndForwardNoResidualSourceAsset() public {
+        // Pre-conditions: shares exist and redeem returns non-zero
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+        uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
+        vm.assume(redeemReturn > 0);
+
+        vm.prank(_keeper);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+
+        // Assert: forwarder's source asset balance is 0 (all transferred to swapper)
+        uint256 forwarderBalance = sourceAsset.balanceOf(address(syfForwarder));
+        assertEq(forwarderBalance, 0);
+    }
+
+    /// @notice When shares == 0, returns 0 without calling swap or redeem
+    function testReportSwapAndForwardZeroSharesPassthrough() public {
+        // Set shares to 0
+        _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
+
+        vm.prank(_keeper);
+        uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+
+        // Assert: returned 0
+        assertEq(assetsOut, 0);
+
+        // Assert: swap was never called (lastSwapReceiver still address(0))
+        address lastSwapReceiver = _loadAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT);
+        assertEq(lastSwapReceiver, address(0));
+
+        // Assert: redeem was never called
+        uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastShares, 0);
+    }
+
+    /// @notice When redeem returns 0 assets (but shares > 0), returns 0 without swap
+    function testReportSwapAndForwardZeroRedeemPassthrough() public {
+        // Set shares > 0 but redeem return to 0
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+        _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, 0);
+
+        // Also zero out the forwarder's pre-loaded ERC20 balance (matches 0 redeem)
+        _storeMappingUInt256(address(sourceAsset), ERC20_BALANCES_SLOT, uint256(uint160(address(syfForwarder))), 0, 0);
+
+        vm.prank(_keeper);
+        uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+
+        // Assert: returned 0
+        assertEq(assetsOut, 0);
+
+        // Assert: swap was never called
+        address lastSwapReceiver = _loadAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT);
+        assertEq(lastSwapReceiver, address(0));
+    }
+
+    /// @notice swap() is called with tokenIn = strategy.asset() and tokenOut = targetAsset
+    function testReportSwapAndForwardCorrectTokenRouting() public {
+        // Pre-conditions: shares exist and redeem returns non-zero
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+        uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
+        vm.assume(redeemReturn > 0);
+
+        vm.prank(_keeper);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+
+        // Assert: tokenIn == sourceAsset (strategy's underlying)
+        address lastTokenIn = _loadAddress(address(mockSwapper), MSWP_LAST_TOKEN_IN_SLOT);
+        assertEq(lastTokenIn, address(sourceAsset));
+
+        // Assert: tokenOut == targetAsset (forwarder's configured target)
+        address lastTokenOut = _loadAddress(address(mockSwapper), MSWP_LAST_TOKEN_OUT_SLOT);
+        assertEq(lastTokenOut, address(targetAsset));
+
+        // Assert: amountIn == redeemReturn
+        uint256 lastAmountIn = _loadUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT);
+        assertEq(lastAmountIn, redeemReturn);
+    }
+
+    /// @notice Inherited reportAndForward() on SwappingYieldForwarder still enforces keeper check
+    function testInheritedReportAndForwardAccessControl() public {
+        address nonKeeper = makeAddr("NON_KEEPER");
+
+        vm.prank(nonKeeper);
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        syfForwarder.reportAndForward(address(mockStrategy), 0);
+    }
+}

--- a/verification/kontrol/SharedStateSlots.k.sol
+++ b/verification/kontrol/SharedStateSlots.k.sol
@@ -128,6 +128,10 @@ uint256 constant MFS_REDEEM_RETURN_SLOT = 1;
 uint256 constant MFS_ASSET_SLOT = 2;
 uint256 constant MFS_LAST_RECEIVER_SLOT = 3;
 uint256 constant MFS_LAST_SHARES_SLOT = 4;
+uint256 constant MFS_LAST_REPORT_CALLER_SLOT = 5;
+uint256 constant MFS_EXPECTED_BALANCE_OF_ACCOUNT_SLOT = 6;
+uint256 constant MFS_LAST_OWNER_SLOT = 7;
+uint256 constant MFS_LAST_MAX_LOSS_SLOT = 8;
 
 // ============================================
 // MockForwarderSwapper (MSWP_) constants
@@ -138,3 +142,4 @@ uint256 constant MSWP_LAST_RECEIVER_SLOT = 1;
 uint256 constant MSWP_LAST_TOKEN_IN_SLOT = 2;
 uint256 constant MSWP_LAST_TOKEN_OUT_SLOT = 3;
 uint256 constant MSWP_LAST_AMOUNT_IN_SLOT = 4;
+uint256 constant MSWP_LAST_MIN_AMOUNT_OUT_SLOT = 5;

--- a/verification/kontrol/SharedStateSlots.k.sol
+++ b/verification/kontrol/SharedStateSlots.k.sol
@@ -110,3 +110,31 @@ uint256 constant MOCK_YS_EXCHANGE_RATE_DECIMALS_SLOT = 3;
 // TestERC20 (OZ ERC20 v5) constants
 // ============================================
 uint256 constant ERC20_BALANCES_SLOT = 0;
+
+// ============================================
+// ReentrancyGuard (OZ v5.3.0, plain storage slot 0)
+// ============================================
+// YieldForwarder / SwappingYieldForwarder inherit ReentrancyGuard
+// which stores _status at slot 0 (NOT ERC-7201 namespaced)
+uint256 constant RG_STATUS_SLOT = 0;
+uint256 constant RG_NOT_ENTERED = 1;
+
+// ============================================
+// MockForwarderStrategy (MFS_) constants
+// ============================================
+// Plain storage slots for the mock strategy used in YieldForwarder Kontrol proofs
+uint256 constant MFS_SHARE_BALANCE_SLOT = 0;
+uint256 constant MFS_REDEEM_RETURN_SLOT = 1;
+uint256 constant MFS_ASSET_SLOT = 2;
+uint256 constant MFS_LAST_RECEIVER_SLOT = 3;
+uint256 constant MFS_LAST_SHARES_SLOT = 4;
+
+// ============================================
+// MockForwarderSwapper (MSWP_) constants
+// ============================================
+// Plain storage slots for the mock swapper used in SwappingYieldForwarder Kontrol proofs
+uint256 constant MSWP_RETURN_SLOT = 0;
+uint256 constant MSWP_LAST_RECEIVER_SLOT = 1;
+uint256 constant MSWP_LAST_TOKEN_IN_SLOT = 2;
+uint256 constant MSWP_LAST_TOKEN_OUT_SLOT = 3;
+uint256 constant MSWP_LAST_AMOUNT_IN_SLOT = 4;

--- a/verification/kontrol/YFSetup.k.sol
+++ b/verification/kontrol/YFSetup.k.sol
@@ -41,6 +41,7 @@ contract YFSetup is KontrolTest {
         // Restore concrete asset address (needed for SYF safeTransfer path)
         // Using address(0xA55E7) as a deterministic mock asset address
         _storeAddress(address(mockStrategy), MFS_ASSET_SLOT, address(0xA55E7));
+        _storeAddress(address(mockStrategy), MFS_EXPECTED_BALANCE_OF_ACCOUNT_SLOT, address(forwarder));
 
         // Set symbolic share balance and redeem return
         uint256 shareBalance = freshUInt256Bounded();
@@ -52,6 +53,9 @@ contract YFSetup is KontrolTest {
         // Clear argument capture slots (so we can detect if redeem was called)
         _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);
         _storeAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT, address(0));
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
+        _storeAddress(address(mockStrategy), MFS_LAST_OWNER_SLOT, address(0));
+        _storeUInt256(address(mockStrategy), MFS_LAST_MAX_LOSS_SLOT, 0);
 
         // ============================================
         // SET FORWARDER REENTRANCY GUARD TO NOT_ENTERED

--- a/verification/kontrol/YFSetup.k.sol
+++ b/verification/kontrol/YFSetup.k.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+import { KontrolTest } from "test/kontrol/KontrolTest.k.sol";
+import { MockForwarderStrategy } from "test/kontrol/MockForwarderStrategy.k.sol";
+import "test/kontrol/SharedStateSlots.k.sol";
+
+/**
+ * @title YFSetup
+ * @notice Symbolic setup for formal verification of YieldForwarder
+ * @dev Deploys YieldForwarder with concrete role addresses and a MockForwarderStrategy
+ *      with symbolic storage. Unlike strategy proofs (where the CUT's storage is symbolic),
+ *      here the forwarder is stateless (immutables + ReentrancyGuard) and the mock
+ *      dependency is made symbolic to verify behavioral guarantees across all input states.
+ */
+contract YFSetup is KontrolTest {
+    YieldForwarder public forwarder;
+    MockForwarderStrategy public mockStrategy;
+
+    address internal _receiver;
+    address internal _keeper;
+
+    function setUp() public virtual {
+        // Concrete role addresses (avoid symbolic branching on prank)
+        _receiver = makeAddr("RECEIVER");
+        _keeper = makeAddr("KEEPER");
+
+        // Deploy mock strategy
+        mockStrategy = new MockForwarderStrategy();
+
+        // Deploy YieldForwarder with concrete immutables
+        forwarder = new YieldForwarder(_receiver, _keeper);
+
+        // ============================================
+        // MAKE MOCK STRATEGY STORAGE SYMBOLIC
+        // ============================================
+        kevm.symbolicStorage(address(mockStrategy));
+
+        // Restore concrete asset address (needed for SYF safeTransfer path)
+        // Using address(0xA55E7) as a deterministic mock asset address
+        _storeAddress(address(mockStrategy), MFS_ASSET_SLOT, address(0xA55E7));
+
+        // Set symbolic share balance and redeem return
+        uint256 shareBalance = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, shareBalance);
+
+        uint256 redeemReturn = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, redeemReturn);
+
+        // Clear argument capture slots (so we can detect if redeem was called)
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);
+        _storeAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT, address(0));
+
+        // ============================================
+        // SET FORWARDER REENTRANCY GUARD TO NOT_ENTERED
+        // ============================================
+        _storeUInt256(address(forwarder), RG_STATUS_SLOT, RG_NOT_ENTERED);
+    }
+}

--- a/verification/kontrol/YFTest.k.sol
+++ b/verification/kontrol/YFTest.k.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+import { YFSetup } from "test/kontrol/YFSetup.k.sol";
+import "test/kontrol/SharedStateSlots.k.sol";
+
+/**
+ * @title YFTest
+ * @notice Kontrol formal verification proofs for YieldForwarder
+ * @dev Proves 5 behavioral properties of the YieldForwarder contract:
+ *      1. Access control: only keeper can call reportAndForward
+ *      2. Receiver guarantee: redeem always targets the hardcoded receiver
+ *      3. No residual shares: forwarder holds 0 shares after execution
+ *      4. Zero-share passthrough: returns 0 without calling redeem when no shares
+ *      5. Return value correctness: return matches mock redeem output
+ */
+contract YFTest is YFSetup {
+    /// @notice Non-keeper address always reverts with OnlyKeeper
+    function testReportAndForwardOnlyKeeper() public {
+        address nonKeeper = makeAddr("NON_KEEPER");
+
+        vm.prank(nonKeeper);
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        forwarder.reportAndForward(address(mockStrategy), 0);
+    }
+
+    /// @notice redeem() is always called with the hardcoded receiver as recipient
+    function testReportAndForwardReceiverGuarantee() public {
+        // Pre-condition: shares exist to trigger the redeem path
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+
+        vm.prank(_keeper);
+        forwarder.reportAndForward(address(mockStrategy), 0);
+
+        // Assert: redeem was called with receiver == forwarder.receiver()
+        address lastReceiver = _loadAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT);
+        assertEq(lastReceiver, _receiver);
+    }
+
+    /// @notice After reportAndForward, forwarder holds 0 shares on the strategy
+    function testReportAndForwardNoResidualShares() public {
+        // Pre-condition: shares exist
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+
+        vm.prank(_keeper);
+        forwarder.reportAndForward(address(mockStrategy), 0);
+
+        // Assert: mock share balance is 0 (set to 0 by mock's redeem)
+        uint256 postShares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        assertEq(postShares, 0);
+    }
+
+    /// @notice When shares == 0, returns 0 and redeem is never called
+    function testReportAndForwardZeroSharesPassthrough() public {
+        // Set shares to 0
+        _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
+
+        vm.prank(_keeper);
+        uint256 assets = forwarder.reportAndForward(address(mockStrategy), 0);
+
+        // Assert: returned 0
+        assertEq(assets, 0);
+
+        // Assert: redeem was never called (lastRedeemShares still 0)
+        uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastShares, 0);
+    }
+
+    /// @notice Return value of reportAndForward equals the value returned by redeem
+    function testReportAndForwardReturnsRedeemAssets() public {
+        // Pre-condition: shares exist
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+
+        uint256 expectedReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
+
+        vm.prank(_keeper);
+        uint256 assets = forwarder.reportAndForward(address(mockStrategy), 0);
+
+        assertEq(assets, expectedReturn);
+    }
+}

--- a/verification/kontrol/YFTest.k.sol
+++ b/verification/kontrol/YFTest.k.sol
@@ -59,15 +59,22 @@ contract YFTest is YFSetup {
         // Set shares to 0
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
 
+        // Write sentinel to detect any redeem call, including redeem(0, ...).
+        // Without this, a regression removing the early return guard would call
+        // redeem(0, ...) which writes lastRedeemShares = 0, indistinguishable
+        // from the "never called" default.
+        uint256 sentinel = type(uint256).max;
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, sentinel);
+
         vm.prank(_keeper);
         uint256 assets = forwarder.reportAndForward(address(mockStrategy), 0);
 
         // Assert: returned 0
         assertEq(assets, 0);
 
-        // Assert: redeem was never called (lastRedeemShares still 0)
+        // Assert: redeem was never called (sentinel preserved)
         uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
-        assertEq(lastShares, 0);
+        assertEq(lastShares, sentinel);
     }
 
     /// @notice Return value of reportAndForward equals the value returned by redeem

--- a/verification/kontrol/YFTest.k.sol
+++ b/verification/kontrol/YFTest.k.sol
@@ -31,13 +31,20 @@ contract YFTest is YFSetup {
         // Pre-condition: shares exist to trigger the redeem path
         uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
         vm.assume(shares > 0);
+        uint256 maxLoss = freshUInt256Bounded();
 
         vm.prank(_keeper);
-        forwarder.reportAndForward(address(mockStrategy), 0);
+        forwarder.reportAndForward(address(mockStrategy), maxLoss);
 
-        // Assert: redeem was called with receiver == forwarder.receiver()
+        // Assert: redeem was called with the expected receiver, owner, and maxLoss.
         address lastReceiver = _loadAddress(address(mockStrategy), MFS_LAST_RECEIVER_SLOT);
         assertEq(lastReceiver, _receiver);
+
+        address lastOwner = _loadAddress(address(mockStrategy), MFS_LAST_OWNER_SLOT);
+        assertEq(lastOwner, address(forwarder));
+
+        uint256 lastMaxLoss = _loadUInt256(address(mockStrategy), MFS_LAST_MAX_LOSS_SLOT);
+        assertEq(lastMaxLoss, maxLoss);
     }
 
     /// @notice After reportAndForward, forwarder holds 0 shares on the strategy
@@ -54,10 +61,11 @@ contract YFTest is YFSetup {
         assertEq(postShares, 0);
     }
 
-    /// @notice When shares == 0, returns 0 and redeem is never called
+    /// @notice When shares == 0, report still runs, returns 0, and redeem is never called
     function testReportAndForwardZeroSharesPassthrough() public {
         // Set shares to 0
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, 0);
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
 
         // Write sentinel to detect any redeem call, including redeem(0, ...).
         // Without this, a regression removing the early return guard would call
@@ -71,6 +79,10 @@ contract YFTest is YFSetup {
 
         // Assert: returned 0
         assertEq(assets, 0);
+
+        // Assert: report still ran before the zero-share early return
+        address lastReportCaller = _loadAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT);
+        assertEq(lastReportCaller, address(forwarder));
 
         // Assert: redeem was never called (sentinel preserved)
         uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);


### PR DESCRIPTION
## Summary

Adds 12 Kontrol formal verification proofs for the YieldForwarder and SwappingYieldForwarder contracts, bringing the total proof count from 26 to 38.

**YieldForwarder (5 proofs):** access control (keeper-only), receiver guarantee (redeem always targets hardcoded receiver), no residual shares, zero-share passthrough, return value correctness.

**SwappingYieldForwarder (7 proofs):** access control on reportSwapAndForward, swap output routed to receiver, no residual source asset after swap, zero-share passthrough, zero-redeem passthrough, correct token routing (tokenIn/tokenOut/amountIn), inherited reportAndForward access control.

**Approach:** Unlike strategy proofs (where the CUT's storage is symbolic), forwarders are stateless orchestrators with only immutables + ReentrancyGuard. The mock dependencies (MockForwarderStrategy, MockForwarderSwapper) are made symbolic to verify behavioral guarantees across all possible input states. SYFSetup uses a real TestERC20 for the source asset to satisfy SafeERC20.safeTransfer in the swap path.


Resolves [OSU-1525](https://linear.app/golemfoundation/issue/OSU-1525)