### PR TITLE
fix: bailsec h-1 redeem proportional shares to prevent loss bypass

### DIFF
--- a/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
+++ b/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
@@ -5,6 +5,7 @@ import { BaseHealthCheck } from "src/strategies/periphery/BaseHealthCheck.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 /**
  * @title MorphoCompounderStrategy
@@ -124,13 +125,38 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
     }
 
     /**
-     * @dev Withdraws assets from Morpho compounder vault
-     * @param _amount Amount of assets to withdraw in asset base units
-     * @custom:security maxLoss set to 100% (10_000 BPS) to prevent revert cascades
-     *                  MultistrategyVault enforces actual loss limits via updateDebt
+     * @dev Redeems a proportional slice of vault shares to free `_amount`. Using the
+     *      strategy's stored deployed total as the denominator forces an unreported
+     *      underlying loss onto the exiter via `TokenizedStrategy._withdraw`'s maxLoss
+     *      path instead of letting them bypass it through an amount-based withdraw at
+     *      the post-loss PPS.
+     * @param _amount Amount of assets to attempt to free
+     * @custom:security maxLoss=10_000 BPS on the inner call mirrors prior semantics;
+     *                  the outer layer enforces the user-supplied loss cap
      */
     function _freeFunds(uint256 _amount) internal override {
-        ITokenizedStrategy(compounderVault).withdraw(_amount, address(this), address(this), 10_000);
+        ITokenizedStrategy vault = ITokenizedStrategy(compounderVault);
+        uint256 vaultShares = vault.balanceOf(address(this));
+        if (vaultShares == 0) return;
+
+        uint256 idleAssets = IERC20(asset).balanceOf(address(this));
+        uint256 storedTotal = TokenizedStrategy.totalAssets();
+        uint256 denom = storedTotal > idleAssets ? storedTotal - idleAssets : vault.maxWithdraw(address(this));
+        if (denom == 0) return;
+
+        uint256 sharesToRedeem = _amount >= denom
+            ? vaultShares
+            : Math.mulDiv(vaultShares, _amount, denom, Math.Rounding.Ceil);
+
+        if (sharesToRedeem == 0) return;
+
+        if (sharesToRedeem < vaultShares && vault.previewRedeem(sharesToRedeem) < _amount) {
+            unchecked {
+                sharesToRedeem++;
+            }
+        }
+
+        vault.redeem(sharesToRedeem, address(this), address(this), 10_000);
     }
 
     /**

--- a/test/integration/strategies/YieldDonating/MorphoCompounderStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/MorphoCompounderStrategy.t.sol
@@ -462,7 +462,9 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
         }
     }
 
-    /// @notice Test that triggers "too much loss" by removing idle funds and mocking withdraw
+    /// @notice Test that triggers "too much loss" by removing idle funds and mocking `freeFunds`.
+    /// @dev Also locks in the redeem-only invariant: `_freeFunds` must reach the compounder
+    ///      via `redeem`, never via the amount-based `withdraw`.
     function testLossDoesNotTriggerTooMuchLossError() public {
         uint256 depositAmount = 100000e6;
         address morphoBlueVault = MorphoTestConfig.MORPHO_BLUE_VAULT;
@@ -492,6 +494,7 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
         airdrop(ERC20(_asset()), _compounderVault(), depositAmount / 10);
 
         vm.mockCall(_compounderVault(), abi.encodeWithSignature("freeFunds(uint256)"), "");
+        vm.expectCall(_compounderVault(), abi.encodeWithSelector(_INNER_WITHDRAW), 0);
 
         vm.startPrank(user);
         YieldDonatingTokenizedStrategy(address(strategy)).redeem(vaultShares - 2, user, user, 10_000);
@@ -501,4 +504,25 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
 
         assertEq(ERC20(_asset()).balanceOf(user), depositAmount / 10, "User should have received balance");
     }
+
+    /// @notice `_freeFunds` must redeem proportional inner shares, not call the
+    ///         amount-based inner `withdraw`.
+    function test_freeFunds_RedeemsProportionalShares() public {
+        // Arrange
+        uint256 depositAmount = 100_000e6;
+        airdrop(ERC20(_asset()), user, depositAmount);
+        vm.prank(user);
+        IERC4626(address(strategy)).deposit(depositAmount, user);
+
+        // Assert (registered before the act per cheatcode contract)
+        vm.expectCall(_compounderVault(), abi.encodeWithSelector(_INNER_WITHDRAW), 0);
+        vm.expectCall(_compounderVault(), abi.encodeWithSelector(_INNER_REDEEM), 1);
+
+        // Act
+        vm.prank(user);
+        IERC4626(address(strategy)).withdraw(depositAmount / 2, user, user);
+    }
+
+    bytes4 private constant _INNER_WITHDRAW = bytes4(keccak256("withdraw(uint256,address,address,uint256)"));
+    bytes4 private constant _INNER_REDEEM = bytes4(keccak256("redeem(uint256,address,address,uint256)"));
 }


### PR DESCRIPTION
Resolves Bailsec H-1 in `MorphoCompounderStrategy` (yieldDonating).

`_freeFunds` called `ITokenizedStrategy.withdraw(_amount, ..., 10_000)` on the inner compounder. With an unreported underlying loss the vault burned extra inner shares at the post-loss PPS to deliver the stale-PPS amount, letting exiters bypass their share of the loss.

Replace with a proportional `ITokenizedStrategy.redeem(sharesToRedeem, ..., 10_000)` where `sharesToRedeem` is derived from the strategy's stored deployed total via `Math.mulDiv(..., Rounding.Ceil)`. Shortfall surfaces through the existing `TokenizedStrategy._withdraw` maxLoss path so the exiter bears the loss.

Hardening:
- `previewRedeem` check: if ceiling-rounded shares still under-deliver by 1 wei (inner floor rounding), bump by one share so `maxLoss=0` withdrawals never revert on dust.
- `vault.maxWithdraw` fallback denominator when donation-skewed idle drives `storedDeployed` to zero, so `emergencyWithdraw` still drains.

Tests: added `vm.expectCall(..., 0)` on the inner 4-arg `withdraw` selector to `testLossDoesNotTriggerTooMuchLossError` and a new `test_freeFunds_RedeemsProportionalShares` that asserts inner `redeem` is called exactly once and inner `withdraw` zero times.