### PR TITLE
fix: burn dragon shares before pricing exits during insolvency

### DIFF
--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -155,6 +155,12 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         StrategyData storage S = _strategyStorage();
         YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
 
+        // Burn stale dragon shares before pricing user exits to prevent dilution
+        // by unburned junior capital during insolvency
+        if (owner != S.dragonRouter) {
+            _applyDragonLossProtectionIfNeeded(S, YS);
+        }
+
         // Calculate actual value returned for debt tracking (before redemption)
         uint256 valueToReturn = shares; // 1 share = 1 ETH value, except in case of uncovered loss (regardless of actual assets received)
 
@@ -204,6 +210,12 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
     ) public override nonReentrant returns (uint256 shares) {
         StrategyData storage S = _strategyStorage();
         YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
+
+        // Burn stale dragon shares before pricing user exits to prevent dilution
+        // by unburned junior capital during insolvency
+        if (owner != S.dragonRouter) {
+            _applyDragonLossProtectionIfNeeded(S, YS);
+        }
 
         // Validate inputs and check limits (replaces super.withdraw validation)
         require(assets <= _maxWithdraw(S, owner), "ERC4626: withdraw more than max");
@@ -694,6 +706,29 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             return exchangeRate * 10 ** (27 - exchangeRateDecimals);
         } else {
             return exchangeRate / 10 ** (exchangeRateDecimals - 27);
+        }
+    }
+
+    /**
+     * @dev Lazily burns dragon shares when the vault is insolvent, so that user exits
+     *      are not diluted by stale junior capital in the totalSupply denominator.
+     *      Only mutates state when burning is enabled AND the vault is currently insolvent.
+     * @param S Strategy storage pointer
+     * @param YS Yield skimming storage pointer
+     */
+    function _applyDragonLossProtectionIfNeeded(StrategyData storage S, YieldSkimmingStorage storage YS) internal {
+        if (!S.enableBurning) return;
+        // Only burn when the vault is insolvent (can't cover user debt).
+        // This is the condition that triggers the pro-rata fallback in _convertToAssets,
+        // which is where dragon shares in totalSupply cause dilution.
+        if (!_isVaultInsolvent()) return;
+
+        uint256 currentRate = _currentRateRay();
+        uint256 currentVaultValue = S.totalAssets.mulDiv(currentRate, WadRayMath.RAY);
+        uint256 totalDebt = YS.totalDebtOwedToUserInAssetValue + YS.dragonRouterDebtInAssetValue;
+
+        if (currentVaultValue < totalDebt) {
+            _handleDragonLossProtection(S, YS, totalDebt - currentVaultValue, currentRate);
         }
     }
 

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -285,7 +285,9 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
     /**
      * @notice Get the maximum amount of assets that can be withdrawn by a user
-     * @dev Dragon router has restrictions based on solvency protection to ensure user debt coverage
+     * @dev Dragon router has restrictions based on solvency protection to ensure user debt coverage.
+     *      For non-dragon users during insolvency, simulates the lazy dragon burn that will occur
+     *      in withdraw() to return the correct post-burn amount (ERC4626 compliance).
      * @param owner Address whose shares would be burned
      * @return Maximum withdraw amount in asset base units
      */
@@ -302,19 +304,32 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             return Math.min(dragonMaxWithdrawAssets, baseMaxWithdraw);
         }
 
+        // Simulate the lazy burn that withdraw() will perform to reflect post-burn pricing.
+        // Without this, maxWithdraw underreports because _convertToAssets uses totalSupply
+        // that still includes dragon shares (which the lazy burn will remove).
+        uint256 burnAmount = _simulateDragonBurnAmount();
+        if (burnAmount > 0) {
+            uint256 postBurnSupply = _totalSupply(S) - burnAmount;
+            if (postBurnSupply == 0) return 0;
+
+            uint256 ownerShares = _balanceOf(S, owner);
+            return ownerShares.mulDiv(S.totalAssets, postBurnSupply, Math.Rounding.Floor);
+        }
+
         return baseMaxWithdraw;
     }
 
     /**
      * @notice Get the maximum amount of shares that can be redeemed by a user
-     * @dev Dragon router has restrictions based on solvency protection to ensure user debt coverage
+     * @dev Dragon router has restrictions based on solvency protection to ensure user debt coverage.
+     *      For non-dragon users, super.maxRedeem returns _balanceOf(owner) because
+     *      availableWithdrawLimit is uncapped — no burn simulation needed here.
      * @param owner Address whose shares would be burned
      * @return Maximum redeem amount in shares
      */
     function maxRedeem(address owner) public view override returns (uint256) {
         StrategyData storage S = _strategyStorage();
 
-        // Get base max redeem from parent
         uint256 baseMaxRedeem = super.maxRedeem(owner);
 
         // Apply dragon-specific restrictions
@@ -707,6 +722,28 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         } else {
             return exchangeRate / 10 ** (exchangeRateDecimals - 27);
         }
