### PR TITLE
docs: introduce ADR practice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,6 +130,34 @@ For detailed security and quality requirements (what edge cases to test, anti-pa
 
 ---
 
+## 📐 Architectural Decision Records (ADRs)
+
+ADRs capture durable, cross-file design decisions that don't belong in contract NatSpec or ephemeral PR descriptions. They provide a discoverable, versioned record of why the architecture looks the way it does.
+
+### When to Write an ADR
+
+- Introducing new contract architecture or significant structural changes
+- Choosing between competing patterns, libraries, or approaches
+- Making audit-driven redesigns or responding to security findings
+- Decisions that affect multiple contracts or subsystems
+
+### Format and Location
+
+- ADRs live in `doc/adr/`
+- Naming convention: `ADR-NNN-short-title.md` (e.g., `ADR-001-vault-strategy-pattern.md`)
+- Use the template at [`doc/adr/ADR-000-template.md`](doc/adr/ADR-000-template.md)
+- Required sections: **Status**, **Context** (with alternatives considered), **Decision**, **Consequences**
+- ADRs may link related requirements docs, NatSpec, audit reports, or PRs in an optional **References** section
+
+### ADR Lifecycle
+
+- **Proposed**: Under discussion, included in a PR for review
+- **Accepted**: Merged and in effect
+- **Deprecated**: No longer applies; note why in the status
+- **Superseded by ADR-NNN**: Replaced by a newer decision
+
+---
+
 ## 📚 NatSpec Documentation Standards
 
 **The Four Pillars**: Every NatSpec contribution must adhere to:

--- a/doc/adr/ADR-000-template.md
+++ b/doc/adr/ADR-000-template.md
@@ -1,0 +1,38 @@
+# ADR-000: Template
+
+## Status
+
+Accepted
+
+## Context
+
+<!-- Describe the problem, constraint, or question that prompted this decision. Include enough background for someone unfamiliar with the discussion to understand why a decision was needed. -->
+
+### Alternatives Considered
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| Option A | ... | ... |
+| Option B | ... | ... |
+| **Chosen** | ... | ... |
+
+## Decision
+
+<!-- State the decision clearly. Explain the key patterns, rationale, and trade-offs that led to this choice. -->
+
+## Consequences
+
+### Positive
+
+- ...
+
+### Negative
+
+- ...
+
+## References
+
+<!-- Optional. Link related PRs, audit reports, requirements docs, external resources, or other ADRs. -->
+
+- [Related PR](#)
+- [Audit report](#)


### PR DESCRIPTION
## Summary

Introduces Architectural Decision Records to octant-v2-core, following the convention already established in [octant-v2-zk-vote-coprocessor](https://github.com/golemfoundation/octant-v2-zk-vote-coprocessor/tree/develop/docs/adr).

- Added `doc/adr/ADR-000-template.md` as a Nygard-format template (Status, Context with alternatives table, Decision, Consequences, References)
- Added ADR guidelines section to `CONTRIBUTING.md` covering when to write ADRs, naming convention (`ADR-NNN-short-title.md`), lifecycle states, and where they live

ADRs capture durable, cross-file design decisions that don't belong in contract NatSpec or ephemeral PR descriptions: vault architecture choices, strategy patterns, audit-driven redesigns, and similar. Backfilling past decisions is a separate effort.

Closes OSU-1564