### PR TITLE
fix(aave): Bailsec audit fixes (44-51)

### DIFF
--- a/scripts/sol-semver.mjs
+++ b/scripts/sol-semver.mjs
@@ -587,6 +587,30 @@ async function prepareWorktreeAsync(worktreeDir) {
   await runAsync("forge", ["build", "--skip", "test", "--skip", "script"], { cwd: worktreeDir });
 }
 
+function overlayUnversionedChangedSourceFiles(worktrees, oldRef, newRef) {
+  const { changedFiles } = gatherChangedSolidityFiles(oldRef, newRef);
+  const overlaid = [];
+
+  for (const sourcePath of changedFiles) {
+    const oldPath = path.join(worktrees.old, sourcePath);
+    const newPath = path.join(worktrees.new, sourcePath);
+    if (!fs.existsSync(oldPath) || !fs.existsSync(newPath)) {
+      continue;
+    }
+
+    const oldSource = fs.readFileSync(oldPath, "utf8");
+    const newSource = fs.readFileSync(newPath, "utf8");
+    if (sourceDeclaresApiVersion(oldSource) || sourceDeclaresApiVersion(newSource)) {
+      continue;
+    }
+
+    fs.copyFileSync(newPath, oldPath);
+    overlaid.push(sourcePath);
+  }
+
+  return overlaid;
+}
+
 function inspectAbi(worktreeDir, contractId) {
   return runJson("forge", ["inspect", contractId, "abi", "--json"], { cwd: worktreeDir });
 }
@@ -1433,9 +1457,20 @@ async function main() {
       prepareWorktreeAsync(worktrees.old),
       prepareWorktreeAsync(worktrees.new)
     ]);
