### PR TITLE
fix(yield-forwarder): Bailsec audit fixes (61, 62, 63 + 64/65/66 docs)

### DIFF
--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -1464,7 +1464,18 @@ abstract contract TokenizedStrategy {
     /**
      * @notice Sets whether to enable burning shares from dragon router during loss protection.
      * @dev Can only be called by the current `management`.
+     *
+     *      Operator note -- dragon-router compatibility: when `dragonRouter` is a
+     *      contract that drains its own share balance on every `report()` (for
+     *      example a YieldForwarder), burn-based loss absorption is best-effort at
+     *      best. Residual balances held by the dragon at loss time are not
+     *      guaranteed, so burns may absorb little or nothing and the shortfall is
+     *      socialized across depositors via PPS reduction. Operators who need to
+     *      rely on `enableBurning = true` should point `dragonRouter` at an EOA,
+     *      multisig, or a splitter that retains balance between reports, not at a
+     *      self-draining forwarder.
      * @param _enableBurning Whether to enable the burning mechanism.
+     * @custom:security Only callable by the current `management`
      */
     function setEnableBurning(bool _enableBurning) external onlyManagement {
         _strategyStorage().enableBurning = _enableBurning;

--- a/src/core/YieldForwarder.sol
+++ b/src/core/YieldForwarder.sol
@@ -64,9 +64,41 @@ interface IReportable {
  *      `reportAndForward` (and, for the swapping variant, `reportSwapAndForward`).
  *      Management must retain an operational channel (multisig, automation key,
  *      etc.) to call those keeper-gated strategy functions directly. For airdrops
- *      routed through `sweepAirdrop`, management should immediately follow up
- *      with `YieldForwarder.forwardToken(airdropToken)` to move the swept balance
- *      onward to the hardcoded receiver.
+ *      routed through `sweepAirdrop`, management should coordinate an immediate
+ *      keeper call to `YieldForwarder.forwardToken(airdropToken)` to move the
+ *      swept balance onward to the hardcoded receiver.
+ *
+ *      MIGRATION NOTE -- 14-day dragon-router cooldown:
+ *      Because this contract is intended to act as both `keeper` and
+ *      `dragonRouter`, migrating a strategy to or away from a forwarder is
+ *      coupled to the TokenizedStrategy dragon-router cooldown. On
+ *      TokenizedStrategy, `setKeeper(address)` takes effect immediately, but
+ *      `setDragonRouter(address)` only enqueues the change -- it emits
+ *      `PendingDragonRouterChange` and starts a 14-day timer, and the new
+ *      router only becomes active once anyone calls
+ *      `finalizeDragonRouterChange()` after the cooldown has elapsed. In
+ *      practice every forwarder swap is a >=14-day operation. The delay is an
+ *      intentional security invariant of the yield-skim design and is not
+ *      bypassable by design.
+ *
+ *      For compromised-keeper incident response, the correct posture is:
+ *        1. Call `setKeeper(newKeeper)` on the strategy (onlyManagement).
+ *           This takes effect immediately and neutralises the compromised
+ *           forwarder: the forwarder's `reportAndForward` (and
+ *           `reportSwapAndForward`) now revert inside `strategy.report()`
+ *           because the strategy no longer recognises the old forwarder as a
+ *           keeper. No 14-day wait is involved in this step.
+ *        2. Concurrently call `setDragonRouter(newRouter)` on the strategy
+ *           to queue the donation-address change and start the 14-day
+ *           cooldown.
+ *        3. After 14 days, call `finalizeDragonRouterChange()` on the
+ *           strategy to activate the new dragon router.
+ *        4. Optional: `shutdownStrategy()` can be used at any point during
+ *           the response to block new deposits and mints. It does NOT stop
+ *           `report()`, `tend()`, or donation-share minting on profit --
+ *           those continue to work post-shutdown -- so shutdown is a
+ *           deposit-inflow brake, not a way to neutralise a compromised
+ *           keeper. Use step 1 for that.
  */
 contract YieldForwarder is ReentrancyGuard {
     // ============================================

--- a/src/core/YieldForwarder.sol
+++ b/src/core/YieldForwarder.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /// @notice Minimal interface for strategy share redemption
@@ -101,6 +102,8 @@ interface IReportable {
  *           keeper. Use step 1 for that.
  */
 contract YieldForwarder is ReentrancyGuard {
+    using SafeERC20 for IERC20;
+
     // ============================================
     // ERRORS
     // ============================================
@@ -124,6 +127,12 @@ contract YieldForwarder is ReentrancyGuard {
     /// @param shares Amount of shares redeemed
     /// @param assets Amount of underlying assets forwarded
     event YieldForwarded(address indexed strategy, address indexed receiver, uint256 shares, uint256 assets);
+
+    /// @notice Emitted when an arbitrary token balance is forwarded to the receiver
+    /// @param token Address of the token whose balance was flushed
+    /// @param receiver Address that received the token balance
+    /// @param amount Amount of the token transferred
+    event TokenForwarded(address indexed token, address indexed receiver, uint256 amount);
 
     // ============================================
     // STATE
@@ -179,5 +188,42 @@ contract YieldForwarder is ReentrancyGuard {
         assets = IRedeemable(strategy).redeem(shares, receiver, address(this), maxLoss);
 
         emit YieldForwarded(strategy, receiver, shares, assets);
+    }
+
+    /**
+     * @notice Forwards the full balance of an arbitrary ERC-20 token to the immutable receiver
+     * @dev Only callable by the authorized keeper. The caller picks which token to
+     *      flush, but cannot pick where it goes -- the destination is the
+     *      construction-time `receiver`, so no new destination trust surface is
+     *      introduced relative to the ordinary report path. Intended for airdrops
+     *      and other non-pipeline tokens that arrive at this contract (for example
+     *      when this forwarder is the `dragonRouter` of a strategy whose
+     *      `sweepAirdrop` delivers non-asset tokens here).
+     *
+     *      Strategy share tokens SHOULD NOT be flushed through this path for normal
+     *      yield accounting -- use {reportAndForward} so shares are redeemed to the
+     *      underlying asset first. Calling `forwardToken(strategy)` is still safe
+     *      (receiver ends up holding redeemable shares, no loss of funds), and is in
+     *      fact the operational workaround when `reportAndForward` is temporarily
+     *      blocked by tight `maxRedeem` liquidity on the strategy.
+     *
+     *      Returns silently (without reverting) if the balance is zero so keepers and
+     *      bots can call it speculatively without having to pre-check every token.
+     * @param token ERC-20 token whose balance should be flushed to the receiver
+     */
+    function forwardToken(address token) external nonReentrant {
+        _authorizeForwardToken();
+
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        if (balance == 0) return;
+
+        IERC20(token).safeTransfer(receiver, balance);
+        emit TokenForwarded(token, receiver, balance);
+    }
+
+    /// @dev Authorizes forwardToken callers. Derived forwarders can extend this
+    ///      when they have an additional governance source.
+    function _authorizeForwardToken() internal view virtual {
+        if (msg.sender != keeper) revert OnlyKeeper();
     }
 }

--- a/src/core/YieldForwarder.sol
+++ b/src/core/YieldForwarder.sol
@@ -43,6 +43,19 @@ interface IReportable {
  *      - Keeper-gated: only the designated keeper can trigger
  *      - Single-purpose: assets can only flow to the hardcoded receiver
  *      - Strategy is passed as a call-time parameter to avoid circular dependencies
+ *
+ *      COMPATIBILITY NOTE -- `enableBurning` loss absorption:
+ *      A YieldForwarder is not a reliable `dragonRouter` for loss absorption.
+ *      `reportAndForward` tries to drain the forwarder's share balance after every
+ *      report, but the redemption is only best-effort: it is capped at
+ *      `strategy.maxRedeem(forwarder)` (residual shares remain when external vault
+ *      headroom is tight) and it is skipped entirely when `convertToAssets(shares)`
+ *      rounds to zero on a loss-impaired strategy (dust share balances remain).
+ *      Under `enableBurning = true`, only whatever happens to be sitting at the
+ *      forwarder at loss time can be burned, and that amount is not guaranteed.
+ *      Operators who want to actually rely on burn-based loss protection must use
+ *      a non-forwarder dragon (EOA, multisig, or a splitter that retains balance
+ *      between reports).
  */
 contract YieldForwarder is ReentrancyGuard {
     // ============================================

--- a/src/core/YieldForwarder.sol
+++ b/src/core/YieldForwarder.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { ReentrancyGuard } from "@openzeppelin/contracts/utils/ReentrancyGuard.sol";
 
 /// @notice Minimal interface for strategy share redemption
@@ -14,6 +15,14 @@ interface IRedeemable {
     /// @param maxLoss Maximum acceptable loss in basis points
     /// @return assets Amount of assets returned
     function redeem(uint256 shares, address receiver, address owner, uint256 maxLoss) external returns (uint256 assets);
+}
+
+/// @notice Minimal interface for ERC-4626 maxRedeem
+interface IMaxRedeem {
+    /// @notice Maximum shares redeemable by `owner` right now (ERC-4626)
+    /// @param owner Address whose redeem headroom is queried
+    /// @return maxShares Upper bound on shares redeemable by `owner`
+    function maxRedeem(address owner) external view returns (uint256 maxShares);
 }
 
 /// @notice Minimal interface for triggering a strategy report
@@ -173,16 +182,28 @@ contract YieldForwarder is ReentrancyGuard {
      *      If report() produces no profit shares, the function returns 0 without reverting
      *      (the report itself may still be useful for loss accounting).
      *
+     *      The inner redemption is capped at `strategy.maxRedeem(this)` so that a tight
+     *      external vault (idle + vaultMax shrinking below the forwarder's share balance)
+     *      cannot roll back `report()`. Residual shares remain at the forwarder and are
+     *      picked up on a later call; `report()`'s side effects always commit.
      * @param strategy Address of the strategy contract (must implement IReportable, IRedeemable, IERC20)
      * @param maxLoss Maximum acceptable loss in basis points for the redemption
      * @return assets Amount of underlying assets forwarded to receiver (0 if no profit shares)
+     * @custom:security Only callable by the immutable `keeper`; destination is the immutable `receiver`
      */
     function reportAndForward(address strategy, uint256 maxLoss) external nonReentrant returns (uint256 assets) {
         if (msg.sender != keeper) revert OnlyKeeper();
 
         IReportable(strategy).report();
 
-        uint256 shares = IERC20(strategy).balanceOf(address(this));
+        uint256 balance = IERC20(strategy).balanceOf(address(this));
+        if (balance == 0) return 0;
+
+        // Cap at strategy.maxRedeem so the inner redeem does not revert when external
+        // vault liquidity (idle + vaultMax) shrinks below the forwarder's share balance.
+        // Residual shares stay at the forwarder and are picked up on a later report once
+        // headroom recovers; the report() side effects above still commit.
+        uint256 shares = Math.min(balance, IMaxRedeem(strategy).maxRedeem(address(this)));
         if (shares == 0) return 0;
 
         assets = IRedeemable(strategy).redeem(shares, receiver, address(this), maxLoss);

--- a/src/core/YieldForwarder.sol
+++ b/src/core/YieldForwarder.sol
@@ -56,6 +56,17 @@ interface IReportable {
  *      Operators who want to actually rely on burn-based loss protection must use
  *      a non-forwarder dragon (EOA, multisig, or a splitter that retains balance
  *      between reports).
+ *
+ *      OPERATIONAL NOTE -- airdrop / keeper-only strategy APIs:
+ *      When this contract is wired in as a strategy's `keeper`, any strategy
+ *      function gated by `onlyKeepers` (for example SparkStrategy.sweepAirdrop)
+ *      cannot be invoked by this contract -- this forwarder only exposes
+ *      `reportAndForward` (and, for the swapping variant, `reportSwapAndForward`).
+ *      Management must retain an operational channel (multisig, automation key,
+ *      etc.) to call those keeper-gated strategy functions directly. For airdrops
+ *      routed through `sweepAirdrop`, management should immediately follow up
+ *      with `YieldForwarder.forwardToken(airdropToken)` to move the swept balance
+ *      onward to the hardcoded receiver.
  */
 contract YieldForwarder is ReentrancyGuard {
     // ============================================

--- a/src/core/YieldForwarder.sol
+++ b/src/core/YieldForwarder.sol
@@ -25,6 +25,14 @@ interface IMaxRedeem {
     function maxRedeem(address owner) external view returns (uint256 maxShares);
 }
 
+/// @notice Minimal interface for ERC-4626 convertToAssets (floor rounding)
+interface IConvertible {
+    /// @notice Preview the assets returned for `shares`, rounded down (ERC-4626)
+    /// @param shares Amount of shares to preview
+    /// @return assets Assets that would be returned by redeem(), before fees/loss
+    function convertToAssets(uint256 shares) external view returns (uint256 assets);
+}
+
 /// @notice Minimal interface for triggering a strategy report
 interface IReportable {
     /// @notice Trigger a strategy report (realize gains/losses, mint profit shares)
@@ -205,6 +213,14 @@ contract YieldForwarder is ReentrancyGuard {
         // headroom recovers; the report() side effects above still commit.
         uint256 shares = Math.min(balance, IMaxRedeem(strategy).maxRedeem(address(this)));
         if (shares == 0) return 0;
+
+        // When totalAssets < totalSupply (a realised loss that was not absorbed because
+        // enableBurning is false), small share balances floor to zero assets and
+        // TokenizedStrategy.redeem reverts with ZERO_ASSETS. That revert would roll back
+        // the report() call above too. Skip the redeem and preserve the accounting update;
+        // the dust share balance stays at the forwarder and is picked up by a later report
+        // once the imbalance resolves on its own.
+        if (IConvertible(strategy).convertToAssets(shares) == 0) return 0;
 
         assets = IRedeemable(strategy).redeem(shares, receiver, address(this), maxLoss);
 

--- a/src/strategies/yieldDonating/SparkStrategy.sol
+++ b/src/strategies/yieldDonating/SparkStrategy.sol
@@ -82,6 +82,16 @@ contract SparkStrategy is ERC4626Strategy {
      * - Transfers entire balance to dragon router
      * - Can be called by both keepers and management for operational flexibility
      * - Emits event for transparency
+     *
+     * @custom:operator-note When `keeper` is a YieldForwarder, this function
+     *                      cannot be invoked by the keeper role (YieldForwarder
+     *                      exposes no strategy-API proxy). In that configuration
+     *                      `management` must retain a separate operational
+     *                      channel to call `sweepAirdrop`. If `dragonRouter` is
+     *                      also a YieldForwarder, follow the sweep with
+     *                      `YieldForwarder.forwardToken(_token)` so the swept
+     *                      balance is forwarded to the hardcoded receiver (see
+     *                      YieldForwarder NatSpec).
      */
     function sweepAirdrop(address _token) external onlyKeepers {
         // Safety checks: prevent sweeping critical tokens

--- a/test/unit/core/YieldForwarderForwardToken.t.sol
+++ b/test/unit/core/YieldForwarderForwardToken.t.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+/// @notice Pre-fix, a `YieldForwarder` deployed as a strategy's `dragonRouter`
+///         had no path for arbitrary ERC-20 balances. If Spark (or any
+///         airdrop-emitting strategy) called `sweepAirdrop` while the forwarder was
+///         the router, the swept tokens were stuck at the forwarder forever. Fix:
+///         keeper-gated `forwardToken(address)` that flushes any ERC-20 balance
+///         to the immutable `receiver`.
+contract YieldForwarderForwardTokenTest is Test {
+    YieldForwarder internal forwarder;
+    ERC20Mock internal token;
+
+    address internal receiver = address(0xBEEF);
+    address internal keeperEOA = address(0xCAFE);
+    address internal randomCaller = address(0xD00D);
+
+    function setUp() public {
+        forwarder = new YieldForwarder(receiver, keeperEOA);
+        token = new ERC20Mock();
+    }
+
+    // --- YieldForwarder.forwardToken ---
+
+    /// @notice Keeper flushes the full token balance to `receiver`.
+    function test_forwardToken_keeperCanForwardToReceiver() public {
+        token.mint(address(forwarder), 123 ether);
+
+        vm.prank(keeperEOA);
+        forwarder.forwardToken(address(token));
+
+        assertEq(token.balanceOf(receiver), 123 ether, "receiver must get full balance");
+        assertEq(token.balanceOf(address(forwarder)), 0, "forwarder must be drained");
+    }
+
+    /// @notice Non-keeper callers cannot flush balances, even though the destination is fixed.
+    function test_forwardToken_revertsWhenNotKeeper() public {
+        token.mint(address(forwarder), 7 ether);
+
+        vm.prank(randomCaller);
+        vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
+        forwarder.forwardToken(address(token));
+
+        assertEq(token.balanceOf(address(forwarder)), 7 ether, "forwarder keeps balance on unauthorized call");
+        assertEq(token.balanceOf(receiver), 0, "receiver gets nothing");
+    }
+
+    /// @notice Zero balance is a no-op for the keeper.
+    function test_forwardToken_zeroBalanceIsNoop() public {
+        assertEq(token.balanceOf(address(forwarder)), 0, "precondition: zero");
+
+        vm.prank(keeperEOA);
+        forwarder.forwardToken(address(token));
+
+        assertEq(token.balanceOf(receiver), 0, "no transfer on zero balance");
+    }
+
+    /// @notice Emits TokenForwarded with the right (token, receiver, amount) tuple.
+    function test_forwardToken_emitsTokenForwardedEvent() public {
+        token.mint(address(forwarder), 50 ether);
+
+        vm.expectEmit(true, true, false, true);
+        emit YieldForwarder.TokenForwarded(address(token), receiver, 50 ether);
+
+        vm.prank(keeperEOA);
+        forwarder.forwardToken(address(token));
+    }
+
+    /// @notice Destination is locked to the immutable `receiver`.
+    function test_forwardToken_destinationIsImmutableReceiver() public {
+        token.mint(address(forwarder), 42 ether);
+
+        vm.prank(keeperEOA);
+        forwarder.forwardToken(address(token));
+
+        assertEq(token.balanceOf(keeperEOA), 0, "caller must not get tokens");
+        assertEq(token.balanceOf(receiver), 42 ether, "only receiver gets tokens");
+    }
+}

--- a/test/unit/core/YieldForwarderMaxRedeem.t.sol
+++ b/test/unit/core/YieldForwarderMaxRedeem.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+/// @notice Programmable share-token + strategy mock. Exposes setters for `maxRedeem`
+///         and for the forwarder's share balance so the test can place the forwarder
+///         in the pre-fix revert state (`balance > maxRedeem`).
+contract MockStrategy is ERC20Mock {
+    ERC20Mock public immutable underlying;
+    uint256 internal _maxRedeemValue;
+    bool public reported;
+    uint256 public lastRedeemedShares;
+    uint256 public constant REDEEM_RATE = 1; // 1 share => 1 unit of underlying (test-local)
+
+    constructor(address _underlying) {
+        underlying = ERC20Mock(_underlying);
+    }
+
+    function asset() external view returns (address) {
+        return address(underlying);
+    }
+
+    function setMaxRedeem(uint256 value) external {
+        _maxRedeemValue = value;
+    }
+
+    function maxRedeem(address) external view returns (uint256) {
+        return _maxRedeemValue;
+    }
+
+    function convertToAssets(uint256 shares) external pure returns (uint256) {
+        // Mirrors the 1:1 REDEEM_RATE used by `redeem`. Non-zero shares => non-zero
+        // assets, so the rounding-skip guard never fires in these tests
+        // (this suite targets the maxRedeem cap path, not the rounding path).
+        return shares * REDEEM_RATE;
+    }
+
+    function report() external returns (uint256, uint256) {
+        reported = true;
+        return (0, 0);
+    }
+
+    function redeem(uint256 shares, address receiver, address owner, uint256) external returns (uint256 assets) {
+        // Pre-fix guard would trip here if shares > _maxRedeemValue.
+        require(shares <= _maxRedeemValue, "MAX_REDEEM");
+        _burn(owner, shares);
+        assets = shares * REDEEM_RATE;
+        underlying.mint(receiver, assets);
+        lastRedeemedShares = shares;
+    }
+}
+
+/// @notice Pre-fix, `reportAndForward` passed `IERC20(strategy).balanceOf(forwarder)`
+///         directly into `redeem`. If external vault liquidity shrank,
+///         `strategy.maxRedeem(forwarder) < balance` and the inner revert rolled back
+///         the entire call, including `report()`. Fix caps shares at `maxRedeem` so
+///         the report always commits and residual shares stay at the forwarder for a
+///         later call.
+contract YieldForwarderMaxRedeemTest is Test {
+    YieldForwarder internal forwarder;
+    ERC20Mock internal underlying;
+    MockStrategy internal strategy;
+
+    address internal receiver = address(0xBEEF);
+    address internal keeperEOA = address(0xCAFE);
+
+    function setUp() public {
+        underlying = new ERC20Mock();
+        forwarder = new YieldForwarder(receiver, keeperEOA);
+        strategy = new MockStrategy(address(underlying));
+    }
+
+    // --- YieldForwarder.reportAndForward ---
+
+    /// @notice Happy path: maxRedeem >= balance, full balance is redeemed.
+    function test_reportAndForward_maxRedeemAboveBalance_redeemsAll() public {
+        strategy.mint(address(forwarder), 100 ether);
+        strategy.setMaxRedeem(1_000 ether);
+
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 0);
+
+        assertEq(assets, 100 ether, "all shares redeemed");
+        assertEq(strategy.balanceOf(address(forwarder)), 0, "no residual shares");
+        assertEq(underlying.balanceOf(receiver), 100 ether, "receiver got assets");
+        assertTrue(strategy.reported(), "report() executed");
+    }
+
+    /// @notice Fix path: maxRedeem < balance. Pre-fix this would revert inside redeem and
+    ///         roll back the report() above. Post-fix: redeem is capped at maxRedeem,
+    ///         report() commits, residual shares remain for a later call.
+    function test_reportAndForward_maxRedeemBelowBalance_capsAtMaxRedeem() public {
+        strategy.mint(address(forwarder), 100 ether);
+        strategy.setMaxRedeem(30 ether);
+
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 0);
+
+        assertEq(assets, 30 ether, "redeem is capped at maxRedeem");
+        assertEq(strategy.balanceOf(address(forwarder)), 70 ether, "residual shares stay at forwarder");
+        assertEq(underlying.balanceOf(receiver), 30 ether, "receiver gets the cap amount");
+        assertTrue(strategy.reported(), "report() still commits");
+    }
+
+    /// @notice When maxRedeem is zero (locked vault), skip the redeem entirely but still commit report().
+    function test_reportAndForward_maxRedeemZero_skipsRedeem() public {
+        strategy.mint(address(forwarder), 100 ether);
+        strategy.setMaxRedeem(0);
+
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 0);
+
+        assertEq(assets, 0, "no redeem when maxRedeem is zero");
+        assertEq(strategy.balanceOf(address(forwarder)), 100 ether, "all shares retained");
+        assertEq(underlying.balanceOf(receiver), 0, "receiver gets nothing");
+        assertTrue(strategy.reported(), "report() commits regardless");
+    }
+
+    /// @notice Forwarder holds zero shares: early return, no maxRedeem probe needed.
+    function test_reportAndForward_zeroBalance_earlyReturn() public {
+        strategy.setMaxRedeem(100 ether);
+
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(strategy), 0);
+
+        assertEq(assets, 0, "early return on zero balance");
+        assertTrue(strategy.reported(), "report() still runs");
+    }
+}

--- a/test/unit/core/YieldForwarderRoundDown.t.sol
+++ b/test/unit/core/YieldForwarderRoundDown.t.sol
@@ -1,0 +1,128 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { YieldForwarder } from "src/core/YieldForwarder.sol";
+
+/// @notice Strategy mock whose convertToAssets uses floor((shares * totalAssets) / totalSupply)
+///         and whose redeem reverts with ZERO_ASSETS if the preview rounds to zero.
+///         Mirrors the real TokenizedStrategy.redeem guard so we can reproduce the pre-fix
+///         DoS (1 wei share dust on a loss-impaired strategy bricks reportAndForward).
+contract LossImpairedStrategy is ERC20Mock {
+    ERC20Mock public immutable underlying;
+    uint256 public totalAssetsStored; // test-visible shadow of TokenizedStrategy.totalAssets
+    bool public reported;
+    bool public redeemCalled;
+
+    constructor(address _underlying) {
+        underlying = ERC20Mock(_underlying);
+    }
+
+    function asset() external view returns (address) {
+        return address(underlying);
+    }
+
+    function setTotalAssets(uint256 v) external {
+        totalAssetsStored = v;
+    }
+
+    function maxRedeem(address) external pure returns (uint256) {
+        // Unlimited for these tests -- we only care about the convertToAssets preview.
+        return type(uint256).max;
+    }
+
+    function convertToAssets(uint256 shares) external view returns (uint256) {
+        uint256 ts = totalSupply();
+        if (ts == 0) return shares;
+        return (shares * totalAssetsStored) / ts; // floor
+    }
+
+    function report() external returns (uint256, uint256) {
+        reported = true;
+        return (0, 0);
+    }
+
+    function redeem(uint256 shares, address receiver, address owner, uint256) external returns (uint256 assets) {
+        redeemCalled = true;
+        uint256 ts = totalSupply();
+        assets = ts == 0 ? shares : (shares * totalAssetsStored) / ts;
+        require(assets > 0, "ZERO_ASSETS");
+        _burn(owner, shares);
+        totalAssetsStored -= assets;
+        underlying.mint(receiver, assets);
+    }
+}
+
+/// @notice Pre-fix, a loss-impaired strategy (totalAssets < totalSupply with
+///         enableBurning=false) lets any holder brick reportAndForward by gifting
+///         1 wei of strategy share to the forwarder. The inner redeem floors to zero
+///         assets, reverts with ZERO_ASSETS, and rolls back the outer report(). Fix:
+///         preview convertToAssets; if it floors to zero, skip the redeem and preserve
+///         the report() side effects.
+contract YieldForwarderRoundDownTest is Test {
+    YieldForwarder internal forwarder;
+    ERC20Mock internal underlying;
+
+    address internal receiver = address(0xBEEF);
+    address internal keeperEOA = address(0xCAFE);
+
+    function setUp() public {
+        underlying = new ERC20Mock();
+        forwarder = new YieldForwarder(receiver, keeperEOA);
+    }
+
+    /// @dev Puts the strategy into totalAssets < totalSupply, with `dust` shares minted
+    ///      to the forwarder so convertToAssets(dust) floors to zero.
+    function _impair(
+        LossImpairedStrategy s,
+        address shareholder,
+        uint256 shareholderShares,
+        address forwarderAddr,
+        uint256 dust
+    ) internal {
+        // Mint a large share float to a shareholder so totalSupply dominates totalAssets.
+        s.mint(shareholder, shareholderShares);
+        // Give the forwarder the dust balance.
+        s.mint(forwarderAddr, dust);
+        // Set totalAssets below totalSupply so (dust * totalAssets) / totalSupply rounds to 0.
+        s.setTotalAssets(shareholderShares - 1);
+    }
+
+    // --- YieldForwarder.reportAndForward ---
+
+    /// @notice Pre-fix DoS reproduction: dust share on a loss-impaired strategy.
+    ///         Post-fix: call succeeds, report() commits, dust stays at forwarder,
+    ///         receiver gets nothing.
+    function test_reportAndForward_dustOnLossImpaired_skipsRedeem() public {
+        LossImpairedStrategy s = new LossImpairedStrategy(address(underlying));
+        _impair(s, address(0xA11CE), 1_000 ether, address(forwarder), 1);
+
+        assertEq(s.convertToAssets(1), 0, "precondition: dust rounds to zero");
+
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(s), 0);
+
+        assertEq(assets, 0, "no assets forwarded");
+        assertEq(s.balanceOf(address(forwarder)), 1, "dust share retained");
+        assertEq(underlying.balanceOf(receiver), 0, "receiver gets nothing");
+        assertTrue(s.reported(), "report() commits");
+        assertFalse(s.redeemCalled(), "redeem must be skipped, not called-and-failed");
+    }
+
+    /// @notice Sanity: when convertToAssets does NOT round to zero, the redeem runs normally.
+    function test_reportAndForward_nonZeroPreview_redeemsNormally() public {
+        LossImpairedStrategy s = new LossImpairedStrategy(address(underlying));
+        // Healthy 1:1 state -- shares to assets ratio 1.
+        s.mint(address(forwarder), 100 ether);
+        s.setTotalAssets(100 ether);
+
+        vm.prank(keeperEOA);
+        uint256 assets = forwarder.reportAndForward(address(s), 0);
+
+        assertEq(assets, 100 ether, "full redeem in healthy state");
+        assertEq(s.balanceOf(address(forwarder)), 0, "no residual");
+        assertEq(underlying.balanceOf(receiver), 100 ether, "receiver got assets");
+        assertTrue(s.redeemCalled(), "redeem was exercised");
+    }
+}


### PR DESCRIPTION
## Summary

Bailsec audit fixes for `YieldForwarder`. One conventional commit per issue/doc item, with the swapping-forwarder mirrors kept out of this PR.

| Bailsec | Severity | Action | Commit |
|---|---|---|---|
| 61 | Low | FIX - skip redeem when `convertToAssets` rounds to zero on a loss-impaired strategy | `31080126` |
| 62 | Low | FIX - cap shares at `strategy.maxRedeem(forwarder)` via `Math.min` | `5dd76827` |
| 63 | Low | FIX - keeper-gated `forwardToken(address)` flushing any ERC-20 to the immutable receiver | `28d1886d` |
| 64 | Info | DOC - `enableBurning` incompatibility note on `YieldForwarder` | `18b291c0` |
| 65 | Info | DOC - keeper-only strategy APIs operational note | `6c22d9bd` |
| 66 | Info | DOC - migration cooldown note | `9887ba7f` |

### Source impact

- `src/core/YieldForwarder.sol` - adds `IMaxRedeem` + `IConvertible` interfaces, `forwardToken(address)`, `TokenForwarded` event; guards `reportAndForward` against zero-asset redeems and maxRedeem violations; documents the operational notes.
- `src/core/TokenizedStrategy.sol` - Bailsec 64 documentation.
- `src/strategies/yieldDonating/SparkStrategy.sol` - Bailsec 65 documentation.

### Explicit boundary

`SwappingYieldForwarder` is not changed in this PR. The swapping-path mirrors for Bailsec 61 and 62 live in PR 417 at commit `7d936b96`.

### Test coverage added

| Test file | Covers |
|---|---|
| `test/unit/core/YieldForwarderRoundDown.t.sol` | 61 - dust share on loss-impaired strategy no longer reverts `reportAndForward`; healthy state regression |
| `test/unit/core/YieldForwarderMaxRedeem.t.sol` | 62 - four `maxRedeem` states: above balance / below balance / zero / zero balance |
| `test/unit/core/YieldForwarderForwardToken.t.sol` | 63 - keeper-gated forwarding, unauthorized caller rejection, zero-balance no-op, immutable destination, event emission |

## Test plan

- [x] `forge test --match-path 'test/unit/core/YieldForwarder*.t.sol'` - 27/27 PASS
- [x] `bash script/check-natspec.sh` - clean
- [x] `node_modules/.bin/prettier --config .prettierrc --plugin=prettier-plugin-solidity --check ...changed files...` - clean
- [x] `node_modules/.bin/commitlint --from origin/develop --to HEAD` - clean
- [x] `git diff --check origin/develop...HEAD` - clean