+    }
+
+    /**
+     * @dev Simulates how many dragon shares the lazy burn would remove from totalSupply.
+     *      Used by maxWithdraw/maxRedeem view functions to reflect post-burn pricing.
+     * @return burnAmount Number of dragon shares that would be burned (0 if no burn would occur)
+     */
+    function _simulateDragonBurnAmount() internal view returns (uint256 burnAmount) {
+        StrategyData storage S = _strategyStorage();
+        if (!S.enableBurning || !_isVaultInsolvent()) return 0;
+
+        uint256 dragonBalance = _balanceOf(S, S.dragonRouter);
+        if (dragonBalance == 0) return 0;
+
+        YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
+        uint256 currentRate = _currentRateRay();
+        uint256 currentVaultValue = S.totalAssets.mulDiv(currentRate, WadRayMath.RAY);
+        uint256 totalDebt = YS.totalDebtOwedToUserInAssetValue + YS.dragonRouterDebtInAssetValue;
+
+        if (currentVaultValue >= totalDebt) return 0;
+
+        return Math.min(totalDebt - currentVaultValue, dragonBalance);
     }
 
     /**

--- a/test/integration/strategies/YieldSkimming/LidoStrategy.t.sol
+++ b/test/integration/strategies/YieldSkimming/LidoStrategy.t.sol
@@ -1221,16 +1221,17 @@ contract LidoStrategyTest is Test {
         vm.stopPrank();
 
         // User1 has 100e18 shares
-        // So user1 receives: 100 shares / 375 shares  * 250e18 = 66.666e18 rETH
+        // With lazy dragon burn fix: dragon shares (50e18) burned first, totalSupply=325
+        // So user1 receives: 100 * 250e18 / 325 = 76923076923076923076 rETH
         assertEq(
             data.user1Assets,
-            66666666666666666666,
-            "User1 should receive 66.666e18 rETH (100e18 shares at last rate 1.5)"
+            76923076923076923076,
+            "User1 should receive 76.923e18 rETH (100e18 shares, dragons burned first)"
         );
         assertEq(
             ERC20(WSTETH).balanceOf(data.user1),
-            66666666666666666666,
-            "User1 balance should be 66.666e18 after withdrawal"
+            76923076923076923076,
+            "User1 balance should be 76.923e18 after withdrawal"
         );
         assertEq(vault.balanceOf(data.user1), 0, "User1 should have no shares left");
 
@@ -1253,7 +1254,8 @@ contract LidoStrategyTest is Test {
         // 3. Deficit (loss) = 183.333e18 - 275e18 = -91.666e18 ETH
         // 4. Loss reported = 91.666e18 ETH ÷ 1.0 rate = 91.666e18 rETH
         assertEq(data.profit2, 0, "Should report no profit in second report");
-        assertEq(data.loss2, 91666666666666666666, "Should report 91.666e18 loss");
+        // Loss is smaller: dragons already burned during user1's redeem
+        assertEq(data.loss2, 51923076923076923076, "Should report 51.923e18 loss");
 
         // Dragon shares burning to cover loss:
         // - Loss to cover: 91.666e18 ETH
@@ -1313,7 +1315,8 @@ contract LidoStrategyTest is Test {
         // This 33.333e18 rETH represents the uncovered portion of the 91.666e18 ETH loss
         // that couldn't be covered by the 50e18 dragon shares that were burned
         console.log("Expected behavior: Assets remain due to uncovered loss");
-        assertEq(remainingAssets, 33333333333333333334, "Expected 33.333e18 rETH to remain from uncovered loss");
+        // User1 got more (76.923 vs 66.667), so less uncovered loss remains
+        assertEq(remainingAssets, 23076923076923076924, "Expected 23.077e18 rETH to remain from uncovered loss");
 
         // lets call report
         vm.startPrank(keeper);

--- a/test/integration/strategies/YieldSkimming/base/BaseYieldSkimmingIntegrationTest.sol
+++ b/test/integration/strategies/YieldSkimming/base/BaseYieldSkimmingIntegrationTest.sol
@@ -873,7 +873,10 @@ abstract contract BaseYieldSkimmingIntegrationTest is BaseIntegrationTest {
         data.user1Assets = vault.redeem(vault.balanceOf(data.user1), data.user1, data.user1);
         vm.stopPrank();
 
-        assertEq(data.user1Assets, 66666666666666666666, "User1 should receive expected assets");
+        // With lazy dragon burn fix: dragon shares (50e18) are burned before pricing,
+        // so user1 redeems against totalSupply=325 instead of 375:
+        // 100 * 250e18 / 325 = 76923076923076923076
+        assertEq(data.user1Assets, 76923076923076923076, "User1 should receive expected assets");
         assertEq(vault.balanceOf(data.user1), 0, "User1 should have no shares left");
 
         vm.startPrank(keeper);
@@ -882,7 +885,10 @@ abstract contract BaseYieldSkimmingIntegrationTest is BaseIntegrationTest {
         data.dragonSharesAfterLoss = vault.balanceOf(donationAddress);
 
         assertEq(data.profit2, 0, "Should report no profit in second report");
-        assertEq(data.loss2, 91666666666666666666, "Should report expected loss");
+        // Loss is smaller now: dragons were already burned during user1's redeem
+        // Remaining: totalAssets=173076923076923076924, totalDebt=225e18
+        // loss = 225e18 - 173076923076923076924 = 51923076923076923076
+        assertEq(data.loss2, 51923076923076923076, "Should report expected loss");
         assertEq(data.dragonSharesAfterLoss, 0, "All dragon shares should be burned");
 
         _clearMocks();
@@ -901,7 +907,9 @@ abstract contract BaseYieldSkimmingIntegrationTest is BaseIntegrationTest {
 
         assertEq(remainingDragonShares, 0, "All dragon shares should be burned");
         assertEq(vault.totalSupply(), 0, "All shares should be withdrawn");
-        assertEq(remainingAssets, 33333333333333333334, "Expected remaining assets from uncovered loss");
+        // User1 got more (76.92 vs 66.67), so less remains for uncovered loss
+        // 173076923076923076924 - 150e18 = 23076923076923076924
+        assertEq(remainingAssets, 23076923076923076924, "Expected remaining assets from uncovered loss");
     }
 
     /// @notice Test dragon router withdrawal followed by rate recovery - user should have no loss

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingStaleDragonBurn.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingStaleDragonBurn.t.sol
@@ -287,4 +287,235 @@ contract YieldSkimmingStaleDragonBurnTest is Test {
             tokenized.redeem(maxDragonRedeem, dragonRouter, dragonRouter);
         }
     }
+
+    // =========================================================================
+    // maxWithdraw / maxRedeem post-burn simulation tests
+    // =========================================================================
+
+    /// @notice maxWithdraw must reflect post-burn pricing during insolvency.
+    ///         Without the fix, maxWithdraw underreports because it prices with
+    ///         dragon shares still in totalSupply.
+    function test_maxWithdraw_reflectsPostBurnDuringInsolvency() public {
+        _depositUser(alice, 100 ether);
+
+        // Create dragon buffer
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        uint256 dragonShares = tokenized.balanceOf(dragonRouter);
+        assertEq(dragonShares, 50 ether, "dragon should have 50 shares");
+        // totalSupply = 150, totalAssets = 100
+
+        // Make vault insolvent
+        strategy.setExchangeRate(9e17); // vaultValue = 90, userDebt = 100
+
+        // maxWithdraw should reflect the POST-burn state, not the pre-burn state.
+        // Post-burn: totalSupply = 100 (dragon burned), pro-rata: 100 * 100 / 100 = 100
+        // Pre-burn (broken): pro-rata: 100 * 100 / 150 = 66.67
+        uint256 maxW = tokenized.maxWithdraw(alice);
+        assertEq(maxW, 100 ether, "maxWithdraw should reflect post-burn pricing (100, not 66.67)");
+    }
+
+    /// @notice withdraw(maxWithdraw()) must succeed in a single transaction and give
+    ///         the user their full entitlement.
+    function test_maxWithdraw_withdraw_roundtrip() public {
+        _depositUser(alice, 100 ether);
+
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        strategy.setExchangeRate(9e17);
+        assertTrue(ys.isVaultInsolvent(), "should be insolvent");
+
+        uint256 maxW = tokenized.maxWithdraw(alice);
+        assertGt(maxW, 0, "maxWithdraw should be nonzero");
+
+        // This must NOT revert — maxWithdraw must be withdrawable in one call
+        vm.prank(alice);
+        uint256 shares = tokenized.withdraw(maxW, alice, alice);
+
+        assertEq(tokenized.balanceOf(alice), 0, "alice should have no shares left");
+        assertEq(asset.balanceOf(alice), maxW, "alice should receive exactly maxWithdraw assets");
+        assertEq(shares, 100 ether, "all 100 shares should be burned");
+    }
+
+    /// @notice redeem(maxRedeem()) and withdraw(maxWithdraw()) should yield the same assets.
+    function test_maxWithdraw_equals_maxRedeem_value() public {
+        // Alice path: withdraw(maxWithdraw)
+        _depositUser(alice, 100 ether);
+        // Bob path: redeem(maxRedeem)
+        _depositUser(bob, 100 ether);
+
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        strategy.setExchangeRate(9e17);
+
+        uint256 aliceMaxW = tokenized.maxWithdraw(alice);
+        uint256 bobMaxR = tokenized.maxRedeem(bob);
+
+        // Alice withdraws
+        vm.prank(alice);
+        tokenized.withdraw(aliceMaxW, alice, alice);
+
+        // Bob redeems
+        vm.prank(bob);
+        uint256 bobAssets = tokenized.redeem(bobMaxR, bob, bob);
+
+        // Both should get the same amount (within 1 wei rounding)
+        assertApproxEqAbs(aliceMaxW, bobAssets, 1, "withdraw and redeem paths should give equal assets");
+    }
+
+    /// @notice maxWithdraw should be unchanged when vault is solvent (no burn simulation needed).
+    function test_maxWithdraw_unchangedWhenSolvent() public {
+        _depositUser(alice, 100 ether);
+
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        // Rate drops but vault stays solvent (vaultValue >= userDebt)
+        strategy.setExchangeRate(12e17);
+        assertFalse(ys.isVaultInsolvent(), "should be solvent");
+
+        // maxWithdraw should use rate-based conversion: 100 shares * RAY / 1.2 RAY = 83.33
+        uint256 maxW = tokenized.maxWithdraw(alice);
+        // Rate-based: 100 shares * RAY / 1.2_RAY = 83.333...
+        // Just verify it's in the right ballpark and NOT the pro-rata value
+        assertGt(maxW, 83 ether, "maxWithdraw should be ~83.33 (rate-based)");
+        assertLt(maxW, 84 ether, "maxWithdraw should be ~83.33 (rate-based)");
+    }
+
+    /// @notice maxWithdraw should not simulate burn when burning is disabled.
+    function test_maxWithdraw_noSimulationWhenBurningDisabled() public {
+        _depositUser(alice, 100 ether);
+
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        // Disable burning
+        vm.prank(management);
+        tokenized.setEnableBurning(false);
+
+        strategy.setExchangeRate(9e17);
+
+        // With burning disabled, no lazy burn will fire, so maxWithdraw uses raw pro-rata
+        // Pro-rata: 100 * 100 / 150 = 66.67
+        uint256 maxW = tokenized.maxWithdraw(alice);
+        assertEq(maxW, 66666666666666666666, "maxWithdraw should use raw pro-rata when burning disabled");
+    }
+
+    /// @notice maxWithdraw should not simulate burn when dragon has 0 shares.
+    function test_maxWithdraw_noSimulationWhenNoDragonShares() public {
+        _depositUser(alice, 100 ether);
+
+        // No report → no dragon shares
+        strategy.setExchangeRate(9e17);
+
+        uint256 maxW = tokenized.maxWithdraw(alice);
+        // totalSupply = 100, totalAssets = 100, pro-rata: 100 * 100 / 100 = 100
+        assertEq(maxW, 100 ether, "maxWithdraw should be full assets when no dragon shares");
+    }
+
+    /// @notice With multiple users, each user's maxWithdraw should be correct post-burn.
+    function test_maxWithdraw_multipleUsers() public {
+        _depositUser(alice, 100 ether);
+        _depositUser(bob, 50 ether);
+        // totalSupply = 150, totalAssets = 150
+
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+        // dragon gets 75 shares (profit = 225 - 150 = 75)
+        // totalSupply = 225, totalAssets = 150
+
+        strategy.setExchangeRate(8e17);
+        // vaultValue = 120, userDebt = 150 → insolvent
+        assertTrue(ys.isVaultInsolvent(), "should be insolvent");
+
+        uint256 aliceMaxW = tokenized.maxWithdraw(alice);
+        uint256 bobMaxW = tokenized.maxWithdraw(bob);
+
+        // Post-burn: dragon burned, totalSupply = 150
+        // Alice: 100/150 * 150 = 100, Bob: 50/150 * 150 = 50
+        assertEq(aliceMaxW, 100 ether, "alice maxWithdraw post-burn");
+        assertEq(bobMaxW, 50 ether, "bob maxWithdraw post-burn");
+
+        // Both can withdraw in one call
+        vm.prank(alice);
+        tokenized.withdraw(aliceMaxW, alice, alice);
+
+        vm.prank(bob);
+        tokenized.withdraw(bobMaxW, bob, bob);
+
+        assertEq(tokenized.totalSupply(), 0, "all shares should be withdrawn");
+    }
+
+    /// @notice maxRedeem should return full balance during insolvency (common case).
+    function test_maxRedeem_returnsFullBalanceDuringInsolvency() public {
+        _depositUser(alice, 100 ether);
+
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        strategy.setExchangeRate(9e17);
+        assertTrue(ys.isVaultInsolvent(), "should be insolvent");
+
+        uint256 maxR = tokenized.maxRedeem(alice);
+        assertEq(maxR, 100 ether, "maxRedeem should return full balance");
+
+        // And redeem should succeed
+        vm.prank(alice);
+        tokenized.redeem(maxR, alice, alice);
+
+        assertEq(tokenized.balanceOf(alice), 0, "all shares redeemed");
+    }
+
+    /// @notice Verify that maxWithdraw for dragon is unchanged by the simulation.
+    function test_maxWithdraw_dragon_unchanged() public {
+        _depositUser(alice, 100 ether);
+
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        // Dragon's maxWithdraw should use _maxDragonRedeemableShares logic, not simulation
+        uint256 dragonMaxW = tokenized.maxWithdraw(dragonRouter);
+        uint256 dragonMaxR = tokenized.maxRedeem(dragonRouter);
+
+        // In solvent state, dragon can withdraw excess over userDebt
+        // vaultValue = 150, userDebt = 100 → excess = 50 → dragon can redeem up to 50
+        assertGt(dragonMaxW, 0, "dragon should be able to withdraw when solvent");
+        assertEq(dragonMaxR, 50 ether, "dragon maxRedeem should be 50 (excess value)");
+    }
+
+    /// @notice Deep insolvency: dragon fully burned, user takes remaining market loss.
+    ///         maxWithdraw should still be accurate.
+    function test_maxWithdraw_deepInsolvency() public {
+        _depositUser(alice, 100 ether);
+
+        strategy.setExchangeRate(12e17);
+        vm.prank(keeper);
+        tokenized.report();
+        // dragon gets 20 shares, totalSupply = 120, totalAssets = 100
+
+        strategy.setExchangeRate(5e17);
+        // vaultValue = 50, userDebt = 100 → deeply insolvent
+        assertTrue(ys.isVaultInsolvent(), "should be insolvent");
+
+        uint256 maxW = tokenized.maxWithdraw(alice);
+        // Post-burn: dragon 20 shares burned, totalSupply = 100
+        // Pro-rata: 100 * 100 / 100 = 100
+        assertEq(maxW, 100 ether, "maxWithdraw should reflect post-burn even in deep insolvency");
+
+        vm.prank(alice);
+        uint256 sharesBurned = tokenized.withdraw(maxW, alice, alice);
+        assertEq(sharesBurned, 100 ether, "all shares burned");
+        assertEq(asset.balanceOf(alice), 100 ether, "alice gets all assets");
+    }
 }

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingStaleDragonBurn.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingStaleDragonBurn.t.sol
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { BaseYieldSkimmingStrategy } from "src/strategies/yieldSkimming/BaseYieldSkimmingStrategy.sol";
+import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
+
+/// @title Concrete implementation for testing (same pattern as BaseYieldSkimmingBranchCoverage)
+contract TestYieldSkimmingStrategy is BaseYieldSkimmingStrategy {
+    uint256 private _rate;
+
+    constructor(
+        address _asset,
+        string memory _name,
+        string memory _symbol,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress
+    )
+        BaseYieldSkimmingStrategy(
+            _asset,
+            _name,
+            _symbol,
+            _management,
+            _keeper,
+            _emergencyAdmin,
+            _donationAddress,
+            _enableBurning,
+            _tokenizedStrategyAddress
+        )
+    {
+        _rate = 1e18;
+    }
+
+    function setExchangeRate(uint256 newRate) external {
+        _rate = newRate;
+    }
+
+    function _getCurrentExchangeRate() internal view override returns (uint256) {
+        return _rate;
+    }
+
+    function decimalsOfExchangeRate() public pure override returns (uint256) {
+        return 18;
+    }
+}
+
+/// @title Tests that dragon shares are burned before pricing user exits during insolvency
+/// @notice Validates the fix for stale dragon share dilution: early and late redeemers
+///         should receive equal value per share when exiting during an unreported loss.
+contract YieldSkimmingStaleDragonBurnTest is Test {
+    using Math for uint256;
+
+    TestYieldSkimmingStrategy public strategy;
+    ERC20Mock public asset;
+
+    address public management = address(0x1);
+    address public keeper = address(0x2);
+    address public emergencyAdmin = address(0x3);
+    address public dragonRouter = address(0x4);
+    address public alice = address(0xA);
+    address public bob = address(0xB);
+
+    uint256 public constant WAD = 1e18;
+
+    ITokenizedStrategy internal tokenized;
+    YieldSkimmingTokenizedStrategy internal ys;
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        YieldSkimmingTokenizedStrategy implementation = new YieldSkimmingTokenizedStrategy();
+
+        strategy = new TestYieldSkimmingStrategy(
+            address(asset),
+            "Test YieldSkim",
+            "tsYS",
+            management,
+            keeper,
+            emergencyAdmin,
+            dragonRouter,
+            true, // enableBurning
+            address(implementation)
+        );
+
+        tokenized = ITokenizedStrategy(address(strategy));
+        ys = YieldSkimmingTokenizedStrategy(address(strategy));
+
+        // Allow large losses for test slashing simulations
+        vm.prank(management);
+        strategy.setLossLimitRatio(9999);
+    }
+
+    function _depositUser(address user, uint256 amount) internal {
+        asset.mint(user, amount);
+        vm.prank(user);
+        asset.approve(address(strategy), amount);
+        vm.prank(user);
+        tokenized.deposit(amount, user);
+    }
+
+    /// @notice Core test: two identical users redeeming during unreported insolvency
+    ///         should receive equal assets per share, regardless of ordering relative
+    ///         to keeper report().
+    function test_equalRedemptionDuringUnreportedInsolvency() public {
+        uint256 depositAmount = 100 ether;
+
+        // Both users deposit at rate=1.0
+        _depositUser(alice, depositAmount);
+        _depositUser(bob, depositAmount);
+
+        assertEq(tokenized.balanceOf(alice), 100 ether, "alice shares");
+        assertEq(tokenized.balanceOf(bob), 100 ether, "bob shares");
+
+        // Rate increases to 1.5 -> keeper reports profit -> dragon shares minted
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        uint256 dragonShares = tokenized.balanceOf(dragonRouter);
+        assertGt(dragonShares, 0, "dragon buffer should exist");
+        assertEq(tokenized.totalSupply(), 300 ether, "totalSupply = 200 user + 100 dragon");
+
+        // Rate drops to 0.6 — vault becomes insolvent but NO keeper report yet
+        strategy.setExchangeRate(6e17);
+        assertTrue(ys.isVaultInsolvent(), "vault should be insolvent");
+
+        // Alice redeems BEFORE any keeper report
+        uint256 aliceShares = tokenized.balanceOf(alice);
+        vm.prank(alice);
+        uint256 aliceAssets = tokenized.redeem(aliceShares, alice, alice);
+
+        // Keeper reports (burns remaining dragons if any)
+        vm.prank(keeper);
+        tokenized.report();
+
+        // Bob redeems AFTER keeper report
+        uint256 bobShares = tokenized.balanceOf(bob);
+        vm.prank(bob);
+        uint256 bobAssets = tokenized.redeem(bobShares, bob, bob);
+
+        // With the fix: alice and bob should receive equal assets per share
+        // (within 1 wei rounding tolerance)
+        assertApproxEqAbs(aliceAssets, bobAssets, 1, "early and late redeemers should receive equal assets");
+    }
+
+    /// @notice Verify that the lazy burn actually removes dragon shares from supply
+    ///         when a user redeems during unreported insolvency.
+    function test_lazyBurnRemovesDragonSharesOnUserRedeem() public {
+        _depositUser(alice, 100 ether);
+
+        // Create dragon buffer via profit
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        uint256 dragonSharesBefore = tokenized.balanceOf(dragonRouter);
+        assertGt(dragonSharesBefore, 0, "dragon should have shares");
+
+        // Make vault insolvent without reporting
+        strategy.setExchangeRate(6e17);
+        assertTrue(ys.isVaultInsolvent(), "vault should be insolvent");
+
+        // Dragon shares should still exist before user redeems
+        assertEq(tokenized.balanceOf(dragonRouter), dragonSharesBefore, "dragon shares stale before redeem");
+
+        // User redeems — this should lazily burn dragon shares
+        uint256 maxRedeem = tokenized.maxRedeem(alice);
+        vm.prank(alice);
+        tokenized.redeem(maxRedeem, alice, alice);
+
+        // Dragon shares should have been burned by the lazy protection
+        assertEq(tokenized.balanceOf(dragonRouter), 0, "dragon shares should be burned after user redeem");
+    }
+
+    /// @notice The lazy burn should be a no-op when burning is disabled.
+    function test_noBurnWhenBurningDisabled() public {
+        // Disable burning
+        vm.prank(management);
+        tokenized.setEnableBurning(false);
+
+        _depositUser(alice, 100 ether);
+
+        // Create dragon buffer via profit (need to re-enable burning temporarily for this)
+        vm.prank(management);
+        tokenized.setEnableBurning(true);
+
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        uint256 dragonSharesBefore = tokenized.balanceOf(dragonRouter);
+
+        // Now disable burning again
+        vm.prank(management);
+        tokenized.setEnableBurning(false);
+
+        // Make vault insolvent without reporting
+        strategy.setExchangeRate(6e17);
+
+        // User redeems — dragon shares should NOT be burned (burning disabled)
+        uint256 maxRedeem = tokenized.maxRedeem(alice);
+        vm.prank(alice);
+        tokenized.redeem(maxRedeem, alice, alice);
+
+        assertEq(
+            tokenized.balanceOf(dragonRouter),
+            dragonSharesBefore,
+            "dragon shares should remain when burning is disabled"
+        );
+    }
+
+    /// @notice The lazy burn should be a no-op when the vault is solvent.
+    function test_noBurnWhenSolvent() public {
+        _depositUser(alice, 100 ether);
+
+        // Create dragon buffer via profit
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        uint256 dragonSharesBefore = tokenized.balanceOf(dragonRouter);
+
+        // Rate drops slightly but vault stays solvent (value > userDebt)
+        strategy.setExchangeRate(12e17);
+        assertFalse(ys.isVaultInsolvent(), "vault should be solvent");
+
+        // User redeems — dragon shares should NOT be burned
+        uint256 maxRedeem = tokenized.maxRedeem(alice);
+        vm.prank(alice);
+        tokenized.redeem(maxRedeem, alice, alice);
+
+        assertEq(
+            tokenized.balanceOf(dragonRouter),
+            dragonSharesBefore,
+            "dragon shares should remain when vault is solvent"
+        );
+    }
+
+    /// @notice Withdraw path should also lazily burn dragon shares.
+    function test_withdrawAlsoTriggersLazyBurn() public {
+        _depositUser(alice, 100 ether);
+
+        // Create dragon buffer
+        strategy.setExchangeRate(15e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        uint256 dragonSharesBefore = tokenized.balanceOf(dragonRouter);
+        assertGt(dragonSharesBefore, 0, "dragon should have shares");
+
+        // Make vault insolvent
+        strategy.setExchangeRate(6e17);
+        assertTrue(ys.isVaultInsolvent(), "vault should be insolvent");
+
+        // Withdraw (not redeem) should also trigger lazy burn
+        uint256 maxWithdraw = tokenized.maxWithdraw(alice);
+        assertGt(maxWithdraw, 0, "alice should be able to withdraw");
+
+        vm.prank(alice);
+        tokenized.withdraw(maxWithdraw, alice, alice);
+
+        assertEq(tokenized.balanceOf(dragonRouter), 0, "dragon shares should be burned via withdraw path");
+    }
+
+    /// @notice Dragon's own redeem should NOT trigger the lazy burn (it's the dragon itself).
+    function test_dragonRedeemDoesNotTriggerLazyBurn() public {
+        _depositUser(alice, 100 ether);
+
+        // Create dragon buffer
+        strategy.setExchangeRate(12e17);
+        vm.prank(keeper);
+        tokenized.report();
+
+        uint256 dragonShares = tokenized.balanceOf(dragonRouter);
+        assertGt(dragonShares, 0, "dragon should have shares");
+
+        // Dragon redeems in solvent state — should not trigger lazy burn
+        uint256 maxDragonRedeem = tokenized.maxRedeem(dragonRouter);
+        if (maxDragonRedeem > 0) {
+            vm.prank(dragonRouter);
+            tokenized.redeem(maxDragonRedeem, dragonRouter, dragonRouter);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes stale dragon share dilution in `YieldSkimmingTokenizedStrategy` during insolvency
- Adds `_applyDragonLossProtectionIfNeeded()` that lazily burns dragon shares at the start of non-dragon `redeem()` and `withdraw()` when the vault is insolvent
- Ensures the first-loss tranche (dragon shares) is wiped from `totalSupply` before user exit pricing runs, eliminating ordering-dependent value transfer between early and late redeemers

## Problem

When the vault becomes insolvent (value < user debt), `_convertToAssets` falls back to `shares * totalAssets / totalSupply`. Dragon shares are junior capital meant to absorb losses, but they remain in `totalSupply` until the keeper calls `report()`. During this stale-loss window, early redeemers are diluted by zombie dragon shares while late redeemers (post-report) capture the freed buffer — a direct user-to-user value transfer.

## Fix

The new `_applyDragonLossProtectionIfNeeded()` function checks:
1. `enableBurning` is true
2. `_isVaultInsolvent()` is true (vault value < user debt)
3. `currentVaultValue < totalDebt` (user + dragon debt)

If all conditions met, it calls the existing `_handleDragonLossProtection()` to burn dragon shares before the conversion math runs. This is a no-op when the vault is solvent or burning is disabled.

## Test plan

- [x] `test_equalRedemptionDuringUnreportedInsolvency` — early and late redeemers get equal assets per share
- [x] `test_lazyBurnRemovesDragonSharesOnUserRedeem` — dragon shares burned on first user exit during insolvency
- [x] `test_noBurnWhenBurningDisabled` — lazy burn is no-op when burning disabled
- [x] `test_noBurnWhenSolvent` — lazy burn is no-op when vault is solvent
- [x] `test_withdrawAlsoTriggersLazyBurn` — withdraw path also triggers lazy burn
- [x] `test_dragonRedeemDoesNotTriggerLazyBurn` — dragon's own redemptions skip lazy burn
- [x] All 1904 existing unit tests pass