-    const buildFailure = buildResults.find((r) => r.status === "rejected");
-    if (buildFailure) {
-      throw buildFailure.reason;
+    const oldBuildFailed = buildResults[0].status === "rejected";
+    const newBuildFailed = buildResults[1].status === "rejected";
+    if (newBuildFailed) {
+      throw buildResults[1].reason;
+    }
+    if (oldBuildFailed) {
+      const overlaid = overlayUnversionedChangedSourceFiles(worktrees, oldRef, newRef);
+      if (overlaid.length === 0) {
+        throw buildResults[0].reason;
+      }
+      console.error(
+        `Old ref build failed; retrying after overlaying unversioned changed source files: ${overlaid.join(", ")}`
+      );
+      await prepareWorktreeAsync(worktrees.old);
     }
 
     if (opts.command === "diff") {

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -129,12 +129,6 @@ contract SwappingYieldForwarder is YieldForwarder {
     /// @param newBps New floor
     event MinSlippageBpsUpdated(uint16 oldBps, uint16 newBps);
 
-    /// @notice Emitted when an arbitrary token balance is forwarded to the receiver
-    /// @param token Address of the token whose balance was flushed
-    /// @param receiver Address that received the token balance
-    /// @param amount Amount of the token transferred
-    event TokenForwarded(address indexed token, address indexed receiver, uint256 amount);
-
     // ============================================
     // STATE
     // ============================================
@@ -327,22 +321,10 @@ contract SwappingYieldForwarder is YieldForwarder {
         emit YieldSwappedAndForwarded(strategy, receiver, shares, assetsIn, assetsOut);
     }
 
-    /**
-     * @notice Forwards the full balance of an arbitrary ERC-20 token to the immutable receiver
-     * @dev Allows either the keeper or the vault management role to recover token balances
-     *      that are outside the normal report/swap pipeline. The caller chooses only the token;
-     *      the destination remains fixed to `receiver`.
-     * @param token ERC-20 token whose balance should be flushed to the receiver
-     */
-    function forwardToken(address token) external nonReentrant {
+    /// @inheritdoc YieldForwarder
+    function _authorizeForwardToken() internal view override {
         if (msg.sender != keeper && msg.sender != ITokenizedStrategy(vault).management()) {
             revert OnlyVaultManagement();
         }
-
-        uint256 balance = IERC20(token).balanceOf(address(this));
-        if (balance == 0) return;
-
-        IERC20(token).safeTransfer(receiver, balance);
-        emit TokenForwarded(token, receiver, balance);
     }
 }

--- a/src/factories/AaveV3StrategyFactory.sol
+++ b/src/factories/AaveV3StrategyFactory.sol
@@ -19,6 +19,13 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
     /// @notice Aave V3 AddressesProvider on Ethereum mainnet
     address public constant AAVE_ADDRESSES_PROVIDER = 0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e;
 
+    /// @notice Aave V3 RewardsController on Ethereum mainnet.
+    /// @dev Wired into every deployed strategy so liquidity-mining emissions can be
+    ///      claimed on demand. The controller is a stable, canonical Aave contract;
+    ///      we hardcode it here rather than making it a per-deploy parameter to keep
+    ///      the factory surface small and to prevent operator misconfiguration.
+    address public constant AAVE_REWARDS_CONTROLLER = 0x8164Cc65827dcFe994AB23944CBC90e0aa80bFcb;
+
     /// @notice USDC token address (0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48 on Ethereum mainnet)
     address public constant USDC = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
 
@@ -60,6 +67,7 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
         bytes32 parameterHash = keccak256(
             abi.encode(
                 AAVE_ADDRESSES_PROVIDER,
+                AAVE_REWARDS_CONTROLLER,
                 USDC,
                 _name,
                 _symbol,
@@ -76,6 +84,7 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
             type(AaveV3Strategy).creationCode,
             abi.encode(
                 AAVE_ADDRESSES_PROVIDER,
+                AAVE_REWARDS_CONTROLLER,
                 USDC,
                 _name,
                 _symbol,
@@ -115,6 +124,7 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
         bytes32 parameterHash = keccak256(
             abi.encode(
                 AAVE_ADDRESSES_PROVIDER,
+                AAVE_REWARDS_CONTROLLER,
                 USDC,
                 _name,
                 _symbol,
@@ -131,6 +141,7 @@ contract AaveV3StrategyFactory is BaseStrategyFactory {
             type(AaveV3Strategy).creationCode,
             abi.encode(
                 AAVE_ADDRESSES_PROVIDER,
+                AAVE_REWARDS_CONTROLLER,
                 USDC,
                 _name,
                 _symbol,

--- a/src/strategies/yieldDonating/AaveV3Strategy.sol
+++ b/src/strategies/yieldDonating/AaveV3Strategy.sol
@@ -125,7 +125,15 @@ contract AaveV3Strategy is BaseHealthCheck {
 
     /**
      * @notice Returns maximum additional assets that can be deposited
-     * @dev Checks Aave V3 supply cap and subtracts current supply
+     * @dev Checks Aave V3 supply cap and subtracts current supply.
+     *
+     *      DUST CAVEAT: Aave mints aTokens proportional to `amount / liquidityIndex`.
+     *      For sub-unit deposits on a high-index reserve, the scaled mint amount can round
+     *      to zero and `pool.supply` reverts with `INVALID_MINT_AMOUNT`. This view does
+     *      NOT pre-filter such dust; integrators relying on `maxDeposit` should be prepared
+     *      for Aave reverts on amounts below the per-reserve scaled-unit floor.
+     *      A pre-flight check is intentionally omitted to keep the hot path cheap for
+     *      the typical case where deposits are far above the dust threshold.
      * @return limit Maximum additional deposit amount in asset base units
      */
     function availableDepositLimit(address /*_owner*/) public view override returns (uint256) {

--- a/src/strategies/yieldDonating/AaveV3Strategy.sol
+++ b/src/strategies/yieldDonating/AaveV3Strategy.sol
@@ -127,9 +127,6 @@ contract AaveV3Strategy is BaseHealthCheck {
     /// @notice Address of the Aave V3 pool
     IPool public immutable pool;
 
-    /// @notice Address of the pool data provider
-    IPoolDataProvider public immutable dataProvider;
-
     /// @notice Address of the aToken for the underlying asset
     address public immutable aToken;
 
@@ -175,12 +172,29 @@ contract AaveV3Strategy is BaseHealthCheck {
 
         addressesProvider = IPoolAddressesProvider(_addressesProvider);
         pool = IPool(addressesProvider.getPool());
-        dataProvider = IPoolDataProvider(addressesProvider.getPoolDataProvider());
 
-        // Derive aToken from pool's registry to ensure correctness
-        (address _aToken, , ) = dataProvider.getReserveTokensAddresses(_asset);
+        // Do NOT cache the data provider as immutable. Aave's `addressesProvider`
+        // rotates the `PoolDataProvider` over time (the Pool itself is a transparent
+        // proxy and is stable, but the data provider is a fresh deployment per Aave
+        // AIP). A cached pointer would keep reading stale supply caps, totals, and
+        // pause flags forever. Read it inline for the constructor-only aToken
+        // derivation; runtime calls go through the public `dataProvider()` view.
+        IPoolDataProvider initialDataProvider = IPoolDataProvider(addressesProvider.getPoolDataProvider());
+        (address _aToken, , ) = initialDataProvider.getReserveTokensAddresses(_asset);
         require(_aToken != address(0), "Asset not supported by pool");
         aToken = _aToken;
+    }
+
+    /**
+     * @notice Returns the current Aave V3 pool data provider.
+     * @dev Resolved from `addressesProvider` on every call so the strategy picks up
+     *      governance-driven `PoolDataProvider` rotations without redeployment. The
+     *      few hundred extra gas per limit query is the cost of not silently reading
+     *      stale supply caps / pause flags.
+     * @return Current `IPoolDataProvider` instance reported by the addresses provider.
+     */
+    function dataProvider() public view returns (IPoolDataProvider) {
+        return IPoolDataProvider(addressesProvider.getPoolDataProvider());
     }
 
     /**
@@ -200,11 +214,11 @@ contract AaveV3Strategy is BaseHealthCheck {
         // Aave-side blockers make `pool.supply` revert when the reserve is paused,
         // inactive, or frozen; surfacing capacity through `maxDeposit` would only
         // route users into failing transactions.
-        if (dataProvider.getPaused(address(asset))) return 0;
-        (, , , , , , , , bool isActive, bool isFrozen) = dataProvider.getReserveConfigurationData(address(asset));
+        if (dataProvider().getPaused(address(asset))) return 0;
+        (, , , , , , , , bool isActive, bool isFrozen) = dataProvider().getReserveConfigurationData(address(asset));
         if (!isActive || isFrozen) return 0;
 
-        (, uint256 supplyCap) = dataProvider.getReserveCaps(address(asset));
+        (, uint256 supplyCap) = dataProvider().getReserveCaps(address(asset));
 
         // If supply cap is 0, it means unlimited (see https://github.com/aave/aave-v3-core/blob/782f51917056a53a2c228701058a6c3fb233684a/contracts/protocol/libraries/types/DataTypes.sol#L53)
         if (supplyCap == 0) {
@@ -256,7 +270,7 @@ contract AaveV3Strategy is BaseHealthCheck {
     ///      `forge coverage` build. Identical on-chain behavior — Solidity decodes the
     ///      first three 32-byte slots of the return data and stops.
     function _cappedTotalSupply() internal view returns (uint256) {
-        (, uint256 accruedToTreasuryScaled, uint256 totalAToken) = IPoolDataProviderSlim(address(dataProvider))
+        (, uint256 accruedToTreasuryScaled, uint256 totalAToken) = IPoolDataProviderSlim(address(dataProvider()))
             .getReserveData(address(asset));
         return
             totalAToken +
@@ -290,8 +304,8 @@ contract AaveV3Strategy is BaseHealthCheck {
         // (Withdrawals are NOT blocked by `isFrozen` -- a frozen reserve still allows
         // exits.) Cap `maxWithdraw`/`maxRedeem` at idle-only so users can still exit
         // any balance already out of the pool even while the Aave side is blocked.
-        if (dataProvider.getPaused(address(asset))) return idleBalance;
-        (, , , , , , , , bool isActive, ) = dataProvider.getReserveConfigurationData(address(asset));
+        if (dataProvider().getPaused(address(asset))) return idleBalance;
+        (, , , , , , , , bool isActive, ) = dataProvider().getReserveConfigurationData(address(asset));
         if (!isActive) return idleBalance;
 
         // Get our aToken balance which represents our deposited assets

--- a/src/strategies/yieldDonating/AaveV3Strategy.sol
+++ b/src/strategies/yieldDonating/AaveV3Strategy.sol
@@ -5,12 +5,29 @@ import { BaseHealthCheck } from "src/strategies/periphery/BaseHealthCheck.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 
 interface IPool {
     /// @notice Supplies an asset to the Aave pool
     function supply(address asset, uint256 amount, address onBehalfOf, uint16 referralCode) external;
     /// @notice Withdraws an asset from the Aave pool
     function withdraw(address asset, uint256 amount, address to) external returns (uint256);
+    /// @notice Returns the projected liquidity index for a reserve, accounting for the
+    ///         accrual since `lastUpdateTimestamp` — this is the `nextLiquidityIndex`
+    ///         Aave's own `validateSupply` uses, so it matches the cap check exactly.
+    function getReserveNormalizedIncome(address asset) external view returns (uint256);
+}
+
+/// @dev Slim view of `IPoolDataProvider.getReserveData` that only decodes the first
+///      three return slots (`unbacked`, `accruedToTreasuryScaled`, `totalAToken`).
+///      The cap path needs only `accruedToTreasuryScaled` and `totalAToken`; reading
+///      the full 12-slot tuple trips a stack-too-deep on the ABI decoder under the
+///      `forge coverage` build profile (viaIR + optimizer disabled). Same underlying
+///      contract, narrower signature.
+interface IPoolDataProviderSlim {
+    function getReserveData(
+        address asset
+    ) external view returns (uint256 unbacked, uint256 accruedToTreasuryScaled, uint256 totalAToken);
 }
 
 interface IPoolDataProvider {
@@ -46,6 +63,30 @@ interface IPoolDataProvider {
 
     /// @notice Returns whether the reserve is paused (governance/risk admin emergency switch)
     function getPaused(address asset) external view returns (bool);
+
+    /// @notice Returns full reserve data including totalAToken and accruedToTreasuryScaled.
+    /// @dev `accruedToTreasuryScaled` is treasury-bound reserve that consumes supply-cap
+    ///      headroom in `ValidationLogic.validateSupply` but is missing from
+    ///      `getATokenTotalSupply`. We add it conservatively to the cap denominator.
+    function getReserveData(
+        address asset
+    )
+        external
+        view
+        returns (
+            uint256 unbacked,
+            uint256 accruedToTreasuryScaled,
+            uint256 totalAToken,
+            uint256 totalStableDebt,
+            uint256 totalVariableDebt,
+            uint256 liquidityRate,
+            uint256 variableBorrowRate,
+            uint256 stableBorrowRate,
+            uint256 averageStableBorrowRate,
+            uint256 liquidityIndex,
+            uint256 variableBorrowIndex,
+            uint40 lastUpdateTimestamp
+        );
 }
 
 interface IPoolAddressesProvider {
@@ -170,8 +211,17 @@ contract AaveV3Strategy is BaseHealthCheck {
             return type(uint256).max;
         }
 
-        // Get current total supply in the pool
-        uint256 totalSupply = dataProvider.getATokenTotalSupply(address(asset));
+        // Aave's `validateSupply` enforces
+        //   (scaledTotalSupply + accruedToTreasury).rayMul(nextLiquidityIndex) + amount
+        //     <= supplyCap * 10^decimals
+        // `getATokenTotalSupply` omits the `accruedToTreasury` contribution, so a
+        // headroom check that uses `totalAToken` alone over-reports cap room and
+        // lets users hit a downstream `SUPPLY_CAP_EXCEEDED` revert. The helper
+        // rayMul-scales treasury into underlying units and keeps its locals out
+        // of this function's stack frame (needed for the `--no-via-ir` coverage
+        // build profile, which otherwise hits a stack-too-deep on the 12-return
+        // decoder combined with the surrounding locals).
+        uint256 totalSupply = _cappedTotalSupply();
 
         // Cap is in whole tokens, need to adjust for decimals (see https://github.com/aave/aave-v3-core/blob/782f51917056a53a2c228701058a6c3fb233684a/contracts/protocol/libraries/types/DataTypes.sol#L53)
         uint256 supplyCapScaled = supplyCap * 10 ** IERC20Metadata(address(asset)).decimals();
@@ -189,6 +239,33 @@ contract AaveV3Strategy is BaseHealthCheck {
         } else {
             return 0;
         }
+    }
+
+    /// @dev Returns the cap-denominator view of total supplied assets, rayMul-scaled
+    ///      into underlying units to match Aave's `validateSupply`:
+    ///      `totalAToken + rayMul(accruedToTreasuryScaled, nextLiquidityIndex)`,
+    ///      ceiling-rounded so headroom stays conservative.
+    ///
+    ///      `liquidityIndex` is read via `IPool.getReserveNormalizedIncome` — this is
+    ///      the projected `nextLiquidityIndex` Aave uses, avoiding the few-seconds-of-
+    ///      accrual gap vs the stored `liquidityIndex` on the data provider.
+    ///
+    ///      Uses `IPoolDataProviderSlim` (3-return view of `getReserveData`) instead
+    ///      of the full 12-return interface: the narrower ABI decoder keeps the call
+    ///      site within the EVM stack budget under the `--no-via-ir` + `--no-optimizer`
+    ///      `forge coverage` build. Identical on-chain behavior — Solidity decodes the
+    ///      first three 32-byte slots of the return data and stops.
+    function _cappedTotalSupply() internal view returns (uint256) {
+        (, uint256 accruedToTreasuryScaled, uint256 totalAToken) = IPoolDataProviderSlim(address(dataProvider))
+            .getReserveData(address(asset));
+        return
+            totalAToken +
+            Math.mulDiv(
+                accruedToTreasuryScaled,
+                pool.getReserveNormalizedIncome(address(asset)),
+                1e27,
+                Math.Rounding.Ceil
+            );
     }
 
     /**

--- a/src/strategies/yieldDonating/AaveV3Strategy.sol
+++ b/src/strategies/yieldDonating/AaveV3Strategy.sol
@@ -167,7 +167,13 @@ contract AaveV3Strategy is BaseHealthCheck {
 
     /**
      * @notice Returns maximum assets withdrawable without expected loss
-     * @dev Checks pool liquidity to ensure withdrawals won't fail due to high utilization
+     * @dev Checks pool liquidity to ensure withdrawals won't fail due to high utilization.
+     *
+     *      DUST CAVEAT: mirrors `availableDepositLimit`. Aave burns aTokens proportional
+     *      to `amount / liquidityIndex`; sub-unit withdrawals can round to a zero scaled
+     *      burn amount and revert with `INVALID_BURN_AMOUNT`. This view does NOT pre-filter
+     *      dust amounts; callers must handle Aave reverts on amounts below the per-reserve
+     *      scaled-unit floor.
      * @return limit Maximum withdrawal amount in asset base units
      */
     function availableWithdrawLimit(address /*_owner*/) public view override returns (uint256) {

--- a/src/strategies/yieldDonating/AaveV3Strategy.sol
+++ b/src/strategies/yieldDonating/AaveV3Strategy.sol
@@ -347,7 +347,26 @@ contract AaveV3Strategy is BaseHealthCheck {
     }
 
     /**
-     * @dev Emergency withdrawal after strategy shutdown
+     * @dev Emergency withdrawal after strategy shutdown.
+     *
+     *      AAVE DEPENDENCY: this path delegates to `_freeFunds`, which calls
+     *      `pool.withdraw(asset, amount, this)` with no fallback. Emergency
+     *      withdrawal therefore depends on Aave pool state -- if Aave has
+     *      paused the reserve, marked it inactive, or utilization is too high
+     *      for the requested amount, the call reverts and no funds are pulled.
+     *
+     *      OPERATIONAL RUNBOOK when Aave blocks an emergency exit:
+     *      1. Call `shutdownStrategy()` first -- this marks the strategy
+     *         shutdown for new deposits independently of Aave state.
+     *      2. Call `emergencyWithdraw(amount)` with `amount` capped at the
+     *         Aave-backed portion of `availableWithdrawLimit(address(0))`.
+     *         The view already accounts for pool liquidity; on a paused or
+     *         inactive reserve it surfaces only idle assets, which are already
+     *         outside Aave and remain withdrawable through regular user exits.
+     *      3. Repeat step 2 as Aave liquidity returns or pauses lift. A
+     *         strategy stuck on a paused reserve recovers automatically once
+     *         Aave governance resumes the pool; no contract-level rescue is
+     *         possible without trusting the Aave counterparty.
      * @param _amount Amount of assets to withdraw in asset base units
      */
     function _emergencyWithdraw(uint256 _amount) internal override {

--- a/src/strategies/yieldDonating/AaveV3Strategy.sol
+++ b/src/strategies/yieldDonating/AaveV3Strategy.sol
@@ -24,6 +24,28 @@ interface IPoolDataProvider {
     function getReserveTokensAddresses(
         address asset
     ) external view returns (address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress);
+
+    /// @notice Returns reserve configuration flags including isActive and isFrozen
+    function getReserveConfigurationData(
+        address asset
+    )
+        external
+        view
+        returns (
+            uint256 decimals,
+            uint256 ltv,
+            uint256 liquidationThreshold,
+            uint256 liquidationBonus,
+            uint256 reserveFactor,
+            bool usageAsCollateralEnabled,
+            bool borrowingEnabled,
+            bool stableBorrowRateEnabled,
+            bool isActive,
+            bool isFrozen
+        );
+
+    /// @notice Returns whether the reserve is paused (governance/risk admin emergency switch)
+    function getPaused(address asset) external view returns (bool);
 }
 
 interface IPoolAddressesProvider {
@@ -134,6 +156,13 @@ contract AaveV3Strategy is BaseHealthCheck {
      * @return limit Maximum additional deposit amount in asset base units
      */
     function availableDepositLimit(address /*_owner*/) public view override returns (uint256) {
+        // Aave-side blockers make `pool.supply` revert when the reserve is paused,
+        // inactive, or frozen; surfacing capacity through `maxDeposit` would only
+        // route users into failing transactions.
+        if (dataProvider.getPaused(address(asset))) return 0;
+        (, , , , , , , , bool isActive, bool isFrozen) = dataProvider.getReserveConfigurationData(address(asset));
+        if (!isActive || isFrozen) return 0;
+
         (, uint256 supplyCap) = dataProvider.getReserveCaps(address(asset));
 
         // If supply cap is 0, it means unlimited (see https://github.com/aave/aave-v3-core/blob/782f51917056a53a2c228701058a6c3fb233684a/contracts/protocol/libraries/types/DataTypes.sol#L53)
@@ -174,9 +203,22 @@ contract AaveV3Strategy is BaseHealthCheck {
      * @return limit Maximum withdrawal amount in asset base units
      */
     function availableWithdrawLimit(address /*_owner*/) public view override returns (uint256) {
+        // Idle balance is always withdrawable -- it lives on this contract, no Aave
+        // pool interaction is required to move it out. This matters on a paused or
+        // inactive reserve (short-circuit below) AND after `emergencyWithdraw`
+        // pulls everything out of Aave into idle.
+        uint256 idleBalance = IERC20(address(asset)).balanceOf(address(this));
+
+        // `pool.withdraw` reverts when the reserve is paused or inactive.
+        // (Withdrawals are NOT blocked by `isFrozen` -- a frozen reserve still allows
+        // exits.) Cap `maxWithdraw`/`maxRedeem` at idle-only so users can still exit
+        // any balance already out of the pool even while the Aave side is blocked.
+        if (dataProvider.getPaused(address(asset))) return idleBalance;
+        (, , , , , , , , bool isActive, ) = dataProvider.getReserveConfigurationData(address(asset));
+        if (!isActive) return idleBalance;
+
         // Get our aToken balance which represents our deposited assets
         uint256 aTokenBalance = IERC20(aToken).balanceOf(address(this));
-        uint256 idleBalance = IERC20(address(asset)).balanceOf(address(this));
 
         // Check pool liquidity - the underlying asset balance held by the aToken contract
         uint256 poolLiquidity = IERC20(address(asset)).balanceOf(aToken);

--- a/src/strategies/yieldDonating/AaveV3Strategy.sol
+++ b/src/strategies/yieldDonating/AaveV3Strategy.sol
@@ -96,6 +96,17 @@ interface IPoolAddressesProvider {
     function getPoolDataProvider() external view returns (address);
 }
 
+interface IRewardsController {
+    /// @notice Claims all accrued rewards across the supplied assets to `to`.
+    /// @dev On Aave V3 mainnet (`0x8164cc65827dcFe994AB23944CBC90e0aa80bFcb`) this is
+    ///      callable from any contract -- there is no permission gate. When no rewards
+    ///      are configured for the supplied assets the call is effectively a no-op.
+    function claimAllRewards(
+        address[] calldata assets,
+        address to
+    ) external returns (address[] memory rewardsList, uint256[] memory claimedAmounts);
+}
+
 /**
  * @title AaveV3Strategy
  * @author [Golem Foundation](https://golem.foundation)
@@ -130,10 +141,26 @@ contract AaveV3Strategy is BaseHealthCheck {
     /// @notice Address of the aToken for the underlying asset
     address public immutable aToken;
 
+    /// @notice Address of Aave V3's RewardsController for liquidity-mining incentives.
+    /// @dev Wired at construction so the strategy can claim supply-side emissions if/when
+    ///      Aave governance enables them on a market we use. May be `address(0)` for
+    ///      chains/markets where no RewardsController exists; in that case
+    ///      `claimAaveRewards` reverts with a clear message instead of silently no-op'ing
+    ///      on a zero target.
+    IRewardsController public immutable rewardsController;
+
+    /// @notice Emitted on a successful `claimAaveRewards` call.
+    event AaveRewardsClaimed(address indexed to, address[] rewardsList, uint256[] amounts);
+
+    /// @notice Emitted on a successful `sweepAirdrop` call.
+    event TokenSwept(address indexed token, uint256 amount, address indexed recipient);
+
     /**
      * @notice Initializes the Aave V3 strategy
-     * @dev Sets up connections to Aave V3 pool and derives aToken from pool registry
+     * @dev Sets up connections to Aave V3 pool, derives aToken from pool registry, and wires the
+     *      optional RewardsController for incentive claims.
      * @param _addressesProvider Address of Aave V3 addresses provider
+     * @param _rewardsController Address of Aave V3 RewardsController (may be `address(0)` to disable)
      * @param _asset Address of the underlying asset (must be supported by Aave pool)
      * @param _name Strategy display name (e.g., "Octant Aave V3 USDC Strategy")
      * @param _symbol Strategy share token symbol (e.g., "osAAVE")
@@ -146,6 +173,7 @@ contract AaveV3Strategy is BaseHealthCheck {
      */
     constructor(
         address _addressesProvider,
+        address _rewardsController,
         address _asset,
         string memory _name,
         string memory _symbol,
@@ -172,6 +200,8 @@ contract AaveV3Strategy is BaseHealthCheck {
 
         addressesProvider = IPoolAddressesProvider(_addressesProvider);
         pool = IPool(addressesProvider.getPool());
+        // _rewardsController may be address(0) — see `claimAaveRewards` for the explicit guard.
+        rewardsController = IRewardsController(_rewardsController);
 
         // Do NOT cache the data provider as immutable. Aave's `addressesProvider`
         // rotates the `PoolDataProvider` over time (the Pool itself is a transparent
@@ -183,6 +213,53 @@ contract AaveV3Strategy is BaseHealthCheck {
         (address _aToken, , ) = initialDataProvider.getReserveTokensAddresses(_asset);
         require(_aToken != address(0), "Asset not supported by pool");
         aToken = _aToken;
+    }
+
+    /**
+     * @notice Claims all accrued Aave V3 supply-side rewards on this strategy's aToken
+     *         position and forwards them directly to the dragon router.
+     * @dev The hook is keeper-callable so it can be folded into the same cron that calls
+     *      `report()`. When no emissions are configured for the aToken the call is a no-op
+     *      (returns empty arrays). Off-chain Merit/Merkl claims are out of scope -- those
+     *      rely on Merkle proofs against an external curator and must be handled by the
+     *      Octant multisig, not the strategy.
+     *
+     *      Reverts on `address(0)` rewardsController so a misconfigured deployment is
+     *      surfaced loudly instead of silently swallowing claim attempts.
+     *
+     *      The dragon router used as `to` MUST be capable of accepting arbitrary
+     *      ERC-20s. EOA / splitter routers are fine; an immutable single-asset router
+     *      would lose any non-asset reward token.
+     * @return rewardsList Reward token addresses claimed (may be empty)
+     * @return amounts     Reward amounts transferred to the dragon router
+     */
+    function claimAaveRewards() external onlyKeepers returns (address[] memory rewardsList, uint256[] memory amounts) {
+        require(address(rewardsController) != address(0), "AaveV3Strategy: RewardsController not configured");
+        address[] memory assets = new address[](1);
+        assets[0] = aToken;
+        address dragon = TokenizedStrategy.dragonRouter();
+        (rewardsList, amounts) = rewardsController.claimAllRewards(assets, dragon);
+        emit AaveRewardsClaimed(dragon, rewardsList, amounts);
+    }
+
+    /**
+     * @notice Sweeps non-critical ERC-20 balances on this strategy address to the dragon
+     *         router. Mirrors `SparkStrategy.sweepAirdrop` so the operational interface
+     *         is consistent across strategies.
+     * @dev Used to forward airdrops, off-chain reward distributions (Merkl/Merit settled
+     *      by an off-chain curator), and any stray ERC-20 that lands on the strategy
+     *      address. Excludes the strategy asset and the aToken to protect the deployed
+     *      position.
+     * @param _token Address of the token to sweep (must NOT be `asset` or `aToken`)
+     */
+    function sweepAirdrop(address _token) external onlyKeepers {
+        require(_token != address(asset), "AaveV3Strategy: Cannot sweep main asset");
+        require(_token != aToken, "AaveV3Strategy: Cannot sweep aToken");
+        uint256 balance = IERC20(_token).balanceOf(address(this));
+        require(balance > 0, "AaveV3Strategy: No balance to sweep");
+        address dragon = TokenizedStrategy.dragonRouter();
+        IERC20(_token).safeTransfer(dragon, balance);
+        emit TokenSwept(_token, balance, dragon);
     }
 
     /**

--- a/src/strategies/yieldDonating/AaveV3Strategy.sol
+++ b/src/strategies/yieldDonating/AaveV3Strategy.sol
@@ -72,7 +72,7 @@ contract AaveV3Strategy is BaseHealthCheck {
 
     /**
      * @notice Initializes the Aave V3 strategy
-     * @dev Sets up connections to Aave V3 pool, derives aToken from pool registry, and approves max allowance
+     * @dev Sets up connections to Aave V3 pool and derives aToken from pool registry
      * @param _addressesProvider Address of Aave V3 addresses provider
      * @param _asset Address of the underlying asset (must be supported by Aave pool)
      * @param _name Strategy display name (e.g., "Octant Aave V3 USDC Strategy")
@@ -118,9 +118,6 @@ contract AaveV3Strategy is BaseHealthCheck {
         (address _aToken, , ) = dataProvider.getReserveTokensAddresses(_asset);
         require(_aToken != address(0), "Asset not supported by pool");
         aToken = _aToken;
-
-        // Approve Aave pool to spend our asset
-        IERC20(_asset).forceApprove(address(pool), type(uint256).max);
     }
 
     /**
@@ -191,11 +188,21 @@ contract AaveV3Strategy is BaseHealthCheck {
     }
 
     /**
-     * @dev Deposits idle assets into Aave V3 pool
+     * @dev Deposits idle assets into Aave V3 pool.
+     *
+     *      We used to grant `type(uint256).max` allowance to the pool in the constructor.
+     *      The Aave pool is an upgradeable proxy controlled by external governance, so a
+     *      standing max-approval would let a hostile upgrade drain the strategy's idle
+     *      balance at any time. We now approve exactly `_amount` for the call and clear
+     *      the allowance afterward, even if a broken counterparty returns after pulling
+     *      less than `_amount`. `forceApprove` handles non-standard tokens that require
+     *      clearing an existing non-zero allowance first.
      * @param _amount Amount of assets to deploy in asset base units
      */
     function _deployFunds(uint256 _amount) internal override {
+        IERC20(address(asset)).forceApprove(address(pool), _amount);
         pool.supply(address(asset), _amount, address(this), 0);
+        IERC20(address(asset)).forceApprove(address(pool), 0);
     }
 
     /**

--- a/test/integration/strategies/YieldDonating/AaveV3Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/AaveV3Strategy.t.sol
@@ -408,6 +408,7 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.expectRevert();
         new AaveV3Strategy(
             AaveV3TestConfig.AAVE_ADDRESSES_PROVIDER,
+            address(0), // rewardsController unused for this revert path
             address(0x123), // Unsupported asset
             _strategyName(),
             _strategySymbol(),

--- a/test/integration/strategies/YieldDonating/AaveV3Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/AaveV3Strategy.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { AaveV3Strategy } from "src/strategies/yieldDonating/AaveV3Strategy.sol";
 import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
@@ -14,6 +15,17 @@ import { AaveV3TestConfig } from "../config/AaveV3TestConfig.sol";
 interface IPoolDataProvider {
     function getReserveCaps(address asset) external view returns (uint256 borrowCap, uint256 supplyCap);
     function getATokenTotalSupply(address asset) external view returns (uint256);
+
+    /// @dev Slim view — decodes only the first three 32-byte slots of Aave's full
+    ///      12-return getReserveData tuple (same signature we use in the strategy to
+    ///      keep the coverage build within the stack budget).
+    function getReserveData(
+        address asset
+    ) external view returns (uint256 unbacked, uint256 accruedToTreasuryScaled, uint256 totalAToken);
+}
+
+interface IPool {
+    function getReserveNormalizedIncome(address asset) external view returns (uint256);
 }
 
 /// @title AaveV3 Yield Donating Test
@@ -180,16 +192,31 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         _testHarvestWithProfit(depositAmount, profitAmount);
     }
 
+    function _aaveDataProvider() internal view returns (IPoolDataProvider) {
+        return IPoolDataProvider(address(strategy.dataProvider()));
+    }
+
+    /// @dev Mirror of the strategy's `_cappedTotalSupply` view: underlying-units
+    ///      `totalAToken + rayMul(accruedToTreasuryScaled, normalizedIncome)`, ceiling-
+    ///      rounded. Keeps the integration assertions in lockstep with the Aave-aligned
+    ///      math the strategy applies to `validateSupply` headroom.
+    function _cappedTotalSupplyOnMainnet() internal view returns (uint256) {
+        IPoolDataProvider dp = _aaveDataProvider();
+        IPool aavePool = IPool(AaveV3TestConfig.AAVE_POOL);
+        (, uint256 accruedToTreasuryScaled, uint256 totalAToken) = dp.getReserveData(_asset());
+        uint256 idx = aavePool.getReserveNormalizedIncome(_asset());
+        return totalAToken + Math.mulDiv(accruedToTreasuryScaled, idx, 1e27, Math.Rounding.Ceil);
+    }
+
     /// @notice Test available deposit limit checks supply cap
     function testAvailableDepositLimitWithSupplyCap() public view {
-        IPoolDataProvider dataProvider = IPoolDataProvider(AaveV3TestConfig.AAVE_DATA_PROVIDER);
-        (, uint256 supplyCap) = dataProvider.getReserveCaps(_asset());
+        (, uint256 supplyCap) = _aaveDataProvider().getReserveCaps(_asset());
 
         if (supplyCap == 0) {
             uint256 limit = strategy.availableDepositLimit(user);
             assertEq(limit, type(uint256).max, "Should return max uint256 when no supply cap");
         } else {
-            uint256 totalSupply = dataProvider.getATokenTotalSupply(_asset());
+            uint256 totalSupply = _cappedTotalSupplyOnMainnet();
             uint256 supplyCapScaled = supplyCap * 10 ** _decimals();
 
             uint256 limit = strategy.availableDepositLimit(user);
@@ -214,13 +241,12 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
 
         assertEq(idleBalance, idleAmount, "Strategy should have idle assets");
 
-        IPoolDataProvider dataProvider = IPoolDataProvider(AaveV3TestConfig.AAVE_DATA_PROVIDER);
-        (, uint256 supplyCap) = dataProvider.getReserveCaps(_asset());
+        (, uint256 supplyCap) = _aaveDataProvider().getReserveCaps(_asset());
 
         if (supplyCap == 0) {
             assertEq(limit, type(uint256).max, "Should return max uint256 when no supply cap");
         } else {
-            uint256 totalSupply = dataProvider.getATokenTotalSupply(_asset());
+            uint256 totalSupply = _cappedTotalSupplyOnMainnet();
             uint256 supplyCapScaled = supplyCap * 10 ** _decimals();
 
             if (supplyCapScaled > totalSupply) {
@@ -233,13 +259,12 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
 
     /// @notice Test available deposit limit returns 0 when idle balance >= available capacity
     function testAvailableDepositLimitIdleExceedsCapacityAave() public {
-        IPoolDataProvider dataProvider = IPoolDataProvider(AaveV3TestConfig.AAVE_DATA_PROVIDER);
-        (, uint256 supplyCap) = dataProvider.getReserveCaps(_asset());
+        (, uint256 supplyCap) = _aaveDataProvider().getReserveCaps(_asset());
 
         // Only test when there is a supply cap
         if (supplyCap == 0) return;
 
-        uint256 totalSupply = dataProvider.getATokenTotalSupply(_asset());
+        uint256 totalSupply = _cappedTotalSupplyOnMainnet();
         uint256 supplyCapScaled = supplyCap * 10 ** _decimals();
 
         // Only test when there is available capacity
@@ -491,9 +516,10 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         assertGe(assetsWithdrawn, (depositAmount * 99) / 100, "User should receive at least 99% of deposit");
     }
 
-    /// @notice Test availableDepositLimit returns 0 when supplyCapScaled <= totalSupply
+    /// @notice Test availableDepositLimit returns 0 when supplyCapScaled <= capped total supply
     function testAvailableDepositLimitCapReachedAave() public {
-        address dataProviderAddr = address(strategy.dataProvider());
+        address dataProviderAddr = address(_aaveDataProvider());
+        address poolAddr = AaveV3TestConfig.AAVE_POOL;
 
         // Mock getReserveCaps to return a non-zero supply cap
         uint256 fakeBorrowCap = 100;
@@ -508,25 +534,31 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         // supplyCapScaled = 1000 * 10^6 = 1_000_000_000
         uint256 supplyCapScaled = fakeSupplyCap * 10 ** _decimals();
 
-        // Mock getATokenTotalSupply to return >= supplyCapScaled so the else branch returns 0
+        vm.mockCall(
+            poolAddr,
+            abi.encodeWithSelector(IPool.getReserveNormalizedIncome.selector, _asset()),
+            abi.encode(1e27)
+        );
+
+        // Mock getReserveData to return cappedTotalSupply == supplyCapScaled.
         vm.mockCall(
             dataProviderAddr,
-            abi.encodeWithSelector(IPoolDataProvider.getATokenTotalSupply.selector, _asset()),
-            abi.encode(supplyCapScaled) // totalSupply == supplyCapScaled, so supplyCapScaled > totalSupply is false
+            abi.encodeWithSelector(IPoolDataProvider.getReserveData.selector, _asset()),
+            abi.encode(0, 0, supplyCapScaled)
         );
 
         uint256 limit = strategy.availableDepositLimit(user);
-        assertEq(limit, 0, "Should return 0 when supply cap is reached (supplyCapScaled == totalSupply)");
+        assertEq(limit, 0, "Should return 0 when supply cap is reached");
 
-        // Also test when totalSupply > supplyCapScaled
+        // Also test when cappedTotalSupply > supplyCapScaled.
         vm.mockCall(
             dataProviderAddr,
-            abi.encodeWithSelector(IPoolDataProvider.getATokenTotalSupply.selector, _asset()),
-            abi.encode(supplyCapScaled + 1)
+            abi.encodeWithSelector(IPoolDataProvider.getReserveData.selector, _asset()),
+            abi.encode(0, 0, supplyCapScaled + 1)
         );
 
         limit = strategy.availableDepositLimit(user);
-        assertEq(limit, 0, "Should return 0 when supply cap is exceeded (totalSupply > supplyCapScaled)");
+        assertEq(limit, 0, "Should return 0 when supply cap is exceeded");
 
         vm.clearMockedCalls();
     }

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -221,7 +221,7 @@ contract SwappingYieldForwarderTest is Test {
         asset.mint(address(forwarder), 11e18);
 
         vm.expectEmit(true, true, false, true);
-        emit SwappingYieldForwarder.TokenForwarded(address(asset), receiver, 11e18);
+        emit YieldForwarder.TokenForwarded(address(asset), receiver, 11e18);
 
         vm.prank(keeperEOA);
         forwarder.forwardToken(address(asset));

--- a/test/unit/strategies/yieldDonating/AaveV3ApprovalHygiene.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3ApprovalHygiene.t.sol
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import { AaveV3Strategy } from "src/strategies/yieldDonating/AaveV3Strategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
+
+/// @title MockPool that pulls funds via transferFrom (so the allowance check is meaningful)
+contract PullingMockPool {
+    uint256 public amountToPull = type(uint256).max;
+
+    function setAmountToPull(uint256 _amountToPull) external {
+        amountToPull = _amountToPull;
+    }
+
+    function supply(address asset, uint256 amount, address /*onBehalfOf*/, uint16 /*referralCode*/) external {
+        uint256 pullAmount = amountToPull == type(uint256).max ? amount : amountToPull;
+        IERC20(asset).transferFrom(msg.sender, address(this), pullAmount);
+    }
+
+    function withdraw(address, uint256, address) external pure returns (uint256) {
+        return 0;
+    }
+}
+
+contract MockDataProvider {
+    address public aToken;
+
+    constructor(address _aToken) {
+        aToken = _aToken;
+    }
+
+    function getReserveTokensAddresses(
+        address
+    ) external view returns (address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress) {
+        return (aToken, address(0), address(0));
+    }
+
+    function getReserveCaps(address) external pure returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    function getATokenTotalSupply(address) external pure returns (uint256) {
+        return 0;
+    }
+}
+
+contract MockAddressesProvider {
+    address public pool;
+    address public dataProvider;
+
+    constructor(address _pool, address _dataProvider) {
+        pool = _pool;
+        dataProvider = _dataProvider;
+    }
+
+    function getPool() external view returns (address) {
+        return pool;
+    }
+
+    function getPoolDataProvider() external view returns (address) {
+        return dataProvider;
+    }
+}
+
+/// @notice Issue 50 -- the Aave pool is an upgradeable proxy controlled by external
+///         governance. A constructor-time `forceApprove(pool, type(uint256).max)` lets a
+///         hostile upgrade pull every idle token from the strategy at any time. The fix
+///         removes the standing approval, approves exactly the deploy amount inside
+///         `_deployFunds`, and clears the approval after `pool.supply`.
+contract AaveV3ApprovalHygieneTest is Test {
+    AaveV3Strategy internal strategy;
+    ERC20Mock internal asset;
+    PullingMockPool internal pool;
+    ERC20Mock internal aToken;
+
+    address internal management = address(0x1);
+    address internal keeper = address(0x2);
+    address internal emergencyAdmin = address(0x3);
+    address internal donationAddress = address(0x4);
+    address internal alice = address(0xA);
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        aToken = new ERC20Mock();
+        pool = new PullingMockPool();
+        MockDataProvider dp = new MockDataProvider(address(aToken));
+        MockAddressesProvider provider = new MockAddressesProvider(address(pool), address(dp));
+
+        // Tokenized strategy implementation lives at its own address; the strategy's
+        // BaseStrategy fallback delegatecalls into it directly (no proxy).
+        YieldDonatingTokenizedStrategy impl = new YieldDonatingTokenizedStrategy();
+
+        strategy = new AaveV3Strategy(
+            address(provider),
+            address(asset),
+            "Test Aave",
+            "tsAAVE",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(impl)
+        );
+    }
+
+    /// @notice Constructor must NOT pre-approve the pool. Pre-fix this assertion
+    ///         fails with `allowance == type(uint256).max`.
+    function test_constructor_doesNotPreApprovePool() public view {
+        assertEq(
+            asset.allowance(address(strategy), address(pool)),
+            0,
+            "constructor must not grant standing approval to upgradeable pool"
+        );
+    }
+
+    /// @notice After deposit the per-call approval must be fully consumed by
+    ///         `pool.supply`, leaving zero residual allowance.
+    function test_deposit_leavesZeroAllowance() public {
+        uint256 amount = 100 ether;
+        asset.mint(alice, amount);
+
+        vm.startPrank(alice);
+        asset.approve(address(strategy), amount);
+        IMockStrategy(address(strategy)).deposit(amount, alice);
+        vm.stopPrank();
+
+        assertEq(
+            asset.allowance(address(strategy), address(pool)),
+            0,
+            "post-deposit allowance must be zero (pool consumed exactly the approved amount)"
+        );
+    }
+
+    /// @notice Even if a broken pool pulls less than approved, the strategy must clear
+    ///         the residual allowance after the external call.
+    function test_deposit_clearsResidualAllowanceWhenPoolPullsLess() public {
+        uint256 amount = 100 ether;
+        asset.mint(alice, amount);
+        pool.setAmountToPull(amount - 1);
+
+        vm.startPrank(alice);
+        asset.approve(address(strategy), amount);
+        IMockStrategy(address(strategy)).deposit(amount, alice);
+        vm.stopPrank();
+
+        assertEq(asset.allowance(address(strategy), address(pool)), 0, "residual allowance must be cleared");
+        assertEq(asset.balanceOf(address(strategy)), 1, "unpulled asset remains idle on the strategy");
+    }
+}

--- a/test/unit/strategies/yieldDonating/AaveV3ApprovalHygiene.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3ApprovalHygiene.t.sol
@@ -46,6 +46,16 @@ contract MockDataProvider {
     function getATokenTotalSupply(address) external pure returns (uint256) {
         return 0;
     }
+
+    function getReserveConfigurationData(
+        address
+    ) external pure returns (uint256, uint256, uint256, uint256, uint256, bool, bool, bool, bool, bool) {
+        return (0, 0, 0, 0, 0, false, false, false, true, false); // isActive=true, isFrozen=false
+    }
+
+    function getPaused(address) external pure returns (bool) {
+        return false;
+    }
 }
 
 contract MockAddressesProvider {

--- a/test/unit/strategies/yieldDonating/AaveV3ApprovalHygiene.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3ApprovalHygiene.t.sol
@@ -106,6 +106,7 @@ contract AaveV3ApprovalHygieneTest is Test {
 
         strategy = new AaveV3Strategy(
             address(provider),
+            address(0), // rewardsController not exercised in approval tests
             address(asset),
             "Test Aave",
             "tsAAVE",

--- a/test/unit/strategies/yieldDonating/AaveV3BranchCoverage.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3BranchCoverage.t.sol
@@ -99,6 +99,7 @@ contract AaveV3BranchCoverageTest is Test {
         vm.expectRevert("Zero addressesProvider");
         new AaveV3Strategy(
             address(0), // zero addressesProvider
+            address(0), // rewardsController unused for this revert path
             address(asset),
             "Test Aave",
             "tsAAVE",
@@ -121,6 +122,7 @@ contract AaveV3BranchCoverageTest is Test {
         vm.expectRevert("Asset not supported by pool");
         new AaveV3Strategy(
             address(provider),
+            address(0), // rewardsController unused for this revert path
             address(asset),
             "Test Aave",
             "tsAAVE",
@@ -143,6 +145,7 @@ contract AaveV3BranchCoverageTest is Test {
 
         AaveV3Strategy strategy = new AaveV3Strategy(
             address(provider),
+            address(0), // rewardsController not exercised in cap tests
             address(asset),
             "Test Aave",
             "tsAAVE",

--- a/test/unit/strategies/yieldDonating/AaveV3BranchCoverage.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3BranchCoverage.t.sol
@@ -60,6 +60,18 @@ contract MockDataProvider {
     function getATokenTotalSupply(address) external view returns (uint256) {
         return totalSupply;
     }
+
+    function getReserveConfigurationData(
+        address
+    ) external pure returns (uint256, uint256, uint256, uint256, uint256, bool, bool, bool, bool, bool) {
+        // Default: active, not frozen — let cap/aToken-derivation tests still exercise
+        // the legacy paths after the pause/freeze short-circuits were added.
+        return (0, 0, 0, 0, 0, false, false, false, true, false);
+    }
+
+    function getPaused(address) external pure returns (bool) {
+        return false;
+    }
 }
 
 /// @title AaveV3Strategy branch coverage tests

--- a/test/unit/strategies/yieldDonating/AaveV3BranchCoverage.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3BranchCoverage.t.sol
@@ -32,6 +32,9 @@ contract MockPool {
     function withdraw(address, uint256, address) external pure returns (uint256) {
         return 0;
     }
+    function getReserveNormalizedIncome(address) external pure returns (uint256) {
+        return 1e27; // RAY — no growth, treasury scaling is a no-op
+    }
 }
 
 /// @title Inline mock for IPoolDataProvider

--- a/test/unit/strategies/yieldDonating/AaveV3DataProviderRotation.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3DataProviderRotation.t.sol
@@ -131,6 +131,7 @@ contract AaveV3DataProviderRotationTest is Test {
 
         strategy = new AaveV3Strategy(
             address(addressesProvider),
+            address(0), // rewardsController not exercised in rotation tests
             address(asset),
             "Test Aave",
             "tsAAVE",

--- a/test/unit/strategies/yieldDonating/AaveV3DataProviderRotation.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3DataProviderRotation.t.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { AaveV3Strategy } from "src/strategies/yieldDonating/AaveV3Strategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+
+contract MockPool {
+    function supply(address, uint256, address, uint16) external {}
+    function withdraw(address, uint256, address) external pure returns (uint256) {
+        return 0;
+    }
+    function getReserveNormalizedIncome(address) external pure returns (uint256) {
+        return 1e27;
+    }
+}
+
+/// @notice Static data provider with caller-controlled paused flag and supply cap.
+contract StaticDataProvider {
+    address public aToken;
+    bool public paused;
+    uint256 public supplyCap;
+
+    constructor(address _aToken, bool _paused, uint256 _supplyCap) {
+        aToken = _aToken;
+        paused = _paused;
+        supplyCap = _supplyCap;
+    }
+
+    function getReserveTokensAddresses(
+        address
+    ) external view returns (address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress) {
+        return (aToken, address(0), address(0));
+    }
+
+    function getReserveCaps(address) external view returns (uint256, uint256) {
+        return (0, supplyCap);
+    }
+
+    function getATokenTotalSupply(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getReserveConfigurationData(
+        address
+    ) external pure returns (uint256, uint256, uint256, uint256, uint256, bool, bool, bool, bool, bool) {
+        return (0, 0, 0, 0, 0, false, false, false, true, false);
+    }
+
+    function getPaused(address) external view returns (bool) {
+        return paused;
+    }
+
+    function getReserveData(
+        address
+    )
+        external
+        pure
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint40
+        )
+    {
+        return (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+}
+
+/// @notice AddressesProvider with a settable data provider pointer — emulates Aave
+///         governance rotating the PoolDataProvider via AIP.
+contract RotatingAddressesProvider {
+    address public pool;
+    address public dataProvider;
+
+    constructor(address _pool, address _dataProvider) {
+        pool = _pool;
+        dataProvider = _dataProvider;
+    }
+
+    function setDataProvider(address newDataProvider) external {
+        dataProvider = newDataProvider;
+    }
+
+    function getPool() external view returns (address) {
+        return pool;
+    }
+
+    function getPoolDataProvider() external view returns (address) {
+        return dataProvider;
+    }
+}
+
+/// @notice Issue 51 -- the pre-fix code cached `dataProvider` as `immutable` from
+///         `addressesProvider.getPoolDataProvider()` at construction time. Aave rotates
+///         its PoolDataProvider periodically (the Pool itself is a transparent proxy and
+///         is stable, but the data provider is a fresh deployment per AIP). A cached
+///         pointer keeps reading stale supply caps and pause flags forever. The fix
+///         resolves the data provider from `addressesProvider` on every limit query.
+contract AaveV3DataProviderRotationTest is Test {
+    AaveV3Strategy internal strategy;
+    ERC20Mock internal asset;
+    ERC20Mock internal aToken;
+    RotatingAddressesProvider internal addressesProvider;
+    StaticDataProvider internal initialDataProvider;
+
+    address internal management = address(0x1);
+    address internal keeper = address(0x2);
+    address internal emergencyAdmin = address(0x3);
+    address internal donationAddress = address(0x4);
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        aToken = new ERC20Mock();
+        MockPool pool = new MockPool();
+
+        // Initial: not paused, large cap → headroom positive.
+        initialDataProvider = new StaticDataProvider(address(aToken), false, 1000);
+        addressesProvider = new RotatingAddressesProvider(address(pool), address(initialDataProvider));
+
+        YieldDonatingTokenizedStrategy impl = new YieldDonatingTokenizedStrategy();
+
+        strategy = new AaveV3Strategy(
+            address(addressesProvider),
+            address(asset),
+            "Test Aave",
+            "tsAAVE",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(impl)
+        );
+    }
+
+    /// @notice After Aave rotates the PoolDataProvider, the strategy must observe
+    ///         the new provider's state. Pre-fix: `dataProvider` was cached as
+    ///         `immutable`, so `availableDepositLimit` would still consult the old
+    ///         provider that reports `paused=false` and return positive headroom.
+    function test_rotationFlippingPause_reflectsImmediately() public {
+        // Baseline: reserve open → headroom positive.
+        assertGt(strategy.availableDepositLimit(address(0)), 0, "baseline must have headroom");
+
+        // Aave governance rotates to a new PoolDataProvider that reports the reserve as paused.
+        StaticDataProvider rotated = new StaticDataProvider(address(aToken), true, 1000);
+        addressesProvider.setDataProvider(address(rotated));
+
+        // Post-fix: limit reads the current data provider → 0.
+        // Pre-fix: limit reads the cached immutable → still > 0.
+        assertEq(strategy.availableDepositLimit(address(0)), 0, "rotation to paused provider must zero deposit limit");
+        assertEq(
+            strategy.availableWithdrawLimit(address(0)),
+            0,
+            "rotation to paused provider must zero withdraw limit"
+        );
+    }
+
+    /// @notice The public `dataProvider()` view must report the CURRENT value from
+    ///         `addressesProvider`, not a snapshot. Pre-fix this assertion fails with
+    ///         the original (cached) address.
+    function test_dataProviderAccessor_returnsCurrentAddress() public {
+        assertEq(
+            address(strategy.dataProvider()),
+            address(initialDataProvider),
+            "initial state - accessor returns initial provider"
+        );
+
+        StaticDataProvider rotated = new StaticDataProvider(address(aToken), false, 2000);
+        addressesProvider.setDataProvider(address(rotated));
+
+        assertEq(
+            address(strategy.dataProvider()),
+            address(rotated),
+            "after rotation - accessor must return the NEW provider, not the cached one"
+        );
+    }
+}

--- a/test/unit/strategies/yieldDonating/AaveV3DepositCapTreasury.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3DepositCapTreasury.t.sol
@@ -155,6 +155,7 @@ contract AaveV3DepositCapTreasuryTest is Test {
 
         strategy = new AaveV3Strategy(
             address(provider),
+            address(0), // rewardsController not exercised in cap tests
             address(asset),
             "Test Aave",
             "tsAAVE",

--- a/test/unit/strategies/yieldDonating/AaveV3DepositCapTreasury.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3DepositCapTreasury.t.sol
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { AaveV3Strategy } from "src/strategies/yieldDonating/AaveV3Strategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+
+/// @dev MockPool with a configurable `getReserveNormalizedIncome`. The strategy's
+///      treasury-scaling path reads the projected `nextLiquidityIndex` off IPool
+///      (not IPoolDataProvider), so these tests exercise the scaling by flipping
+///      this value instead of the stored `liquidityIndex` on the data provider.
+contract MockPool {
+    uint256 public normalizedIncome = 1e27; // default: RAY (no growth)
+
+    function supply(address, uint256, address, uint16) external {}
+    function withdraw(address, uint256, address) external pure returns (uint256) {
+        return 0;
+    }
+    function getReserveNormalizedIncome(address) external view returns (uint256) {
+        return normalizedIncome;
+    }
+    function setNormalizedIncome(uint256 v) external {
+        normalizedIncome = v;
+    }
+}
+
+/// @notice Mock that lets tests configure totalAToken and accruedToTreasuryScaled
+///         independently. Pre-fix code only sees `getATokenTotalSupply` (totalAToken),
+///         post-fix code reads both and sums them via `getReserveData`.
+contract TreasuryAwareDataProvider {
+    uint256 internal constant RAY = 1e27;
+
+    address public aToken;
+    uint256 public supplyCapWholeTokens;
+    uint256 public totalAToken;
+    uint256 public accruedToTreasuryScaled;
+    uint256 public liquidityIndex = RAY; // default: no growth (scale = 1:1)
+
+    constructor(address _aToken, uint256 _supplyCapWholeTokens) {
+        aToken = _aToken;
+        supplyCapWholeTokens = _supplyCapWholeTokens;
+    }
+
+    function setTotals(uint256 _totalAToken, uint256 _accruedToTreasuryScaled) external {
+        totalAToken = _totalAToken;
+        accruedToTreasuryScaled = _accruedToTreasuryScaled;
+    }
+
+    /// @dev Configure the reserve liquidity index to simulate growth. `_liquidityIndex`
+    ///      is in Aave's RAY convention (1e27 = 1.0x = no growth).
+    function setLiquidityIndex(uint256 _liquidityIndex) external {
+        liquidityIndex = _liquidityIndex;
+    }
+
+    function getReserveTokensAddresses(
+        address
+    ) external view returns (address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress) {
+        return (aToken, address(0), address(0));
+    }
+
+    function getReserveCaps(address) external view returns (uint256, uint256) {
+        return (0, supplyCapWholeTokens);
+    }
+
+    // Legacy view — pre-fix code path. Returns only totalAToken (omits treasury accrual).
+    function getATokenTotalSupply(address) external view returns (uint256) {
+        return totalAToken;
+    }
+
+    function getReserveConfigurationData(
+        address
+    ) external pure returns (uint256, uint256, uint256, uint256, uint256, bool, bool, bool, bool, bool) {
+        return (0, 0, 0, 0, 0, false, false, false, true, false); // active, not frozen
+    }
+
+    function getPaused(address) external pure returns (bool) {
+        return false;
+    }
+
+    // Post-fix view — exposes accruedToTreasuryScaled separately so the strategy can
+    // include it in cap-headroom math.
+    function getReserveData(
+        address
+    )
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint40
+        )
+    {
+        return (0, accruedToTreasuryScaled, totalAToken, 0, 0, 0, 0, 0, 0, liquidityIndex, 0, 0);
+    }
+}
+
+contract MockAddressesProvider {
+    address public pool;
+    address public dataProvider;
+
+    constructor(address _pool, address _dataProvider) {
+        pool = _pool;
+        dataProvider = _dataProvider;
+    }
+
+    function getPool() external view returns (address) {
+        return pool;
+    }
+
+    function getPoolDataProvider() external view returns (address) {
+        return dataProvider;
+    }
+}
+
+/// @notice Issue 45 -- `validateSupply` enforces
+///         `(scaledTotalSupply + accruedToTreasury).rayMul(idx) + amount <= cap`.
+///         The pre-fix code compared cap against `getATokenTotalSupply` only, which
+///         omits the `accruedToTreasury` contribution. That over-reports headroom by
+///         exactly `accruedToTreasuryScaled`, sending users into `SUPPLY_CAP_EXCEEDED`
+///         reverts. The fix incorporates `accruedToTreasuryScaled` conservatively into
+///         the cap denominator.
+contract AaveV3DepositCapTreasuryTest is Test {
+    AaveV3Strategy internal strategy;
+    ERC20Mock internal asset;
+    ERC20Mock internal aToken;
+    TreasuryAwareDataProvider internal dp;
+    MockPool internal pool;
+
+    address internal management = address(0x1);
+    address internal keeper = address(0x2);
+    address internal emergencyAdmin = address(0x3);
+    address internal donationAddress = address(0x4);
+
+    uint256 internal constant SUPPLY_CAP_WHOLE = 1000;
+    uint256 internal constant CAP_SCALED = 1000 ether; // 1000 * 1e18
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        aToken = new ERC20Mock();
+        pool = new MockPool();
+        dp = new TreasuryAwareDataProvider(address(aToken), SUPPLY_CAP_WHOLE);
+        MockAddressesProvider provider = new MockAddressesProvider(address(pool), address(dp));
+
+        YieldDonatingTokenizedStrategy impl = new YieldDonatingTokenizedStrategy();
+
+        strategy = new AaveV3Strategy(
+            address(provider),
+            address(asset),
+            "Test Aave",
+            "tsAAVE",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(impl)
+        );
+    }
+
+    /// @notice Treasury accrual must reduce reported headroom. Pre-fix code returns
+    ///         `cap - totalAToken` (overstated); post-fix returns `cap - (totalAToken + treasury)`.
+    function test_treasuryAccrualReducesHeadroom() public {
+        // Configure so that:
+        //   totalAToken             = 800 ether
+        //   accruedToTreasuryScaled = 100 ether
+        //   cap                     = 1000 ether
+        // Pre-fix headroom: 1000 - 800       = 200 ether (WRONG -- cap is at 900 effectively).
+        // Post-fix headroom: 1000 - (800+100) = 100 ether.
+        dp.setTotals(800 ether, 100 ether);
+
+        uint256 limit = strategy.availableDepositLimit(address(0));
+        assertEq(
+            limit,
+            100 ether,
+            "Headroom must subtract accruedToTreasury -- pre-fix returned 200 ether (overstated by 100 ether)"
+        );
+    }
+
+    /// @notice When treasury accrual fully consumes remaining cap headroom, the limit
+    ///         must be zero. Pre-fix code still reports positive headroom equal to the
+    ///         treasury balance, sending depositors into SUPPLY_CAP_EXCEEDED.
+    function test_treasuryAccrualSaturatesCap_returnsZero() public {
+        // totalAToken + accruedToTreasury equals the scaled cap exactly.
+        dp.setTotals(900 ether, 100 ether);
+
+        uint256 limit = strategy.availableDepositLimit(address(0));
+        assertEq(limit, 0, "Limit must be zero when treasury accrual fills the cap");
+    }
+
+    /// @notice Sanity check: with zero treasury accrual, the limit matches the legacy
+    ///         calculation. Locks in that the fix doesn't regress the common case.
+    function test_zeroTreasury_matchesLegacyHeadroom() public {
+        dp.setTotals(700 ether, 0);
+        uint256 limit = strategy.availableDepositLimit(address(0));
+        assertEq(limit, 300 ether, "Zero-treasury case must equal cap - totalAToken");
+    }
+
+    /// @notice Codex P2 regression -- `accruedToTreasuryScaled` is in scaled (pre-rayMul)
+    ///         units while `totalAToken` is in underlying units. When `liquidityIndex > 1e27`
+    ///         the old code summed them directly, under-counting treasury contribution and
+    ///         overstating headroom. Post-fix the strategy rayMuls treasury into underlying
+    ///         units (ceiling-rounded) before adding.
+    ///
+    ///         Scenario:
+    ///           totalAToken             = 800 ether (underlying)
+    ///           accruedToTreasuryScaled = 100 ether (scaled; actual underlying = 105 ether)
+    ///           liquidityIndex          = 1.05e27
+    ///         Pre-fix headroom (raw sum): 1000 - (800 + 100)       = 100 ether (overstated by 5 ether).
+    ///         Post-fix headroom:          1000 - (800 + 105)       =  95 ether.
+    function test_treasuryAccrual_scalesByLiquidityIndex() public {
+        dp.setTotals(800 ether, 100 ether);
+        pool.setNormalizedIncome(1.05e27); // 5% reserve growth
+
+        uint256 limit = strategy.availableDepositLimit(address(0));
+        assertEq(
+            limit,
+            95 ether,
+            "Headroom must scale treasury by liquidityIndex -- pre-fix returned 100 ether (overstated by 5 ether)"
+        );
+    }
+
+    /// @notice Ceiling-rounding sanity check: sub-wei fractional residue after rayMul
+    ///         must round up so headroom stays conservative. With 1 wei scaled accrual
+    ///         and liquidityIndex = 1e27 + 1, `mulDiv(1, 1e27+1, 1e27, Ceil) == 2`;
+    ///         floor would give 1. The difference must be visible in the returned limit.
+    function test_treasuryAccrual_ceilingDivisionRoundsUp() public {
+        dp.setTotals(100 ether, 1);
+        pool.setNormalizedIncome(1e27 + 1);
+
+        uint256 limit = strategy.availableDepositLimit(address(0));
+        assertEq(limit, 1000 ether - 100 ether - 2, "Sub-wei treasury residue must round up, not down");
+    }
+}

--- a/test/unit/strategies/yieldDonating/AaveV3DustReverts.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3DustReverts.t.sol
@@ -12,6 +12,7 @@ contract DustAavePoolMock {
     uint256 internal constant RAY = 1e27;
 
     string internal constant INVALID_MINT_AMOUNT = "24";
+    string internal constant INVALID_BURN_AMOUNT = "25";
 
     uint256 public liquidityIndex = 3e27;
 
@@ -20,7 +21,8 @@ contract DustAavePoolMock {
         IERC20(asset).transferFrom(msg.sender, address(this), amount);
     }
 
-    function withdraw(address, uint256 amount, address) external pure returns (uint256) {
+    function withdraw(address, uint256 amount, address) external view returns (uint256) {
+        require(_rayDiv(amount, liquidityIndex) != 0, INVALID_BURN_AMOUNT);
         return amount;
     }
 
@@ -137,5 +139,10 @@ contract AaveV3DustRevertsTest is Test {
 
         vm.expectRevert(bytes("24"));
         strategy.exposedDeployFunds(1);
+    }
+
+    function test_withdrawDustRevertsWithInvalidBurnAmount() public {
+        vm.expectRevert(bytes("25"));
+        strategy.exposedFreeFunds(1);
     }
 }

--- a/test/unit/strategies/yieldDonating/AaveV3DustReverts.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3DustReverts.t.sol
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { AaveV3Strategy } from "src/strategies/yieldDonating/AaveV3Strategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+
+contract DustAavePoolMock {
+    uint256 internal constant RAY = 1e27;
+
+    string internal constant INVALID_MINT_AMOUNT = "24";
+
+    uint256 public liquidityIndex = 3e27;
+
+    function supply(address asset, uint256 amount, address, uint16) external {
+        require(_rayDiv(amount, liquidityIndex) != 0, INVALID_MINT_AMOUNT);
+        IERC20(asset).transferFrom(msg.sender, address(this), amount);
+    }
+
+    function withdraw(address, uint256 amount, address) external pure returns (uint256) {
+        return amount;
+    }
+
+    function getReserveNormalizedIncome(address) external view returns (uint256) {
+        return liquidityIndex;
+    }
+
+    function _rayDiv(uint256 a, uint256 b) internal pure returns (uint256) {
+        return (a * RAY + b / 2) / b;
+    }
+}
+
+contract DustDataProviderMock {
+    address public immutable aToken;
+
+    constructor(address _aToken) {
+        aToken = _aToken;
+    }
+
+    function getReserveTokensAddresses(
+        address
+    ) external view returns (address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress) {
+        return (aToken, address(0), address(0));
+    }
+}
+
+contract DustAddressesProviderMock {
+    address public immutable pool;
+    address public immutable dataProvider;
+
+    constructor(address _pool, address _dataProvider) {
+        pool = _pool;
+        dataProvider = _dataProvider;
+    }
+
+    function getPool() external view returns (address) {
+        return pool;
+    }
+
+    function getPoolDataProvider() external view returns (address) {
+        return dataProvider;
+    }
+}
+
+contract AaveV3DustHarness is AaveV3Strategy {
+    constructor(
+        address addressesProvider,
+        address asset,
+        address management,
+        address keeper,
+        address emergencyAdmin,
+        address donationAddress,
+        address implementation
+    )
+        AaveV3Strategy(
+            addressesProvider,
+            address(0),
+            asset,
+            "Test Aave Dust",
+            "tsAAVEDUST",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            implementation
+        )
+    {}
+
+    function exposedDeployFunds(uint256 amount) external {
+        _deployFunds(amount);
+    }
+
+    function exposedFreeFunds(uint256 amount) external {
+        _freeFunds(amount);
+    }
+}
+
+contract AaveV3DustRevertsTest is Test {
+    ERC20Mock internal asset;
+    ERC20Mock internal aToken;
+    DustAavePoolMock internal pool;
+    AaveV3DustHarness internal strategy;
+
+    address internal management = address(0x1);
+    address internal keeper = address(0x2);
+    address internal emergencyAdmin = address(0x3);
+    address internal donationAddress = address(0x4);
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        aToken = new ERC20Mock();
+        pool = new DustAavePoolMock();
+        DustDataProviderMock dataProvider = new DustDataProviderMock(address(aToken));
+        DustAddressesProviderMock addressesProvider = new DustAddressesProviderMock(
+            address(pool),
+            address(dataProvider)
+        );
+        YieldDonatingTokenizedStrategy implementation = new YieldDonatingTokenizedStrategy();
+
+        strategy = new AaveV3DustHarness(
+            address(addressesProvider),
+            address(asset),
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            address(implementation)
+        );
+    }
+
+    function test_supplyDustRevertsWithInvalidMintAmount() public {
+        asset.mint(address(strategy), 1);
+
+        vm.expectRevert(bytes("24"));
+        strategy.exposedDeployFunds(1);
+    }
+}

--- a/test/unit/strategies/yieldDonating/AaveV3PausedFrozen.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3PausedFrozen.t.sol
@@ -142,6 +142,7 @@ contract AaveV3PausedFrozenTest is Test {
 
         strategy = new AaveV3Strategy(
             address(provider),
+            address(0), // rewardsController not exercised in pause/freeze tests
             address(asset),
             "Test Aave",
             "tsAAVE",

--- a/test/unit/strategies/yieldDonating/AaveV3PausedFrozen.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3PausedFrozen.t.sol
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { AaveV3Strategy } from "src/strategies/yieldDonating/AaveV3Strategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+
+contract MockPool {
+    function supply(address, uint256, address, uint16) external {}
+    function withdraw(address, uint256, address) external pure returns (uint256) {
+        return 0;
+    }
+}
+
+/// @notice Configurable data provider so tests can flip paused/active/frozen flags.
+contract ConfigurableDataProvider {
+    address public aToken;
+
+    bool public paused;
+    bool public isActive = true;
+    bool public isFrozen;
+
+    uint256 public supplyCap; // whole-token cap, default unbounded enough that headroom > 0
+    uint256 public totalSupply;
+
+    constructor(address _aToken, uint256 _supplyCapWholeTokens, uint256 _totalSupply) {
+        aToken = _aToken;
+        supplyCap = _supplyCapWholeTokens;
+        totalSupply = _totalSupply;
+    }
+
+    function setPaused(bool v) external {
+        paused = v;
+    }
+
+    function setActive(bool v) external {
+        isActive = v;
+    }
+
+    function setFrozen(bool v) external {
+        isFrozen = v;
+    }
+
+    function getReserveTokensAddresses(
+        address
+    ) external view returns (address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress) {
+        return (aToken, address(0), address(0));
+    }
+
+    function getReserveCaps(address) external view returns (uint256, uint256) {
+        return (0, supplyCap);
+    }
+
+    function getATokenTotalSupply(address) external view returns (uint256) {
+        return totalSupply;
+    }
+
+    function getReserveConfigurationData(
+        address
+    ) external view returns (uint256, uint256, uint256, uint256, uint256, bool, bool, bool, bool, bool) {
+        return (0, 0, 0, 0, 0, false, false, false, isActive, isFrozen);
+    }
+
+    function getPaused(address) external view returns (bool) {
+        return paused;
+    }
+}
+
+contract MockAddressesProvider {
+    address public pool;
+    address public dataProvider;
+
+    constructor(address _pool, address _dataProvider) {
+        pool = _pool;
+        dataProvider = _dataProvider;
+    }
+
+    function getPool() external view returns (address) {
+        return pool;
+    }
+
+    function getPoolDataProvider() external view returns (address) {
+        return dataProvider;
+    }
+}
+
+/// @notice Issue 47 -- when Aave governance/risk admin pauses or freezes a reserve,
+///         `pool.supply` / `pool.withdraw` revert. The cap views must short-circuit to
+///         zero in those states so ERC-4626 `maxDeposit`/`maxRedeem` consumers don't
+///         route users straight into failing transactions.
+///         Withdraw is gated on `paused` and `!isActive` (NOT `isFrozen`) -- a frozen
+///         reserve still allows exits in Aave's validation logic.
+contract AaveV3PausedFrozenTest is Test {
+    AaveV3Strategy internal strategy;
+    ERC20Mock internal asset;
+    ERC20Mock internal aToken;
+    ConfigurableDataProvider internal dp;
+
+    address internal management = address(0x1);
+    address internal keeper = address(0x2);
+    address internal emergencyAdmin = address(0x3);
+    address internal donationAddress = address(0x4);
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        aToken = new ERC20Mock();
+        MockPool pool = new MockPool();
+        // supplyCap = 1000 whole tokens with 18 decimals; totalSupply = 0 -> headroom > 0
+        dp = new ConfigurableDataProvider(address(aToken), 1000, 0);
+        MockAddressesProvider provider = new MockAddressesProvider(address(pool), address(dp));
+
+        YieldDonatingTokenizedStrategy impl = new YieldDonatingTokenizedStrategy();
+
+        strategy = new AaveV3Strategy(
+            address(provider),
+            address(asset),
+            "Test Aave",
+            "tsAAVE",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(impl)
+        );
+
+        // Park aTokens on the strategy AND back them with underlying liquidity at the
+        // aToken address — `availableWithdrawLimit` returns `min(aTokenBalance, poolLiquidity)`,
+        // where poolLiquidity = `asset.balanceOf(aToken)`.
+        aToken.mint(address(strategy), 500 ether);
+        asset.mint(address(aToken), 500 ether);
+    }
+
+    /// @notice Baseline (active, not paused, not frozen): both views return positive.
+    function test_baseline_bothLimitsPositive() public view {
+        assertGt(strategy.availableDepositLimit(address(0)), 0, "deposit limit should be positive in baseline");
+        assertGt(strategy.availableWithdrawLimit(address(0)), 0, "withdraw limit should be positive in baseline");
+    }
+
+    /// @notice Paused (zero idle on strategy) -> both limits return 0.
+    function test_paused_zeroIdle_bothLimitsZero() public {
+        dp.setPaused(true);
+        assertEq(strategy.availableDepositLimit(address(0)), 0, "paused reserve must block deposits");
+        assertEq(strategy.availableWithdrawLimit(address(0)), 0, "paused + no idle -> no withdrawable");
+    }
+
+    /// @notice Inactive (zero idle on strategy) -> both limits return 0.
+    function test_inactive_zeroIdle_bothLimitsZero() public {
+        dp.setActive(false);
+        assertEq(strategy.availableDepositLimit(address(0)), 0, "inactive reserve must block deposits");
+        assertEq(strategy.availableWithdrawLimit(address(0)), 0, "inactive + no idle -> no withdrawable");
+    }
+
+    /// @notice Codex P1 regression -- when the reserve is paused, any idle balance
+    ///         already sitting on the strategy (direct transfers, post-shutdown
+    ///         emergency withdraw, rebates, partially-freed funds) doesn't need an
+    ///         Aave pool interaction to exit. `availableWithdrawLimit` must surface
+    ///         that idle balance so ERC-4626 `maxWithdraw` / `maxRedeem` aren't zero.
+    function test_paused_withIdle_returnsIdleBalance() public {
+        // Seed idle balance on the strategy (direct transfer / emergency-withdraw scenario).
+        uint256 idle = 42 ether;
+        asset.mint(address(strategy), idle);
+
+        dp.setPaused(true);
+        assertEq(
+            strategy.availableDepositLimit(address(0)),
+            0,
+            "paused reserve must block deposits regardless of idle"
+        );
+        assertEq(
+            strategy.availableWithdrawLimit(address(0)),
+            idle,
+            "paused + idle -> idle is withdrawable (no Aave pool interaction needed)"
+        );
+    }
+
+    /// @notice Same invariant for the inactive flag -- an inactive reserve still lets
+    ///         users exit the idle leg via ERC-4626.
+    function test_inactive_withIdle_returnsIdleBalance() public {
+        uint256 idle = 17 ether;
+        asset.mint(address(strategy), idle);
+
+        dp.setActive(false);
+        assertEq(
+            strategy.availableDepositLimit(address(0)),
+            0,
+            "inactive reserve must block deposits regardless of idle"
+        );
+        assertEq(
+            strategy.availableWithdrawLimit(address(0)),
+            idle,
+            "inactive + idle -> idle is withdrawable (no Aave pool interaction needed)"
+        );
+    }
+
+    /// @notice Frozen blocks deposits but NOT withdraws (Aave semantics).
+    function test_frozen_blocksDepositButNotWithdraw() public {
+        dp.setFrozen(true);
+        assertEq(strategy.availableDepositLimit(address(0)), 0, "frozen reserve must block deposits");
+        assertGt(
+            strategy.availableWithdrawLimit(address(0)),
+            0,
+            "frozen reserve must still allow withdraws (Aave validation logic)"
+        );
+    }
+}

--- a/test/unit/strategies/yieldDonating/AaveV3PausedFrozen.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3PausedFrozen.t.sol
@@ -11,6 +11,9 @@ contract MockPool {
     function withdraw(address, uint256, address) external pure returns (uint256) {
         return 0;
     }
+    function getReserveNormalizedIncome(address) external pure returns (uint256) {
+        return 1e27;
+    }
 }
 
 /// @notice Configurable data provider so tests can flip paused/active/frozen flags.
@@ -64,6 +67,31 @@ contract ConfigurableDataProvider {
 
     function getPaused(address) external view returns (bool) {
         return paused;
+    }
+
+    function getReserveData(
+        address
+    )
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint40
+        )
+    {
+        // accruedToTreasuryScaled=0, totalAToken=totalSupply (mirrors the legacy
+        // getATokenTotalSupply value used by the pre-fix cap path).
+        return (0, 0, totalSupply, 0, 0, 0, 0, 0, 0, 0, 0, 0);
     }
 }
 

--- a/test/unit/strategies/yieldDonating/AaveV3RewardsAndSweep.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3RewardsAndSweep.t.sol
@@ -1,0 +1,257 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { AaveV3Strategy } from "src/strategies/yieldDonating/AaveV3Strategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+
+contract MockPool {
+    function supply(address, uint256, address, uint16) external {}
+    function withdraw(address, uint256, address) external pure returns (uint256) {
+        return 0;
+    }
+}
+
+contract MockDataProvider {
+    address public aToken;
+
+    constructor(address _aToken) {
+        aToken = _aToken;
+    }
+
+    function getReserveTokensAddresses(
+        address
+    ) external view returns (address aTokenAddress, address stableDebtTokenAddress, address variableDebtTokenAddress) {
+        return (aToken, address(0), address(0));
+    }
+
+    function getReserveCaps(address) external pure returns (uint256, uint256) {
+        return (0, 0);
+    }
+
+    function getATokenTotalSupply(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function getReserveConfigurationData(
+        address
+    ) external pure returns (uint256, uint256, uint256, uint256, uint256, bool, bool, bool, bool, bool) {
+        return (0, 0, 0, 0, 0, false, false, false, true, false);
+    }
+
+    function getPaused(address) external pure returns (bool) {
+        return false;
+    }
+
+    function getReserveData(
+        address
+    )
+        external
+        pure
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint40
+        )
+    {
+        return (0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    }
+}
+
+contract MockAddressesProvider {
+    address public pool;
+    address public dataProvider;
+
+    constructor(address _pool, address _dataProvider) {
+        pool = _pool;
+        dataProvider = _dataProvider;
+    }
+
+    function getPool() external view returns (address) {
+        return pool;
+    }
+
+    function getPoolDataProvider() external view returns (address) {
+        return dataProvider;
+    }
+}
+
+/// @notice Mock RewardsController that hands back caller-controlled lists and
+///         transfers a recorded reward token to `to` so the dragon-router payout path
+///         is mechanically verified end-to-end.
+contract MockRewardsController {
+    ERC20Mock public rewardToken;
+    uint256 public payout;
+
+    constructor(ERC20Mock _rewardToken, uint256 _payout) {
+        rewardToken = _rewardToken;
+        payout = _payout;
+    }
+
+    function claimAllRewards(
+        address[] calldata /*assets*/,
+        address to
+    ) external returns (address[] memory rewardsList, uint256[] memory amounts) {
+        rewardsList = new address[](1);
+        rewardsList[0] = address(rewardToken);
+        amounts = new uint256[](1);
+        amounts[0] = payout;
+        if (payout > 0) {
+            rewardToken.mint(to, payout);
+        }
+    }
+}
+
+/// @notice Issue 44 -- the strategy used to ignore Aave's RewardsController and any
+///         airdropped ERC-20 that landed on its address, so liquidity-mining emissions and
+///         off-chain reward distributions were unrecoverable. The fix wires the
+///         RewardsController and adds keeper-only `claimAaveRewards` and `sweepAirdrop`.
+contract AaveV3RewardsAndSweepTest is Test {
+    AaveV3Strategy internal strategy;
+    AaveV3Strategy internal strategyWithoutRewards;
+    ERC20Mock internal asset;
+    ERC20Mock internal aToken;
+    ERC20Mock internal rewardToken;
+    MockRewardsController internal rewards;
+
+    address internal management = address(0x1);
+    address internal keeper = address(0x2);
+    address internal emergencyAdmin = address(0x3);
+    address internal donationAddress = address(0x4);
+    address internal randomCaller = address(0xBEEF);
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        aToken = new ERC20Mock();
+        rewardToken = new ERC20Mock();
+
+        MockPool pool = new MockPool();
+        MockDataProvider dp = new MockDataProvider(address(aToken));
+        MockAddressesProvider provider = new MockAddressesProvider(address(pool), address(dp));
+
+        rewards = new MockRewardsController(rewardToken, 100 ether);
+
+        YieldDonatingTokenizedStrategy impl = new YieldDonatingTokenizedStrategy();
+
+        strategy = new AaveV3Strategy(
+            address(provider),
+            address(rewards),
+            address(asset),
+            "Test Aave",
+            "tsAAVE",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(impl)
+        );
+
+        strategyWithoutRewards = new AaveV3Strategy(
+            address(provider),
+            address(0), // explicit zero — claim path must revert with a clear message
+            address(asset),
+            "Test Aave No Rewards",
+            "tsAAVE_NR",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(impl)
+        );
+    }
+
+    // --- claimAaveRewards ---
+
+    /// @notice Keeper claim transfers reward tokens from controller to dragon router.
+    function test_claimAaveRewards_keeperPaysOutToDragon() public {
+        assertEq(rewardToken.balanceOf(donationAddress), 0, "dragon must start with no reward tokens");
+
+        vm.prank(keeper);
+        strategy.claimAaveRewards();
+
+        assertEq(rewardToken.balanceOf(donationAddress), 100 ether, "claim must forward emissions to dragon router");
+    }
+
+    /// @notice Random caller cannot claim. Pre-fix this whole entry point did not exist;
+    ///         post-fix it must enforce keeper authorization.
+    function test_claimAaveRewards_revertsForUnauthorizedCaller() public {
+        vm.prank(randomCaller);
+        vm.expectRevert(); // BaseStrategy onlyKeepers reverts on unauthorized caller
+        strategy.claimAaveRewards();
+    }
+
+    /// @notice Misconfigured deployment (no rewardsController) must revert loudly
+    ///         instead of silently no-op'ing on a zero target.
+    function test_claimAaveRewards_revertsWhenControllerUnset() public {
+        vm.prank(keeper);
+        vm.expectRevert("AaveV3Strategy: RewardsController not configured");
+        strategyWithoutRewards.claimAaveRewards();
+    }
+
+    // --- sweepAirdrop ---
+
+    /// @notice Keeper can sweep an arbitrary ERC-20 to the dragon router.
+    function test_sweepAirdrop_keeperForwardsToDragon() public {
+        ERC20Mock airdrop = new ERC20Mock();
+        airdrop.mint(address(strategy), 75 ether);
+
+        vm.prank(keeper);
+        strategy.sweepAirdrop(address(airdrop));
+
+        assertEq(airdrop.balanceOf(donationAddress), 75 ether, "dragon must receive swept balance");
+        assertEq(airdrop.balanceOf(address(strategy)), 0, "strategy must hold zero post-sweep");
+    }
+
+    /// @notice Sweeping the strategy asset is rejected — would let a keeper drain the
+    ///         strategy's idle (pre-deploy) balance to the dragon router.
+    function test_sweepAirdrop_revertsOnMainAsset() public {
+        asset.mint(address(strategy), 1 ether);
+
+        vm.prank(keeper);
+        vm.expectRevert("AaveV3Strategy: Cannot sweep main asset");
+        strategy.sweepAirdrop(address(asset));
+    }
+
+    /// @notice Sweeping the aToken is rejected — would let a keeper liquidate the
+    ///         deployed Aave position to the dragon router.
+    function test_sweepAirdrop_revertsOnAToken() public {
+        aToken.mint(address(strategy), 1 ether);
+
+        vm.prank(keeper);
+        vm.expectRevert("AaveV3Strategy: Cannot sweep aToken");
+        strategy.sweepAirdrop(address(aToken));
+    }
+
+    /// @notice Random caller cannot sweep.
+    function test_sweepAirdrop_revertsForUnauthorizedCaller() public {
+        ERC20Mock airdrop = new ERC20Mock();
+        airdrop.mint(address(strategy), 1 ether);
+
+        vm.prank(randomCaller);
+        vm.expectRevert();
+        strategy.sweepAirdrop(address(airdrop));
+    }
+
+    /// @notice Sweeping a zero-balance token is rejected — keeps the keeper from
+    ///         emitting noise events and, more importantly, surfaces a misconfigured
+    ///         token address loudly.
+    function test_sweepAirdrop_revertsOnZeroBalance() public {
+        ERC20Mock airdrop = new ERC20Mock();
+
+        vm.prank(keeper);
+        vm.expectRevert("AaveV3Strategy: No balance to sweep");
+        strategy.sweepAirdrop(address(airdrop));
+    }
+}


### PR DESCRIPTION
## Summary

Bailsec audit fixes for `AaveV3Strategy`. The Aave remediation stack remains one signed conventional commit per issue/fix. Two support commits are included to keep PR #414 green against current `develop`: one fixes the inherited `SwappingYieldForwarder` token-forwarding collision, and one makes the semver check robust when the old base ref cannot compile because of unversioned support-file changes.

| Bailsec | Severity | Action | Commit |
|---|---|---|---|
| Issue 46 | Low | DOC - note Aave deposit dust revert in `availableDepositLimit` | `57ed4d57` |
| Issue 48 | Low | DOC - note Aave withdraw dust revert in `availableWithdrawLimit` | `62873aa3` |
| Issue 50 | Low | FIX - clear Aave pool approval after each exact supply | `57ea2d6b` |
| Issue 47 | Low | FIX - short-circuit limits when reserve is paused or frozen | `67e9b151` |
| Issue 45 | Medium | FIX - include `accruedToTreasury` in deposit cap headroom | `a7c7328d` |
| Issue 51 | Low | FIX - re-read `dataProvider` on every call to track Aave rotations | `984e94c6` |
| Issue 49 | Low | DOC - `_emergencyWithdraw` depends on Aave pool state | `c87d90b1` |
| Issue 44 | Medium | FIX - RewardsController claim path plus airdrop sweep | `935cde8b` |

### Support commits

| Area | Action | Commit |
|---|---|---|
| Forwarder develop compatibility | `SwappingYieldForwarder` reuses the inherited `YieldForwarder.forwardToken` implementation and overrides only `_authorizeForwardToken`, removing the duplicate event/function collision on the PR merge commit | `7fd969db` |
| CI semver compatibility | `sol-semver` retries the old-ref build by overlaying changed unversioned source files when the old base ref itself does not compile | `25578019` |

### Review follow-ups folded

- Issues 46 and 48 now name the exact upstream Aave dust reverts: `INVALID_MINT_AMOUNT` for supply dust and `INVALID_BURN_AMOUNT` for withdraw dust.
- `AaveV3DustReverts.t.sol` covers both dust paths against a scaled-balance mock.
- Issue 50 approves exactly the supply amount and clears the pool allowance after `pool.supply`, with a regression for a mock pool that pulls less than approved.
- Issue 45 owns the cap-correctness refactor: slim `getReserveData`, `_cappedTotalSupply`, `getReserveNormalizedIncome`, coverage-safe formatting, NatSpec placement, and the integration cap-reached mock update plus the current-provider integration helper so fork mocks target the provider the strategy actually calls.
- Issue 44 owns the previous RewardsAndSweep Prettier touch-up.
- Issue 49 docs distinguish Aave-backed liquidity from idle assets on paused or inactive reserves.
- Production NatSpec/source comments no longer contain audit issue tags or GitHub-style issue numbers.

### Source impact

- `src/strategies/yieldDonating/AaveV3Strategy.sol` - Aave interface extensions, no cached data-provider immutable, no constructor max approval, exact per-call approval clearing, `claimAaveRewards`, `sweepAirdrop`, `_cappedTotalSupply`, and updated limit/emergency docs.
- `src/factories/AaveV3StrategyFactory.sol` - adds the mainnet RewardsController constant and threads it through deterministic deployment hashing/bytecode.
- `src/core/SwappingYieldForwarder.sol` - compatibility fix for the current `develop` inherited `forwardToken` implementation.
- `scripts/sol-semver.mjs` - old-ref build retry for unversioned support-file overlays.

### Test coverage added

| Test file | Covers |
|---|---|
| `AaveV3DustReverts.t.sol` | Issues 46/48 - Aave scaled mint/burn dust reverts (`INVALID_MINT_AMOUNT` / `INVALID_BURN_AMOUNT`) |
| `AaveV3ApprovalHygiene.t.sol` | Issue 50 - zero constructor allowance, zero post-deposit allowance, residual allowance cleared when pool pulls less than approved |
| `AaveV3PausedFrozen.t.sol` | Issue 47 - baseline plus paused/inactive/frozen branches, idle-balance withdrawal paths, and frozen-withdraw asymmetry |
| `AaveV3DepositCapTreasury.t.sol` | Issue 45 - treasury accrual trims headroom, cap saturation, zero-treasury parity, normalized-income scaling, ceiling rounding |
| `AaveV3DataProviderRotation.t.sol` | Issue 51 - provider rotation reflected immediately in accessor and limit views |
| `AaveV3RewardsAndSweep.t.sol` | Issue 44 - keeper claim payout, unauthorized guard, unset-controller guard, sweep happy path, asset/aToken/zero-balance exclusions |

Existing Aave branch-coverage and integration mocks were updated for the new interfaces and constructor arity.

### Out of scope

- Off-chain Merit/Merkl claims remain handled by the Octant multisig per the audit recommendation.

## Test plan

- [x] Final Aave unit suite: `forge test --match-path 'test/unit/strategies/yieldDonating/AaveV3*.t.sol'` - 29/29 PASS.
- [x] Forwarder compatibility suite: `forge test --match-path 'test/unit/core/*Forwarder*.t.sol'` - 81/81 PASS.
- [x] `bash script/check-natspec.sh` - clean.
- [x] `npx -y @yarnpkg/cli-dist@4.9.2 format:check` - clean.
- [x] `npx -y @yarnpkg/cli-dist@4.9.2 lint` - exit 0, repo warnings only.
- [x] `npx -y @yarnpkg/cli-dist@4.9.2 build` - compile successful.
- [x] `FOUNDRY_DENY_WARNINGS=false forge doc` - clean.
- [x] `./node_modules/.bin/commitlint --from origin/develop --to HEAD` - clean.
- [x] `node scripts/sol-semver.mjs check --old-ref origin/develop --new-ref HEAD` - clean.
- [x] `git diff --check` - clean.
- [x] Verified all commits are signed by `skimaharvey <maximeviard@hotmail.fr>`.
- [x] GitHub PR Standards Check - all jobs green on head `25578019`.

Local note: `npx -y @yarnpkg/cli-dist@4.9.2 test:ci` ran successfully for the non-fork tests (2221 passed) and only failed the fork integration setup because this shell has no `TEST_RPC_URL`; GitHub CI provides that env and passed.
