### PR TITLE
fix(yield-skim): Bailsec audit fixes (25, 29, 35, 38, 39, 41)

### DIFF
--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -91,8 +91,12 @@ abstract contract TokenizedStrategy {
 
     /**
      * @notice Emitted when the strategy reports `profit` or `loss`.
-     * @param profit Profit amount
-     * @param loss Loss amount
+     * @dev Base semantics are notional gain/loss since the previous report.
+     *      Specialized strategies may override the meaning; for
+     *      YieldSkimmingTokenizedStrategy, `loss` is a gross shortfall level
+     *      and must not be summed across consecutive reports.
+     * @param profit Profit amount in asset units, subject to implementation semantics
+     * @param loss Loss amount in asset units, subject to implementation semantics
      */
     event Reported(uint256 profit, uint256 loss);
 
@@ -1142,6 +1146,9 @@ abstract contract TokenizedStrategy {
      * @dev This will account for any gains/losses since the last report.
      * This function is virtual and meant to be overridden by specialized
      * strategies that implement custom yield handling mechanisms.
+     * Specialized overrides may define different return and event semantics;
+     * YieldSkimmingTokenizedStrategy reports `loss` as a gross shortfall level
+     * rather than an incremental delta.
      *
      * Two primary implementations are provided in specialized strategies:
      * - YieldDonatingTokenizedStrategy: Mints shares from profits to the dragonRouter
@@ -1149,8 +1156,7 @@ abstract contract TokenizedStrategy {
      *
      * @return profit Notional amount of gain since last report
      * report in terms of `asset`.
-     * @return loss Notional amount of loss since last report
-     * report in terms of `asset`.
+     * @return loss Notional loss in terms of `asset`, subject to override-specific semantics.
      */
     function report() external virtual returns (uint256 profit, uint256 loss);
 

--- a/src/core/interfaces/ITokenizedStrategy.sol
+++ b/src/core/interfaces/ITokenizedStrategy.sol
@@ -29,6 +29,10 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
 
     /**
      * @notice Emitted when the strategy reports `profit` or `loss`.
+     * @dev Base semantics are gain/loss since the previous report. Specialized
+     *      implementations may define narrower semantics; for
+     *      YieldSkimmingTokenizedStrategy, `loss` is a gross shortfall level
+     *      and must not be summed across consecutive reports.
      */
     event Reported(uint256 profit, uint256 loss);
 
@@ -169,9 +173,11 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
      * @dev Keepers should consider MEV-protected submission. Specialized implementations may
      *      mint shares to the donation destination (dragon router) on profit, and apply
      *      loss-protection via dragon burning (if enabled). The return values are denominated
-     *      in the underlying `asset`.
+     *      in the underlying `asset`, subject to implementation-specific semantics.
+     *      YieldSkimmingTokenizedStrategy returns and emits `loss` as a gross shortfall level,
+     *      not an incremental delta.
      * @return _profit Gain since last report, in `asset` units.
-     * @return _loss Loss since last report, in `asset` units.
+     * @return _loss Loss in `asset` units, subject to implementation-specific semantics.
      */
     function report() external returns (uint256 _profit, uint256 _loss);
 

--- a/src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol
+++ b/src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol
@@ -38,21 +38,21 @@ interface IYieldSkimmingStrategy {
     function getCurrentRateRay() external view returns (uint256 currentRateRay);
 
     /**
-     * @notice Total ETH-value debt owed to users (excludes dragon router)
+     * @notice Total underlying-asset-value debt owed to users (excludes dragon router)
      * @dev Units: value-shares where 1 share = 1 unit of asset value
      * @return userDebtInAssetValue Users’ combined value debt
      */
     function gettotalDebtOwedToUserInAssetValue() external view returns (uint256 userDebtInAssetValue);
 
     /**
-     * @notice Total ETH-value debt owed to dragon router
+     * @notice Total underlying-asset-value debt owed to dragon router
      * @dev Increases on profit mints, decreases on loss burns or debt rebalancing
      * @return dragonDebtInAssetValue Dragon router value debt
      */
     function getDragonRouterDebtInAssetValue() external view returns (uint256 dragonDebtInAssetValue);
 
     /**
-     * @notice Combined ETH-value debt owed to users and dragon router
+     * @notice Combined underlying-asset-value debt owed to users and dragon router
      * @return totalDebtInAssetValue Users + dragon value debt
      */
     function getTotalValueDebtInAssetValue() external view returns (uint256 totalDebtInAssetValue);

--- a/src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol
+++ b/src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol
@@ -59,8 +59,10 @@ interface IYieldSkimmingStrategy {
 
     /**
      * @notice Check whether the vault is insolvent
-     * @dev Insolvent when total vault value (assets * rate) < total value debt (users + dragon)
-     * @return isInsolvent True if vault cannot cover total value debt
+     * @dev Insolvent when total vault value (assets * rate) is below user debt.
+     *      Dragon debt is excluded from this check because dragon shares are junior
+     *      loss-buffer accounting and are expected to absorb losses before users.
+     * @return isInsolvent True if vault cannot cover user value debt
      */
     function isVaultInsolvent() external view returns (bool isInsolvent);
 }

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -452,8 +452,19 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      * 3. **Loss Protection**: When current value is less than total shares, burns dragon shares (if enabled) to cover shortfall
      * 4. **Insolvency Handling**: If dragon buffer insufficient for losses, remaining shortfall is handled through proportional asset distribution during withdrawals
      *
-     * @return profit Profit in assets from underlying value appreciation
-     * @return loss Loss in assets from underlying value depreciation
+     * Event semantics: the `loss` value emitted via `Reported` is a gross
+     * shortfall — the full gap between total value debt and current vault
+     * value at the time of the call — not an incremental delta since the last
+     * report. If `report()` is called multiple times during the same impairment
+     * (e.g. dragon shares cannot fully cover the loss), the same gross shortfall
+     * is re-emitted on each call.
+     *
+     * Integrators must not naively sum `loss` across consecutive `Reported`
+     * events to compute cumulative damage; doing so double-counts persistent
+     * impairments. Treat the event as a level signal, not a delta signal.
+     *
+     * @return profit Profit in assets from underlying value appreciation since the last report
+     * @return loss Loss in assets — gross shortfall (level), not a delta. See event semantics above.
      */
     function report()
         public
@@ -505,6 +516,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         S.lastReport = uint96(block.timestamp);
         YS.lastReportedRate = currentRate;
         emit Harvest(msg.sender, currentRate.rayToWad());
+        // `loss` here is a gross shortfall (level), not a delta; see report() NatSpec.
         emit Reported(profit, loss);
 
         return (profit, loss);

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -41,9 +41,10 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         uint256 dragonRouterDebtInAssetValue; // Track the underlying-asset-value debt owed to dragon router
     }
 
-    // exchange rate storage slot
+    // ERC-7201 namespaced storage slot for yield-skimming state.
+    // Formula: keccak256(abi.encode(uint256(keccak256(NAMESPACE)) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant YIELD_SKIMMING_STORAGE_SLOT =
-        bytes32(uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1);
+        keccak256(abi.encode(uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1)) & ~bytes32(uint256(0xff));
 
     /// @dev Event emitted when harvest is performed
     event Harvest(address indexed caller, uint256 currentRate);

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -802,8 +802,12 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             uint256 dragonBurn = Math.min(lossValue, dragonBalance);
             _burn(S, S.dragonRouter, dragonBurn);
 
-            // update the dragon value debt
-            YS.dragonRouterDebtInAssetValue -= dragonBurn;
+            // Saturating subtraction: dragon-balance and dragon-debt should stay in sync,
+            // but if accounting drifts (e.g. balance > debt) the raw `-=` would underflow
+            // and brick loss protection. Match the defensive pattern used in redeem/withdraw.
+            YS.dragonRouterDebtInAssetValue = YS.dragonRouterDebtInAssetValue > dragonBurn
+                ? YS.dragonRouterDebtInAssetValue - dragonBurn
+                : 0;
 
             emit DonationBurned(S.dragonRouter, dragonBurn, currentRate.rayToWad());
         }

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -815,7 +815,13 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
     /**
      * @notice Finalizes the dragon router change with proper debt accounting migration
-     * @dev Migrates debt tracking when dragon router changes to maintain correct accounting
+     * @dev Migrates debt tracking when dragon router changes to maintain correct accounting.
+     *      The solvency check runs AFTER debt migration so that:
+     *      - Migrations that would restore solvency (new dragon holds user shares whose
+     *        conversion to dragon debt drops user debt below vault value) are allowed.
+     *      - Migrations that would create insolvency (old dragon balance becoming user
+     *        debt pushes user debt above vault value) are blocked.
+     *      A pre-migration check inspecting the old state misclassifies both directions.
      */
     function finalizeDragonRouterChange() external override {
         StrategyData storage S = _strategyStorage();
@@ -830,10 +836,6 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         // Get balances before changing the router
         uint256 oldDragonBalance = _balanceOf(S, oldDragonRouter);
         uint256 newDragonBalance = _balanceOf(S, newDragonRouter);
-
-        if (oldDragonBalance > 0) {
-            _requireDragonSolvency(oldDragonRouter);
-        }
 
         // Migrate debt accounting:
         // 1. Old dragon router's balance becomes user debt
@@ -854,6 +856,12 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             } else {
                 YS.totalDebtOwedToUserInAssetValue = 0;
             }
+        }
+
+        // Post-migration solvency check: only enforced when burning is enabled
+        // (mirrors the gating used by _requireDragonSolvency / _maxDragonRedeemableShares).
+        if (S.enableBurning) {
+            require(!_isVaultInsolvent(), "Router change would cause insolvency");
         }
 
         // Now call the parent implementation to actually change the router

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -845,6 +845,12 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         address oldDragonRouter = S.dragonRouter;
         address newDragonRouter = S.pendingDragonRouter;
 
+        // Burn any stale junior loss buffer before snapshotting balances so a
+        // dust transfer to the old dragon cannot decide migration accounting.
+        if (S.enableBurning) {
+            _applyDragonLossProtectionIfNeeded(S, YS);
+        }
+
         // Get balances before changing the router
         uint256 oldDragonBalance = _balanceOf(S, oldDragonRouter);
         uint256 newDragonBalance = _balanceOf(S, newDragonRouter);

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -15,7 +15,10 @@ import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.s
  * @custom:security-contact security@golem.foundation
  * @notice Specialized TokenizedStrategy for yield-bearing assets with appreciating exchange rates.
  * @dev Mechanism:
- *      - Shares represent ETH value (1 share = 1 ETH value) rather than asset amounts
+ *      - Shares represent value-units of the underlying asset at the strategy exchange rate
+ *        (1 share = 1 unit of underlying-asset value as returned by getCurrentExchangeRate)
+ *        rather than raw asset amounts. Note: the underlying-asset value is NOT pegged to native ETH,
+ *        even when the asset references stETH/wstETH/rETH — value follows the live exchange rate.
  *      - On report(), compares total vault value (assets * rate) vs total outstanding shares
  *        • Profit: mints dragon shares equal to excess value above total share debt
  *        • Loss: burns dragon shares (if enabled) up to available balance to cover shortfall
@@ -33,9 +36,9 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
     /// @dev Storage for yield skimming strategy
     struct YieldSkimmingStorage {
-        uint256 totalDebtOwedToUserInAssetValue; // Track ETH value owed to users only
+        uint256 totalDebtOwedToUserInAssetValue; // Track underlying-asset-value debt owed to users only
         uint256 lastReportedRate; // Track the last reported rate
-        uint256 dragonRouterDebtInAssetValue; // Track the ETH value owed to dragon router
+        uint256 dragonRouterDebtInAssetValue; // Track the underlying-asset-value debt owed to dragon router
     }
 
     // exchange rate storage slot
@@ -61,7 +64,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      *      - Tracks asset value debt
      * @param assets Amount of assets to deposit in asset base units
      * @param receiver Address to receive the shares (cannot be dragon router)
-     * @return shares Amount of shares minted (1 share = 1 asset value)
+     * @return shares Amount of shares minted (1 share = 1 unit of underlying-asset value at the current rate)
      */
     function deposit(uint256 assets, address receiver) public virtual override nonReentrant returns (uint256 shares) {
         // Block deposits during vault insolvency
@@ -86,7 +89,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         // Checking max deposit will also check if shutdown.
         require(assets <= _maxDeposit(S, receiver), "ERC4626: deposit more than max");
 
-        // Issue shares based on value (1 share = 1 ETH value, except in case of uncovered loss)
+        // Issue shares based on value (1 share = 1 unit of underlying-asset value, except in case of uncovered loss)
         shares = assets.mulDiv(currentRate, WadRayMath.RAY);
         require(shares != 0, "ZERO_SHARES");
 
@@ -101,10 +104,10 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
     /**
      * @notice Mint exact shares from the strategy with value debt tracking
-     * @dev Implements insolvency protection and tracks ETH value debt
+     * @dev Implements insolvency protection and tracks underlying-asset-value debt
      * @param shares Amount of shares to mint
      * @param receiver Address to receive the shares
-     * @return assets Amount of assets deposited in asset base units (1 share = 1 ETH value, except in case of uncovered loss)
+     * @return assets Amount of assets deposited in asset base units (1 share = 1 unit of underlying-asset value, except in case of uncovered loss)
      */
     function mint(uint256 shares, address receiver) public virtual override nonReentrant returns (uint256 assets) {
         // Block mints during vault insolvency
@@ -124,7 +127,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         // Checking max mint will also check if shutdown
         require(shares <= _maxMint(S, receiver), "ERC4626: mint more than max");
 
-        // Calculate assets needed based on value (1 share = 1 ETH value, except in case of uncovered loss)
+        // Calculate assets needed based on value (1 share = 1 unit of underlying-asset value, except in case of uncovered loss)
         assets = shares.mulDiv(WadRayMath.RAY, currentRate, Math.Rounding.Ceil);
         require(assets != 0, "ZERO_ASSETS");
 
@@ -139,7 +142,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
 
     /**
      * @notice Redeem shares from the strategy with value debt tracking
-     * @dev Shares represent ETH value (1 share = 1 ETH value, except in case of uncovered loss)
+     * @dev Shares represent underlying-asset value (1 share = 1 unit of underlying-asset value at the current rate, except in case of uncovered loss)
      * @param shares Amount of shares to redeem
      * @param receiver Address to receive the assets
      * @param owner Address whose shares are being redeemed
@@ -162,7 +165,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         }
 
         // Calculate actual value returned for debt tracking (before redemption)
-        uint256 valueToReturn = shares; // 1 share = 1 ETH value, except in case of uncovered loss (regardless of actual assets received)
+        uint256 valueToReturn = shares; // 1 share = 1 unit of underlying-asset value, except in case of uncovered loss (regardless of actual assets received)
 
         // Validate inputs and check limits (replaces super.redeem validation)
         require(shares <= _maxRedeem(S, owner), "ERC4626: redeem more than max");
@@ -222,7 +225,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         require((shares = _convertToShares(S, assets, Math.Rounding.Ceil)) != 0, "ZERO_SHARES");
 
         // Calculate actual value returned for debt tracking (before withdrawal)
-        uint256 valueToReturn = shares; // 1 share = 1 ETH value
+        uint256 valueToReturn = shares; // 1 share = 1 unit of underlying-asset value
 
         // Check if dragon withdrawal would compromise vault solvency
         _requireDragonSolvencyAfterOperation(owner, shares);
@@ -342,24 +345,24 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
     }
 
     /**
-     * @notice Get the total ETH value debt owed to users
-     * @return Total user debt in asset value
+     * @notice Get the total underlying-asset-value debt owed to users
+     * @return Total user debt in underlying-asset value units
      */
     function gettotalDebtOwedToUserInAssetValue() external view returns (uint256) {
         return _strategyYieldSkimmingStorage().totalDebtOwedToUserInAssetValue;
     }
 
     /**
-     * @notice Get the total ETH value debt owed to dragon router
-     * @return Total dragon router debt in asset value
+     * @notice Get the total underlying-asset-value debt owed to dragon router
+     * @return Total dragon router debt in underlying-asset value units
      */
     function getDragonRouterDebtInAssetValue() external view returns (uint256) {
         return _strategyYieldSkimmingStorage().dragonRouterDebtInAssetValue;
     }
 
     /**
-     * @notice Get the total ETH value debt owed to both users and dragon router combined
-     * @return Total debt in asset value combining users and dragon router
+     * @notice Get the total underlying-asset-value debt owed to both users and dragon router combined
+     * @return Total debt in underlying-asset value units combining users and dragon router
      */
     function getTotalValueDebtInAssetValue() external view returns (uint256) {
         YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
@@ -478,7 +481,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
             // Yield captured! Mint profit shares to dragon
             uint256 profitValue = currentValue - YS.totalDebtOwedToUserInAssetValue - YS.dragonRouterDebtInAssetValue;
 
-            uint256 profitShares = profitValue; // 1 share = 1 ETH value, except in case of uncovered loss
+            uint256 profitShares = profitValue; // 1 share = 1 unit of underlying-asset value, except in case of uncovered loss
 
             // Convert profit value to assets for reporting
             profit = profitValue.mulDiv(WadRayMath.RAY, currentRate);
@@ -527,7 +530,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      * @param S Strategy storage
      * @param assets Amount of assets to convert
      * @param rounding Rounding mode for division
-     * @return Amount of shares equivalent in value (1 share = 1 ETH value, except in case of uncovered loss)
+     * @return Amount of shares equivalent in value (1 share = 1 unit of underlying-asset value, except in case of uncovered loss)
      */
     function _convertToShares(
         StrategyData storage S,
@@ -679,7 +682,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         YieldSkimmingStorage storage YS = _strategyYieldSkimmingStorage();
         StrategyData storage S = _strategyStorage();
 
-        // Direct transfer: shares represent ETH value 1:1 in this system
+        // Direct transfer: shares represent underlying-asset value 1:1 in this system
         if (from == S.dragonRouter) {
             // Dragon sends shares: dragon loses debt obligation, users gain debt obligation
             require(YS.dragonRouterDebtInAssetValue >= transferAmount, "Insufficient dragon debt");
@@ -773,7 +776,7 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
      * @dev Internal function to handle loss protection by burning dragon shares
      * @param S Strategy storage pointer
      * @param YS Yield skimming storage pointer
-     * @param lossValue Loss amount in ETH value terms
+     * @param lossValue Loss amount in underlying-asset value terms
      * @param currentRate Current exchange rate in RAY format
      * @return loss Loss amount in asset terms for reporting
      */

--- a/test/unit/strategies/yieldSkimming/AccessControl.t.sol
+++ b/test/unit/strategies/yieldSkimming/AccessControl.t.sol
@@ -302,9 +302,10 @@ contract AccessControlTest is Setup {
         vm.prank(management);
         strategy.setEnableBurning(true);
 
-        // Act + Assert: finalize should revert during insolvency
+        // Act + Assert: finalize should revert because the post-migration state is
+        // still insolvent. Here oldDragonShares move to user debt, which only worsens the gap.
         skip(14 days);
-        vm.expectRevert("Dragon cannot operate during insolvency");
+        vm.expectRevert("Router change would cause insolvency");
         strategy.finalizeDragonRouterChange();
     }
 

--- a/test/unit/strategies/yieldSkimming/BranchCoverage.t.sol
+++ b/test/unit/strategies/yieldSkimming/BranchCoverage.t.sol
@@ -979,7 +979,10 @@ contract YieldSkimmingBranchCoverageTest is Setup {
 
         assertTrue(IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent());
 
-        vm.expectRevert("Dragon cannot operate during insolvency");
+        // Solvency check is now post-migration. Old dragon balance becoming user debt
+        // only worsens the gap here, so the post-state remains insolvent and finalize
+        // reverts with the new error message.
+        vm.expectRevert("Router change would cause insolvency");
         strategy.finalizeDragonRouterChange();
     }
 
@@ -1548,7 +1551,7 @@ contract YieldSkimmingBranchCoverageTest is Setup {
         // Deposit first so we have shares
         mintAndDepositIntoStrategy(strategy, user1, 100e18);
 
-        // Set rate to 0 and manipulate debts to 0 so vault stays "solvent"
+        // Set rate to 0 and manipulate debts to 0 so vault stays "solvent".
         MockStrategySkimming(address(strategy)).updateExchangeRate(0);
         vm.store(address(strategy), YS_SLOT, bytes32(uint256(0))); // totalDebtOwedToUserInAssetValue = 0
         bytes32 dragonDebtSlot = bytes32(uint256(YS_SLOT) + 2);

--- a/test/unit/strategies/yieldSkimming/BranchCoverage.t.sol
+++ b/test/unit/strategies/yieldSkimming/BranchCoverage.t.sol
@@ -15,6 +15,14 @@ contract YieldSkimmingBranchCoverageTest is Setup {
     address internal user1;
     address internal user2;
 
+    /// @dev ERC-7201 namespaced slot for YieldSkimmingStorage.
+    ///      Field offsets:
+    ///        slot+0  totalDebtOwedToUserInAssetValue
+    ///        slot+1  lastReportedRate
+    ///        slot+2  dragonRouterDebtInAssetValue
+    bytes32 internal constant YS_SLOT =
+        keccak256(abi.encode(uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1)) & ~bytes32(uint256(0xff));
+
     function setUp() public override {
         super.setUp();
         dragon = strategy.dragonRouter();
@@ -1329,11 +1337,8 @@ contract YieldSkimmingBranchCoverageTest is Setup {
         uint256 dragonBalance = strategy.balanceOf(dragon);
         assertGt(dragonBalance, 0, "Dragon should have shares");
 
-        // Directly reduce dragonRouterDebtInAssetValue to be less than dragon balance
-        // YieldSkimmingStorage slot: keccak256("octant.yieldSkimming.exchangeRate") - 1
-        // dragonRouterDebtInAssetValue is at offset 2 from the base slot
-        bytes32 baseSlot = bytes32(uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1);
-        bytes32 dragonDebtSlot = bytes32(uint256(baseSlot) + 2);
+        // Directly reduce dragonRouterDebtInAssetValue to be less than dragon balance.
+        bytes32 dragonDebtSlot = bytes32(uint256(YS_SLOT) + 2);
         // Set dragon debt to 1 wei (much less than dragon balance)
         vm.store(address(strategy), dragonDebtSlot, bytes32(uint256(1)));
 
@@ -1370,9 +1375,8 @@ contract YieldSkimmingBranchCoverageTest is Setup {
         // To trigger the else, we need userDebt < newDragonBalance.
         // Use vm.store to reduce user debt below newDragonBalance.
 
-        bytes32 baseSlot = bytes32(uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1);
         // totalDebtOwedToUserInAssetValue is at offset 0
-        vm.store(address(strategy), baseSlot, bytes32(uint256(100e18)));
+        vm.store(address(strategy), YS_SLOT, bytes32(uint256(100e18)));
         // Now userDebt = 100e18 < newDragonBalance = 200e18
 
         uint256 userDebt = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
@@ -1546,9 +1550,8 @@ contract YieldSkimmingBranchCoverageTest is Setup {
 
         // Set rate to 0 and manipulate debts to 0 so vault stays "solvent"
         MockStrategySkimming(address(strategy)).updateExchangeRate(0);
-        bytes32 baseSlot = bytes32(uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1);
-        vm.store(address(strategy), baseSlot, bytes32(uint256(0))); // totalDebtOwedToUserInAssetValue = 0
-        bytes32 dragonDebtSlot = bytes32(uint256(baseSlot) + 2);
+        vm.store(address(strategy), YS_SLOT, bytes32(uint256(0))); // totalDebtOwedToUserInAssetValue = 0
+        bytes32 dragonDebtSlot = bytes32(uint256(YS_SLOT) + 2);
         vm.store(address(strategy), dragonDebtSlot, bytes32(uint256(0))); // dragonRouterDebtInAssetValue = 0
 
         // Now vault has no debts but rate is 0 -> solvent + rate 0

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingDragonDebtSubtraction.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingDragonDebtSubtraction.t.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { BaseYieldSkimmingStrategy } from "src/strategies/yieldSkimming/BaseYieldSkimmingStrategy.sol";
+import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
+import { IYieldSkimmingStrategy } from "src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol";
+
+/// @dev Concrete strategy mirroring the pattern in YieldSkimmingStaleDragonBurn tests.
+contract TestYieldSkimmingStrategyForDebtSub is BaseYieldSkimmingStrategy {
+    uint256 private _rate;
+
+    constructor(
+        address _asset,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress
+    )
+        BaseYieldSkimmingStrategy(
+            _asset,
+            "Test YieldSkim",
+            "tsYS",
+            _management,
+            _keeper,
+            _emergencyAdmin,
+            _donationAddress,
+            _enableBurning,
+            _tokenizedStrategyAddress
+        )
+    {
+        _rate = 1e18;
+    }
+
+    function setExchangeRate(uint256 newRate) external {
+        _rate = newRate;
+    }
+
+    function _getCurrentExchangeRate() internal view override returns (uint256) {
+        return _rate;
+    }
+
+    function decimalsOfExchangeRate() public pure override returns (uint256) {
+        return 18;
+    }
+}
+
+/// @notice Bailsec #39 — `_handleDragonLossProtection` previously used a raw
+///         subtraction `YS.dragonRouterDebtInAssetValue -= dragonBurn`. If
+///         `dragonBalance` ever exceeded `dragonRouterDebtInAssetValue` (drift
+///         from rebasing tokens, future code paths, or storage manipulation),
+///         the burn would underflow and brick loss protection. The fix mirrors
+///         the saturating pattern already used in redeem/withdraw.
+contract YieldSkimmingDragonDebtSubtractionTest is Test {
+    TestYieldSkimmingStrategyForDebtSub internal strategy;
+    ERC20Mock internal asset;
+
+    address internal management = address(0x1);
+    address internal keeper = address(0x2);
+    address internal emergencyAdmin = address(0x3);
+    address internal dragonRouter = address(0x4);
+    address internal alice = address(0xA);
+
+    ITokenizedStrategy internal tokenized;
+    YieldSkimmingTokenizedStrategy internal ys;
+
+    /// @dev ERC-7201 namespaced slot for YieldSkimmingStorage; field offsets:
+    ///        slot+0 totalDebtOwedToUserInAssetValue
+    ///        slot+1 lastReportedRate
+    ///        slot+2 dragonRouterDebtInAssetValue
+    bytes32 internal constant YS_SLOT =
+        keccak256(abi.encode(uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1)) & ~bytes32(uint256(0xff));
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        YieldSkimmingTokenizedStrategy implementation = new YieldSkimmingTokenizedStrategy();
+        strategy = new TestYieldSkimmingStrategyForDebtSub(
+            address(asset),
+            management,
+            keeper,
+            emergencyAdmin,
+            dragonRouter,
+            true, // enableBurning
+            address(implementation)
+        );
+        tokenized = ITokenizedStrategy(address(strategy));
+        ys = YieldSkimmingTokenizedStrategy(address(strategy));
+
+        vm.prank(management);
+        strategy.setLossLimitRatio(9999);
+    }
+
+    function _depositUser(address user, uint256 amount) internal {
+        asset.mint(user, amount);
+        vm.prank(user);
+        asset.approve(address(strategy), amount);
+        vm.prank(user);
+        tokenized.deposit(amount, user);
+    }
+
+    /// @notice Simulate accounting drift where dragon balance > dragon debt, then
+    ///         trigger a loss whose burn amount exceeds the (corrupted) debt. The
+    ///         saturating subtraction should keep the burn going; without it the
+    ///         transaction reverts with an arithmetic underflow.
+    function test_lossProtectionSurvivesDebtBelowBurn() public {
+        _depositUser(alice, 100 ether);
+
+        // Generate profit so dragon is minted shares with synced balance/debt.
+        strategy.setExchangeRate(2e18); // double the rate => +100 value
+        vm.prank(keeper);
+        tokenized.report();
+
+        uint256 dragonBalance = tokenized.balanceOf(dragonRouter);
+        uint256 dragonDebt = ys.getDragonRouterDebtInAssetValue();
+        assertEq(dragonBalance, dragonDebt, "balance and debt should start synced");
+        assertGt(dragonBalance, 0, "dragon should hold shares after profit");
+
+        // Drift: shrink dragonRouterDebtInAssetValue to 1 wei but leave the
+        // dragon's share balance untouched. Now dragonBalance >> debt, so the
+        // next burn will subtract more than the tracked debt.
+        bytes32 dragonDebtSlot = bytes32(uint256(YS_SLOT) + 2);
+        vm.store(address(strategy), dragonDebtSlot, bytes32(uint256(1)));
+        assertEq(ys.getDragonRouterDebtInAssetValue(), 1, "drift not applied");
+
+        // Drop the rate so the vault is insolvent and a burn is required.
+        strategy.setExchangeRate(5e17); // halve from initial; assets * 0.5 < userDebt + dragonDebt
+        assertTrue(ys.isVaultInsolvent(), "vault should be insolvent");
+
+        // With the fix: report() processes the burn cleanly and saturates debt to 0.
+        // Without the fix: this call reverts with `panic: arithmetic underflow`.
+        vm.prank(keeper);
+        tokenized.report();
+
+        assertEq(ys.getDragonRouterDebtInAssetValue(), 0, "debt must saturate to zero");
+        assertLt(tokenized.balanceOf(dragonRouter), dragonBalance, "dragon shares should have been burned");
+    }
+}

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingDragonRouterMigrationSolvency.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingDragonRouterMigrationSolvency.t.sol
@@ -22,6 +22,7 @@ contract YieldSkimmingDragonRouterMigrationSolvencyTest is Setup {
     address internal charlie;
 
     uint256 internal constant DEPOSIT = 100e18;
+    uint256 internal constant DUST_SHARES = 1;
 
     function setUp() public override {
         super.setUp();
@@ -119,5 +120,71 @@ contract YieldSkimmingDragonRouterMigrationSolvencyTest is Setup {
         // Assert no state mutation happened (router unchanged, pending preserved).
         assertEq(strategy.dragonRouter(), donationAddress, "router unchanged on revert");
         assertEq(strategy.pendingDragonRouter(), charlie, "pending preserved on revert");
+    }
+
+    /// @notice Bailsec #25: a dust transfer to the old dragon must not leave
+    ///         stale junior shares behind to affect migration. When burning is
+    ///         enabled and the vault is insolvent, finalize first applies the
+    ///         same lazy dragon burn used by user exits, then snapshots balances.
+    function test_finalize_burnsOldDragonDustBeforeMigrationWhenBurningEnabled() public {
+        // Alice and Bob deposit at rate 1.0. Bob will become the new dragon.
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        mintAndDepositIntoStrategy(strategy, bob, 50e18);
+
+        vm.prank(management);
+        strategy.setDragonRouter(bob);
+        skip(14 days);
+
+        // Rate drops: pre-migration user debt is 150, vault value is 120, so
+        // the vault is insolvent. Migrating Bob's 50 shares to dragon debt
+        // restores user-debt coverage.
+        MockStrategySkimming(address(strategy)).updateExchangeRate(8e17);
+        assertTrue(IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(), "pre-migration insolvent");
+
+        vm.prank(alice);
+        strategy.transfer(donationAddress, DUST_SHARES);
+
+        assertEq(strategy.balanceOf(donationAddress), DUST_SHARES, "old dragon has attacker dust");
+        assertEq(
+            IYieldSkimmingStrategy(address(strategy)).getDragonRouterDebtInAssetValue(),
+            DUST_SHARES,
+            "dust was classified as dragon debt"
+        );
+
+        strategy.finalizeDragonRouterChange();
+
+        assertEq(strategy.dragonRouter(), bob, "router migrated");
+        assertEq(strategy.balanceOf(donationAddress), 0, "old dragon dust was burned before migration");
+        assertEq(
+            IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue(),
+            DEPOSIT - DUST_SHARES,
+            "burned dust is not reclassified back into user debt"
+        );
+        assertFalse(IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(), "post-migration solvent");
+    }
+
+    /// @notice The issue #25 burn is gated by `enableBurning`. With burning
+    ///         disabled, finalize preserves the old dragon balance and follows
+    ///         the existing unrestricted dragon-operation policy.
+    function test_finalize_doesNotBurnOldDragonDustWhenBurningDisabled() public {
+        vm.prank(management);
+        strategy.setEnableBurning(false);
+
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+        mintAndDepositIntoStrategy(strategy, bob, 50e18);
+
+        vm.prank(management);
+        strategy.setDragonRouter(bob);
+        skip(14 days);
+
+        MockStrategySkimming(address(strategy)).updateExchangeRate(8e17);
+
+        vm.prank(alice);
+        strategy.transfer(donationAddress, DUST_SHARES);
+
+        strategy.finalizeDragonRouterChange();
+
+        assertEq(strategy.dragonRouter(), bob, "router migrated");
+        assertEq(strategy.balanceOf(donationAddress), DUST_SHARES, "old dragon dust is preserved");
     }
 }

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingDragonRouterMigrationSolvency.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingDragonRouterMigrationSolvency.t.sol
@@ -1,0 +1,123 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Setup, IMockStrategy } from "./utils/Setup.sol";
+import { IYieldSkimmingStrategy } from "src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol";
+import { MockStrategySkimming } from "test/mocks/core/tokenized-strategies/MockStrategySkimming.sol";
+
+/// @notice `finalizeDragonRouterChange` previously evaluated solvency
+///         on the OLD state (before debt migration). That misclassified both
+///         directions:
+///           - Migrations that would RESTORE solvency (new dragon holds user shares
+///             whose conversion to dragon debt drops user debt below vault value)
+///             were blocked because the old state was insolvent.
+///           - Migrations that would CAUSE insolvency (old dragon balance becoming
+///             user debt pushes user debt above vault value) were allowed because
+///             the old state was solvent.
+///         The fix runs the solvency check after debt migration so the post-state
+///         drives the decision.
+contract YieldSkimmingDragonRouterMigrationSolvencyTest is Setup {
+    address internal alice;
+    address internal bob;
+    address internal charlie;
+
+    uint256 internal constant DEPOSIT = 100e18;
+
+    function setUp() public override {
+        super.setUp();
+        alice = makeAddr("alice");
+        bob = makeAddr("bob");
+        charlie = makeAddr("charlie");
+
+        // Issue 29's check only fires when burning is enabled — mirror the existing
+        // suite's pattern of enabling it before exercising migration logic.
+        vm.prank(management);
+        strategy.setEnableBurning(true);
+    }
+
+    /// @notice Migration that would RESTORE solvency must succeed under the fix.
+    ///         Pre-fix code reverts with "Dragon cannot operate during insolvency"
+    ///         because the pre-migration state is still insolvent; post-fix code
+    ///         executes the migration first, which moves new-dragon shares from
+    ///         user debt to dragon debt and drops user debt back below vault value.
+    function test_finalize_succeedsWhenMigrationRestoresSolvency() public {
+        // 1. Alice deposits at rate 1.0 → userDebt = 100, totalAssets = 100
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+
+        // 2. Rate climbs to 1.5; bob deposits 200 → bob shares = 200 * 1.5 = 300,
+        //    userDebt = 100 + 300 = 400, totalAssets = 300.
+        MockStrategySkimming(address(strategy)).updateExchangeRate(15e17);
+        mintAndDepositIntoStrategy(strategy, bob, 200e18);
+
+        // 3. Report at rate 1.5 mints profit shares to old dragon (donationAddress).
+        //    currentValue = 300 * 1.5 = 450, totalDebt = 400, profit = 50.
+        vm.prank(keeper);
+        strategy.report();
+        uint256 oldDragonShares = strategy.balanceOf(donationAddress);
+        assertGt(oldDragonShares, 0, "old dragon must hold shares for the bug to trigger");
+
+        // 4. Pending migration to bob (who currently holds 300 user shares).
+        vm.prank(management);
+        strategy.setDragonRouter(bob);
+        skip(14 days);
+
+        // 5. Rate drops to 0.6 → vault value = 300 * 0.6 = 180.
+        //    userDebt = 400 (still > 180) → vault tracked-insolvent.
+        MockStrategySkimming(address(strategy)).updateExchangeRate(6e17);
+        assertTrue(
+            IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(),
+            "vault must be insolvent in the pre-migration state"
+        );
+
+        // 6. Post-fix: migration runs first.
+        //      userDebt = 400 + oldDragonShares - 300  (≈ 150 once oldDragonShares ≈ 50)
+        //    vault value 180 > userDebt → solvent → migration succeeds.
+        //    Pre-fix this call would revert with "Dragon cannot operate during insolvency".
+        strategy.finalizeDragonRouterChange();
+
+        assertEq(strategy.dragonRouter(), bob, "router migrated");
+        assertFalse(
+            IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(),
+            "post-migration state must be solvent"
+        );
+    }
+
+    /// @notice Migration that would CAUSE insolvency must revert under the fix.
+    ///         Pre-fix code lets it through because the pre-migration state is solvent,
+    ///         leaving the vault permanently undercollateralised after finalize. The
+    ///         fix evaluates the post-migration state and rejects the change.
+    function test_finalize_revertsWhenMigrationWouldCauseInsolvency() public {
+        // 1. Alice deposits at rate 1.0 → userDebt = 100, totalAssets = 100
+        mintAndDepositIntoStrategy(strategy, alice, DEPOSIT);
+
+        // 2. Profit cycle: rate to 2.0 → currentValue = 200, profit = 100, dragon
+        //    receives 100 shares, dragonDebt = 100. totalSupply = 200.
+        MockStrategySkimming(address(strategy)).updateExchangeRate(2e18);
+        vm.prank(keeper);
+        strategy.report();
+        uint256 oldDragonShares = strategy.balanceOf(donationAddress);
+        assertGt(oldDragonShares, 0, "dragon must hold shares for migration to convert");
+
+        // 3. Migrate to charlie (fresh address with no shares).
+        vm.prank(management);
+        strategy.setDragonRouter(charlie);
+        skip(14 days);
+
+        // 4. Rate dips to 1.4 → vault value = 100 * 1.4 = 140.
+        //    Pre-migration: userDebt = 100 < 140 → SOLVENT. Pre-fix would let migration through.
+        //    Post-migration: userDebt = 100 + oldDragonShares ≈ 200 > 140 → INSOLVENT.
+        MockStrategySkimming(address(strategy)).updateExchangeRate(14e17);
+        assertFalse(
+            IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(),
+            "pre-migration state should still be solvent (the bug)"
+        );
+
+        // 5. Post-fix: revert because the migration would push user debt above vault value.
+        vm.expectRevert("Router change would cause insolvency");
+        strategy.finalizeDragonRouterChange();
+
+        // Assert no state mutation happened (router unchanged, pending preserved).
+        assertEq(strategy.dragonRouter(), donationAddress, "router unchanged on revert");
+        assertEq(strategy.pendingDragonRouter(), charlie, "pending preserved on revert");
+    }
+}

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingStorageSlot.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingStorageSlot.t.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.18;
+
+import { Setup, IMockStrategy } from "./utils/Setup.sol";
+import { IYieldSkimmingStrategy } from "src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol";
+
+/// @notice Verifies that YIELD_SKIMMING_STORAGE_SLOT conforms to the ERC-7201 namespaced
+///         storage formula. Bailsec #38 flagged that the constant previously omitted the
+///         outer keccak256(abi.encode(...)) wrap and the alignment mask, deviating from the
+///         standard. This test pins the canonical derivation and proves that namespaced
+///         state actually lands at that slot.
+contract YieldSkimmingStorageSlotTest is Setup {
+    /// @dev Canonical ERC-7201 derivation for the namespace used by the strategy.
+    bytes32 internal constant EXPECTED_SLOT =
+        keccak256(abi.encode(uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1)) & ~bytes32(uint256(0xff));
+
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function test_storageSlot_matchesERC7201Derivation() public pure {
+        // Mask must be applied: low byte is zero.
+        assertEq(uint256(EXPECTED_SLOT) & 0xff, 0, "ERC-7201 alignment mask not applied");
+
+        // Slot must derive from the outer keccak256(abi.encode(inner)) wrap (not bytes32(inner)).
+        uint256 inner = uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1;
+        bytes32 nonCompliant = bytes32(inner);
+        assertTrue(EXPECTED_SLOT != nonCompliant, "slot must not equal pre-fix non-compliant derivation");
+    }
+
+    function test_storageSlot_namespacedStateLandsAtCanonicalSlot() public {
+        // Drive the namespaced storage by depositing — this writes
+        // YS.totalDebtOwedToUserInAssetValue to the namespaced slot.
+        uint256 depositAmount = 1e18;
+        mintAndDepositIntoStrategy(strategy, user, depositAmount);
+
+        // Namespaced struct layout:
+        //   slot+0  totalDebtOwedToUserInAssetValue
+        //   slot+1  lastReportedRate
+        //   slot+2  dragonRouterDebtInAssetValue
+        bytes32 word0 = vm.load(address(strategy), EXPECTED_SLOT);
+        bytes32 word1 = vm.load(address(strategy), bytes32(uint256(EXPECTED_SLOT) + 1));
+
+        uint256 userDebt = uint256(word0);
+        uint256 lastRate = uint256(word1);
+
+        // Cross-check via the public accessor: storage at the canonical ERC-7201 slot
+        // must match what the contract reports.
+        uint256 reportedDebt = IYieldSkimmingStrategy(address(strategy)).gettotalDebtOwedToUserInAssetValue();
+        assertEq(userDebt, reportedDebt, "user debt not at canonical ERC-7201 slot");
+        assertGt(userDebt, 0, "deposit should have set user debt");
+
+        uint256 reportedRate = IYieldSkimmingStrategy(address(strategy)).getLastRateRay();
+        assertEq(lastRate, reportedRate, "lastReportedRate not at canonical ERC-7201 slot");
+        assertGt(lastRate, 0, "deposit should have set lastReportedRate");
+    }
+}


### PR DESCRIPTION
## Summary

Bailsec audit fixes for the **Yield-Skim** subcategory. This PR now contains six independently reviewable commits: one issue, one fix. Issue 36 is intentionally ACK/no-code after the earlier unsafe donation-floor fix and revert were removed from the final history.

| Commit | Issue | Severity | Subject |
|---|---:|---|---|
| `df5db0cc` | 41 | Info | Clarify share value is underlying-asset units, not native ETH (NatSpec) |
| `c38082d6` | 38 | Info | Conform `YIELD_SKIMMING_STORAGE_SLOT` to ERC-7201 and realign slot-based tests |
| `3e9555ec` | 39 | Info | Saturate dragon-debt subtraction in `_handleDragonLossProtection` |
| `27f8e29e` | 29 | Medium | Move solvency check after dragon-router debt migration and align insolvency docs |
| `98cb0ad2` | 35 | Info | Clarify `Reported.loss` is a gross shortfall level signal in ABI-facing docs |
| `bc9fc1ef` | 25 | Medium | Burn old dragon dust before router-migration balance snapshots |

### Highlights

- **25 (Medium)**: `finalizeDragonRouterChange` now applies the existing lazy dragon loss-protection burn before snapshotting old/new router balances when burning is enabled. This consumes dust sent to the old dragon during insolvency instead of letting a permissionless transfer affect migration accounting. A paired regression test confirms burning-disabled mode preserves the old unrestricted behavior and does not burn.
- **29 (Medium)**: Solvency is now evaluated on the post-migration state in `finalizeDragonRouterChange`. Migrations that restore solvency can finalize, and migrations that would create insolvency revert with `"Router change would cause insolvency"`. Public insolvency docs now match the implementation: user debt only, with dragon debt excluded as junior loss-buffer accounting.
- **35 (Info)**: `Reported.loss` is documented as a gross shortfall level for YieldSkimming, not a per-report delta. The clarification is now in the YieldSkimming report override, the emit-site comment, and shared ABI-facing event/report docs for indexers.
- **38 (Info)**: The storage slot now follows the ERC-7201 formula. Existing `vm.store` call sites were moved into the same commit so the ERC-7201 commit is self-contained and independently green.
- **39 (Info)**: Dragon-debt subtraction now saturates, mirroring the existing redeem/withdraw accounting pattern and preventing underflow if dragon balance ever exceeds tracked dragon debt.
- **41 (Info)**: NatSpec now describes share value in underlying-asset units at the strategy exchange rate, not native ETH.
- **36 (ACK / no code)**: The donation-floor approach was removed from history. Donations remain invisible until `report()`, preserving the original behavior and avoiding the withdrawal-underflow DoS introduced by the removed approach.

### Skipped / Out Of Scope

- **ACK**: 23, 24, 26, 27, 32, 33, 34, 36, 37, 40
- **DISMISS**: 28, 30
- **Pending team discussion**: 31

## Test Plan

- [x] Original per-commit signed replay: `git rebase --gpg-sign --exec "forge test --match-path 'test/unit/strategies/yieldSkimming/*.t.sol'" origin/develop`
  - [x] `df5db0cc`: 219/219 yield-skim unit tests pass
  - [x] `c38082d6`: 221/221 yield-skim unit tests pass
  - [x] `3e9555ec`: 222/222 yield-skim unit tests pass
  - [x] `27f8e29e`: 224/224 yield-skim unit tests pass
  - [x] `98cb0ad2`: 224/224 yield-skim unit tests pass
- [x] `forge test --match-path test/unit/strategies/yieldSkimming/YieldSkimmingDragonRouterMigrationSolvency.t.sol -vvv` (4/4)
- [x] `forge test --match-path 'test/unit/strategies/yieldSkimming/*.t.sol'` (226/226)
- [x] `YieldSkimmingStorageSlot.t.sol`: canonical ERC-7201 slot derivation and namespaced storage placement
- [x] `YieldSkimmingDragonDebtSubtraction.t.sol`: dragon debt below dragon balance plus loss no longer underflows; debt saturates to zero
- [x] `YieldSkimmingDragonRouterMigrationSolvency.t.sol`: restore-solvency + cause-insolvency + issue 25 dust-burn cases
- [x] `./node_modules/.bin/commitlint --from origin/develop --to HEAD`
- [x] `yarn format:check`
- [x] `git diff --check origin/develop...HEAD`
- [x] `yarn lint` (0 errors; existing warnings only)
