### PR TITLE
feat(swappers): swapper audit fixes (61, 62, 67, 68, 70, 72-76) + Cantina 1, 2

### DIFF
--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ISwapper } from "./interfaces/ISwapper.sol";
 import { ITokenizedStrategy } from "./interfaces/ITokenizedStrategy.sol";
@@ -66,6 +67,14 @@ contract SwappingYieldForwarder is YieldForwarder {
     /// @param actual Amount actually reported
     error InsufficientSwapOutput(uint256 expected, uint256 actual);
 
+    /// @notice Thrown when setMinSlippageBps is called with a value above MAX_BPS
+    error InvalidSlippageBps();
+
+    /// @notice Thrown when the caller's minAmountOut falls below the admin-set floor
+    /// @param floor Required minimum (assetsIn * minSlippageBps / MAX_BPS)
+    /// @param supplied The minAmountOut the keeper passed in
+    error SlippageFloorTooLoose(uint256 floor, uint256 supplied);
+
     // ============================================
     // EVENTS
     // ============================================
@@ -89,6 +98,11 @@ contract SwappingYieldForwarder is YieldForwarder {
     /// @param newSwapper The newly installed ISwapper implementation
     event SwapperUpdated(address indexed oldSwapper, address indexed newSwapper);
 
+    /// @notice Emitted when the admin-set slippage floor is updated
+    /// @param oldBps Previous floor (basis points of assetsIn)
+    /// @param newBps New floor
+    event MinSlippageBpsUpdated(uint16 oldBps, uint16 newBps);
+
     // ============================================
     // STATE
     // ============================================
@@ -108,6 +122,16 @@ contract SwappingYieldForwarder is YieldForwarder {
     /// @dev Settable by vault.management() to pivot to a different adapter
     ///      (e.g. a new pool tier, a new DEX version) without redeploying.
     ISwapper public swapper;
+
+    /// @notice Denominator for basis-point calculations (10_000 = 100%)
+    uint16 public constant MAX_BPS = 10_000;
+
+    /// @notice Floor on minAmountOut, denominated as basis points of assetsIn.
+    /// @dev Set at construction so the deployment config explicitly chooses whether
+    ///      the floor is active from the first report. A value of 0 is an intentional
+    ///      opt-out for routes where management relies on the keeper's oracle-informed
+    ///      minAmountOut instead of a near-parity floor.
+    uint16 public minSlippageBps;
 
     // ============================================
     // MODIFIERS
@@ -132,19 +156,23 @@ contract SwappingYieldForwarder is YieldForwarder {
     /// @param _targetAsset Address of the desired output token after swapping
     /// @param _swapper Initial ISwapper implementation for DEX routing
     /// @param _vault Vault contract whose management() controls swapper rotation
+    /// @param _minSlippageBps Initial floor in basis points of assetsIn (0 disables)
     constructor(
         address _receiver,
         address _keeper,
         address _targetAsset,
         address _swapper,
-        address _vault
+        address _vault,
+        uint16 _minSlippageBps
     ) YieldForwarder(_receiver, _keeper) {
         if (_targetAsset == address(0)) revert InvalidTargetAsset();
         if (_swapper == address(0)) revert InvalidSwapper();
         if (_vault == address(0)) revert InvalidVault();
+        if (_minSlippageBps > MAX_BPS) revert InvalidSlippageBps();
         targetAsset = _targetAsset;
         swapper = ISwapper(_swapper);
         vault = _vault;
+        minSlippageBps = _minSlippageBps;
     }
 
     // ============================================
@@ -161,6 +189,15 @@ contract SwappingYieldForwarder is YieldForwarder {
         if (_newSwapper == address(0)) revert InvalidSwapper();
         emit SwapperUpdated(address(swapper), _newSwapper);
         swapper = ISwapper(_newSwapper);
+    }
+
+    /// @notice Update the slippage floor applied to the keeper's minAmountOut
+    /// @dev Authorized by vault.management(). Passing 0 disables the floor.
+    /// @param _bps New floor in basis points of assetsIn (max 10_000)
+    function setMinSlippageBps(uint16 _bps) external onlyVaultManagement {
+        if (_bps > MAX_BPS) revert InvalidSlippageBps();
+        emit MinSlippageBpsUpdated(minSlippageBps, _bps);
+        minSlippageBps = _bps;
     }
 
     /**
@@ -199,6 +236,24 @@ contract SwappingYieldForwarder is YieldForwarder {
         }
 
         address assetIn = IERC4626Asset(strategy).asset();
+
+        // Configured slippage floor: keeper's minAmountOut must be at least
+        // `assetsIn * minSlippageBps / MAX_BPS`, normalized from `assetIn` decimals
+        // into `targetAsset` decimals so mixed-decimal pairs (USDC 6 <-> USDS 18, etc.)
+        // aren't silently bypassed or DoS'd. A constructor value of 0 disables the floor.
+        // The 1:1 value assumption matches the documented use case (near-parity pairs:
+        // stablecoin<>stablecoin, LST<>LST); admins must keep the floor at 0 for
+        // non-parity pairs.
+        uint16 floorBps = minSlippageBps;
+        if (floorBps != 0) {
+            uint8 inDecimals = IERC20Metadata(assetIn).decimals();
+            uint8 outDecimals = IERC20Metadata(targetAsset).decimals();
+            uint256 assetsInScaled = inDecimals >= outDecimals
+                ? assetsIn / (10 ** (inDecimals - outDecimals))
+                : assetsIn * (10 ** (outDecimals - inDecimals));
+            uint256 floor = (assetsInScaled * floorBps) / MAX_BPS;
+            if (minAmountOut < floor) revert SlippageFloorTooLoose(floor, minAmountOut);
+        }
 
         // Approve swapper and execute swap to receiver. The swapper pulls
         // via transferFrom and returns any unused tokenIn before returning.

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -129,6 +129,12 @@ contract SwappingYieldForwarder is YieldForwarder {
     /// @param newBps New floor
     event MinSlippageBpsUpdated(uint16 oldBps, uint16 newBps);
 
+    /// @notice Emitted when an arbitrary token balance is forwarded to the receiver
+    /// @param token Address of the token whose balance was flushed
+    /// @param receiver Address that received the token balance
+    /// @param amount Amount of the token transferred
+    event TokenForwarded(address indexed token, address indexed receiver, uint256 amount);
+
     // ============================================
     // STATE
     // ============================================
@@ -318,5 +324,24 @@ contract SwappingYieldForwarder is YieldForwarder {
         if (assetsOut < minAmountOut) revert InsufficientSwapOutput(minAmountOut, assetsOut);
 
         emit YieldSwappedAndForwarded(strategy, receiver, shares, assetsIn, assetsOut);
+    }
+
+    /**
+     * @notice Forwards the full balance of an arbitrary ERC-20 token to the immutable receiver
+     * @dev Allows either the keeper or the vault management role to recover token balances
+     *      that are outside the normal report/swap pipeline. The caller chooses only the token;
+     *      the destination remains fixed to `receiver`.
+     * @param token ERC-20 token whose balance should be flushed to the receiver
+     */
+    function forwardToken(address token) external nonReentrant {
+        if (msg.sender != keeper && msg.sender != ITokenizedStrategy(vault).management()) {
+            revert OnlyVaultManagement();
+        }
+
+        uint256 balance = IERC20(token).balanceOf(address(this));
+        if (balance == 0) return;
+
+        IERC20(token).safeTransfer(receiver, balance);
+        emit TokenForwarded(token, receiver, balance);
     }
 }

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ISwapper } from "./interfaces/ISwapper.sol";
+import { ITokenizedStrategy } from "./interfaces/ITokenizedStrategy.sol";
 import { YieldForwarder, IRedeemable, IReportable } from "./YieldForwarder.sol";
 
 /// @notice Minimal ERC4626 interface to read a strategy's underlying asset
@@ -33,10 +34,11 @@ interface IERC4626Asset {
  *      minted to this contract -> redeem shares directly to receiver
  *
  *      DESIGN:
- *      - Fully immutable: no admin, no upgrades, no sweep
- *      - Keeper-gated: only the designated keeper can trigger
+ *      - Keeper-gated: only the designated keeper can trigger yield forwarding
  *      - Single-purpose: assets can only flow to the hardcoded receiver
- *      - Pluggable swap: ISwapper adapter handles DEX-specific logic
+ *      - Pluggable swap: ISwapper adapter handles DEX-specific logic; the adapter
+ *        itself is settable by the vault's management() role so deeper pools or
+ *        newer adapter versions can be adopted without redeploying the forwarder
  *      - Dual-mode: keeper picks swap vs no-swap path at call-time
  *      - Strategy is passed as a call-time parameter to avoid circular dependencies
  */
@@ -52,6 +54,17 @@ contract SwappingYieldForwarder is YieldForwarder {
 
     /// @notice Thrown when the target asset address is zero
     error InvalidTargetAsset();
+
+    /// @notice Thrown when the vault address is zero
+    error InvalidVault();
+
+    /// @notice Thrown when a swapper-management function is called by a non-management address
+    error OnlyVaultManagement();
+
+    /// @notice Thrown when a swapper reports an output below the enforced minimum
+    /// @param expected Minimum amount expected
+    /// @param actual Amount actually reported
+    error InsufficientSwapOutput(uint256 expected, uint256 actual);
 
     // ============================================
     // EVENTS
@@ -71,6 +84,11 @@ contract SwappingYieldForwarder is YieldForwarder {
         uint256 assetsOut
     );
 
+    /// @notice Emitted when the swap adapter is replaced by vault management
+    /// @param oldSwapper The previous ISwapper implementation
+    /// @param newSwapper The newly installed ISwapper implementation
+    event SwapperUpdated(address indexed oldSwapper, address indexed newSwapper);
+
     // ============================================
     // STATE
     // ============================================
@@ -79,40 +97,79 @@ contract SwappingYieldForwarder is YieldForwarder {
     /// @dev Set once at construction, cannot be changed
     address public immutable targetAsset;
 
+    /// @notice The governance source for this forwarder
+    /// @dev Calls to vault.management() at swapper-management time authorize the caller.
+    ///      In a 1:1 forwarder-to-vault deployment this is the tokenized strategy
+    ///      whose profit shares flow through this forwarder; vault management is
+    ///      the same multisig that already controls keeper/dragon-router rotation.
+    address public immutable vault;
+
     /// @notice The swap adapter used to convert underlying -> target asset
-    /// @dev Set once at construction, cannot be changed
-    ISwapper public immutable swapper;
+    /// @dev Settable by vault.management() to pivot to a different adapter
+    ///      (e.g. a new pool tier, a new DEX version) without redeploying.
+    ISwapper public swapper;
+
+    // ============================================
+    // MODIFIERS
+    // ============================================
+
+    /// @dev Restricts a call to the vault's management() address. Reading this at call
+    ///      time (instead of caching a local admin) means rotation via the vault's
+    ///      own two-step transfer (setPendingManagement / acceptManagement) is
+    ///      picked up automatically.
+    modifier onlyVaultManagement() {
+        if (msg.sender != ITokenizedStrategy(vault).management()) revert OnlyVaultManagement();
+        _;
+    }
 
     // ============================================
     // CONSTRUCTOR
     // ============================================
 
-    /// @notice Creates a new SwappingYieldForwarder with fixed receiver, keeper, target asset, and swapper
+    /// @notice Creates a new SwappingYieldForwarder
     /// @param _receiver Address that will receive all forwarded assets
     /// @param _keeper Address authorized to call reportAndForward / reportSwapAndForward
     /// @param _targetAsset Address of the desired output token after swapping
-    /// @param _swapper Address of the ISwapper implementation for DEX routing
+    /// @param _swapper Initial ISwapper implementation for DEX routing
+    /// @param _vault Vault contract whose management() controls swapper rotation
     constructor(
         address _receiver,
         address _keeper,
         address _targetAsset,
-        address _swapper
+        address _swapper,
+        address _vault
     ) YieldForwarder(_receiver, _keeper) {
         if (_targetAsset == address(0)) revert InvalidTargetAsset();
         if (_swapper == address(0)) revert InvalidSwapper();
+        if (_vault == address(0)) revert InvalidVault();
         targetAsset = _targetAsset;
         swapper = ISwapper(_swapper);
+        vault = _vault;
     }
 
     // ============================================
     // EXTERNAL FUNCTIONS
     // ============================================
 
+    /// @notice Replace the active swap adapter
+    /// @dev Authorized by vault.management(). The new adapter must expose the
+    ///      ISwapper pull-pattern semantic; the forwarder enforces its own
+    ///      minAmountOut re-check inside reportSwapAndForward as a
+    ///      defence-in-depth guard against a buggy adapter.
+    /// @param _newSwapper New ISwapper implementation
+    function setSwapper(address _newSwapper) external onlyVaultManagement {
+        if (_newSwapper == address(0)) revert InvalidSwapper();
+        emit SwapperUpdated(address(swapper), _newSwapper);
+        swapper = ISwapper(_newSwapper);
+    }
+
     /**
      * @notice Calls report() on the strategy, redeems profit shares, swaps the underlying
      *         asset to the target asset via the configured ISwapper, and forwards to the receiver
-     * @dev The swap path: redeem to self -> transfer to swapper -> swapper.swap() -> receiver.
-     *      The swapper enforces minAmountOut internally and reverts if not met.
+     * @dev The swap path: redeem to self -> approve swapper -> swapper.swap() -> receiver.
+     *      The swapper enforces minAmountOut internally; the forwarder additionally
+     *      re-checks the reported output against minAmountOut as defence-in-depth
+     *      in case a future/buggy adapter forgets its own check.
      *
      *      If report() produces no profit shares, the function returns 0 without reverting.
      *      If redemption returns 0 assets, the function returns 0 without attempting a swap.
@@ -145,8 +202,14 @@ contract SwappingYieldForwarder is YieldForwarder {
 
         // Approve swapper and execute swap to receiver. The swapper pulls
         // via transferFrom and returns any unused tokenIn before returning.
-        IERC20(assetIn).forceApprove(address(swapper), assetsIn);
-        assetsOut = swapper.swap(assetIn, targetAsset, assetsIn, minAmountOut, receiver);
+        ISwapper currentSwapper = swapper;
+        IERC20(assetIn).forceApprove(address(currentSwapper), assetsIn);
+        assetsOut = currentSwapper.swap(assetIn, targetAsset, assetsIn, minAmountOut, receiver);
+
+        // Forwarder-side minAmountOut re-check, independent of the swapper's own
+        // check. Catches an honest-but-buggy adapter whose swap() returns an
+        // amountOut below the threshold without reverting.
+        if (assetsOut < minAmountOut) revert InsufficientSwapOutput(minAmountOut, assetsOut);
 
         emit YieldSwappedAndForwarded(strategy, receiver, shares, assetsIn, assetsOut);
     }

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -317,6 +317,7 @@ contract SwappingYieldForwarder is YieldForwarder {
         ISwapper currentSwapper = swapper;
         IERC20(assetIn).forceApprove(address(currentSwapper), assetsIn);
         assetsOut = currentSwapper.swap(assetIn, targetAsset, assetsIn, minAmountOut, receiver);
+        IERC20(assetIn).forceApprove(address(currentSwapper), 0);
 
         // Forwarder-side minAmountOut re-check, independent of the swapper's own
         // check. Catches an honest-but-buggy adapter whose swap() returns an

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -18,7 +18,7 @@ interface IERC4626Asset {
 /// @notice Minimal interface for ERC-4626 maxRedeem
 /// @dev Defined inline here (rather than imported from YieldForwarder) so this
 ///      contract compiles standalone on develop while the matching base-class
-///      interface declarations ship in the sibling #415 PR. Once both PRs merge,
+///      interface declarations ship in the sibling forwarder PR. Once both PRs merge,
 ///      both copies are byte-for-byte identical.
 interface IMaxRedeem {
     /// @notice Maximum shares redeemable by `owner` right now (ERC-4626)
@@ -243,7 +243,7 @@ contract SwappingYieldForwarder is YieldForwarder {
      *      If report() produces no profit shares, the function returns 0 without reverting.
      *      If redemption returns 0 assets, the function returns 0 without attempting a swap.
      *
-     *      Bailsec #68: the caller MUST supply a fresh `deadline` (seconds since epoch).
+     *      The caller MUST supply a fresh `deadline` (seconds since epoch).
      *      The underlying Uniswap V3 adapter uses `block.timestamp` as the router deadline,
      *      which always passes at inclusion and therefore adds no real time bound between
      *      the keeper's quote and settlement. Enforcing an explicit expiry at the forwarder
@@ -263,7 +263,7 @@ contract SwappingYieldForwarder is YieldForwarder {
         uint256 minAmountOut,
         uint256 deadline
     ) external nonReentrant returns (uint256 assetsOut) {
-        // Bailsec #68: freshness check runs before any state-touching work so an expired
+        // Freshness check runs before any state-touching work so an expired
         // call fails cheaply and the keeper can retry with a fresh deadline.
         if (block.timestamp > deadline) revert ExpiredDeadline(deadline, block.timestamp);
         if (msg.sender != keeper) revert OnlyKeeper();
@@ -273,14 +273,14 @@ contract SwappingYieldForwarder is YieldForwarder {
         uint256 balance = IERC20(strategy).balanceOf(address(this));
         if (balance == 0) return 0;
 
-        // Bailsec #62: mirror reportAndForward's maxRedeem cap so the inner redeem
-        // cannot revert when external vault liquidity tightens below the forwarder's
+        // Mirror reportAndForward's maxRedeem cap so the inner redeem cannot
+        // revert when external vault liquidity tightens below the forwarder's
         // share balance. Residual shares stay at the forwarder until headroom recovers.
         uint256 shares = Math.min(balance, IMaxRedeem(strategy).maxRedeem(address(this)));
         if (shares == 0) return 0;
 
-        // Bailsec #61: mirror reportAndForward's ZERO_ASSETS skip so a dust share
-        // balance on a loss-impaired strategy (totalAssets < totalSupply) does not
+        // Mirror reportAndForward's zero-asset skip so a dust share balance on
+        // a loss-impaired strategy (totalAssets < totalSupply) does not
         // roll back the report() above. The dust stays at the forwarder for a later
         // report once the imbalance resolves.
         if (IConvertible(strategy).convertToAssets(shares) == 0) return 0;

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -96,6 +96,11 @@ contract SwappingYieldForwarder is YieldForwarder {
     /// @param supplied The minAmountOut the keeper passed in
     error SlippageFloorTooLoose(uint256 floor, uint256 supplied);
 
+    /// @notice Thrown when `reportSwapAndForward` is called past the caller-supplied deadline
+    /// @param deadline The keeper-chosen expiry timestamp (seconds since epoch)
+    /// @param blockTimestamp The block time at which the call landed
+    error ExpiredDeadline(uint256 deadline, uint256 blockTimestamp);
+
     // ============================================
     // EVENTS
     // ============================================
@@ -232,16 +237,29 @@ contract SwappingYieldForwarder is YieldForwarder {
      *      If report() produces no profit shares, the function returns 0 without reverting.
      *      If redemption returns 0 assets, the function returns 0 without attempting a swap.
      *
+     *      Bailsec #68: the caller MUST supply a fresh `deadline` (seconds since epoch).
+     *      The underlying Uniswap V3 adapter uses `block.timestamp` as the router deadline,
+     *      which always passes at inclusion and therefore adds no real time bound between
+     *      the keeper's quote and settlement. Enforcing an explicit expiry at the forwarder
+     *      prevents stale-slippage execution when a queued transaction lands in a later
+     *      block against a moved market. There is no `0 = disabled` sentinel: keepers
+     *      always pass `block.timestamp + buffer` at transaction assembly time.
+     *
      * @param strategy Address of the strategy contract (must implement IReportable, IRedeemable, IERC20, IERC4626Asset)
      * @param maxLoss Maximum acceptable loss in basis points for the redemption
      * @param minAmountOut Minimum acceptable amount of target asset after swap (slippage protection)
+     * @param deadline Unix timestamp (seconds) past which the call reverts with ExpiredDeadline
      * @return assetsOut Amount of target asset forwarded to receiver (0 if no profit shares)
      */
     function reportSwapAndForward(
         address strategy,
         uint256 maxLoss,
-        uint256 minAmountOut
+        uint256 minAmountOut,
+        uint256 deadline
     ) external nonReentrant returns (uint256 assetsOut) {
+        // Bailsec #68: freshness check runs before any state-touching work so an expired
+        // call fails cheaply and the keeper can retry with a fresh deadline.
+        if (block.timestamp > deadline) revert ExpiredDeadline(deadline, block.timestamp);
         if (msg.sender != keeper) revert OnlyKeeper();
 
         IReportable(strategy).report();

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.25;
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { IERC20Metadata } from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { ISwapper } from "./interfaces/ISwapper.sol";
 import { ITokenizedStrategy } from "./interfaces/ITokenizedStrategy.sol";
 import { YieldForwarder, IRedeemable, IReportable } from "./YieldForwarder.sol";
@@ -12,6 +13,26 @@ import { YieldForwarder, IRedeemable, IReportable } from "./YieldForwarder.sol";
 interface IERC4626Asset {
     /// @notice Returns the address of the underlying asset
     function asset() external view returns (address);
+}
+
+/// @notice Minimal interface for ERC-4626 maxRedeem
+/// @dev Defined inline here (rather than imported from YieldForwarder) so this
+///      contract compiles standalone on develop while the matching base-class
+///      interface declarations ship in the sibling #415 PR. Once both PRs merge,
+///      both copies are byte-for-byte identical.
+interface IMaxRedeem {
+    /// @notice Maximum shares redeemable by `owner` right now (ERC-4626)
+    /// @param owner Address whose redeem headroom is queried
+    /// @return maxShares Upper bound on shares redeemable by `owner`
+    function maxRedeem(address owner) external view returns (uint256 maxShares);
+}
+
+/// @notice Minimal interface for ERC-4626 convertToAssets (floor rounding)
+interface IConvertible {
+    /// @notice Preview the assets returned for `shares`, rounded down (ERC-4626)
+    /// @param shares Amount of shares to preview
+    /// @return assets Assets that would be returned by redeem(), before fees/loss
+    function convertToAssets(uint256 shares) external view returns (uint256 assets);
 }
 
 /**
@@ -225,8 +246,20 @@ contract SwappingYieldForwarder is YieldForwarder {
 
         IReportable(strategy).report();
 
-        uint256 shares = IERC20(strategy).balanceOf(address(this));
+        uint256 balance = IERC20(strategy).balanceOf(address(this));
+        if (balance == 0) return 0;
+
+        // Bailsec #62: mirror reportAndForward's maxRedeem cap so the inner redeem
+        // cannot revert when external vault liquidity tightens below the forwarder's
+        // share balance. Residual shares stay at the forwarder until headroom recovers.
+        uint256 shares = Math.min(balance, IMaxRedeem(strategy).maxRedeem(address(this)));
         if (shares == 0) return 0;
+
+        // Bailsec #61: mirror reportAndForward's ZERO_ASSETS skip so a dust share
+        // balance on a loss-impaired strategy (totalAssets < totalSupply) does not
+        // roll back the report() above. The dust stays at the forwarder for a later
+        // report once the imbalance resolves.
+        if (IConvertible(strategy).convertToAssets(shares) == 0) return 0;
 
         // Redeem to this contract (not receiver) so we can swap first
         uint256 assetsIn = IRedeemable(strategy).redeem(shares, address(this), address(this), maxLoss);

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -143,8 +143,9 @@ contract SwappingYieldForwarder is YieldForwarder {
 
         address assetIn = IERC4626Asset(strategy).asset();
 
-        // Transfer underlying to swapper, then execute swap to receiver
-        IERC20(assetIn).safeTransfer(address(swapper), assetsIn);
+        // Approve swapper and execute swap to receiver. The swapper pulls
+        // via transferFrom and returns any unused tokenIn before returning.
+        IERC20(assetIn).forceApprove(address(swapper), assetsIn);
         assetsOut = swapper.swap(assetIn, targetAsset, assetsIn, minAmountOut, receiver);
 
         emit YieldSwappedAndForwarded(strategy, receiver, shares, assetsIn, assetsOut);

--- a/src/core/interfaces/ISwapper.sol
+++ b/src/core/interfaces/ISwapper.sol
@@ -7,15 +7,21 @@ pragma solidity ^0.8.25;
  * @custom:security-contact security@golem.foundation
  * @notice Minimal interface for pluggable token swap adapters
  * @dev Implementations are expected to be stateless and hold no tokens between calls.
- *      The caller transfers tokenIn to the swapper before calling swap().
+ *      The caller MUST approve this contract for at least `amountIn` of `tokenIn`
+ *      before calling swap(); the implementation pulls tokens via transferFrom.
+ *      Any unused `tokenIn` (e.g. from a partial fill) MUST be returned to
+ *      msg.sender before swap() returns.
  */
 interface ISwapper {
     /// @notice Execute a token swap and send output to receiver
-    /// @dev The caller MUST transfer `amountIn` of `tokenIn` to this contract before calling.
+    /// @dev The caller MUST have approved this contract for at least `amountIn`
+    ///      of `tokenIn` before calling. The implementation pulls via
+    ///      transferFrom(msg.sender, this, amountIn) and returns any unused
+    ///      `tokenIn` to msg.sender before returning.
     ///      Reverts if output is less than `minAmountOut`.
     /// @param tokenIn Address of the input token
     /// @param tokenOut Address of the output token
-    /// @param amountIn Amount of tokenIn to swap (already transferred to this contract)
+    /// @param amountIn Maximum amount of tokenIn to pull from msg.sender
     /// @param minAmountOut Minimum acceptable output amount (reverts if not met)
     /// @param receiver Address to receive the output tokens
     /// @return amountOut Actual amount of tokenOut sent to receiver

--- a/src/swappers/CurveSwapper.sol
+++ b/src/swappers/CurveSwapper.sol
@@ -124,6 +124,7 @@ contract CurveSwapper is ISwapper {
     ) external override returns (uint256 amountOut) {
         if (_tokenIn != tokenIn || _tokenOut != tokenOut) revert InvalidToken();
 
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
         IERC20(tokenIn).forceApprove(pool, amountIn);
 
         uint256 balBefore = IERC20(tokenOut).balanceOf(address(this));

--- a/src/swappers/CurveSwapper.sol
+++ b/src/swappers/CurveSwapper.sol
@@ -134,5 +134,15 @@ contract CurveSwapper is ISwapper {
         IERC20(tokenIn).forceApprove(pool, 0);
 
         IERC20(tokenOut).safeTransfer(receiver, amountOut);
+
+        // Zero-residue invariant (cantina #1): Curve pools normally pull
+        // the full `amountIn`, but any tokenIn that ended up here — whether
+        // from an unusual pool implementation or a donation — is returned
+        // to the caller so the adapter upholds its stateless-between-calls
+        // contract on every path.
+        uint256 leftover = IERC20(tokenIn).balanceOf(address(this));
+        if (leftover != 0) {
+            IERC20(tokenIn).safeTransfer(msg.sender, leftover);
+        }
     }
 }

--- a/src/swappers/CurveSwapper.sol
+++ b/src/swappers/CurveSwapper.sol
@@ -135,11 +135,10 @@ contract CurveSwapper is ISwapper {
 
         IERC20(tokenOut).safeTransfer(receiver, amountOut);
 
-        // Zero-residue invariant (cantina #1): Curve pools normally pull
-        // the full `amountIn`, but any tokenIn that ended up here — whether
-        // from an unusual pool implementation or a donation — is returned
-        // to the caller so the adapter upholds its stateless-between-calls
-        // contract on every path.
+        // Curve pools normally pull the full `amountIn`, but any tokenIn that
+        // ended up here -- whether from an unusual pool implementation or a
+        // donation -- is returned to the caller so the adapter upholds its
+        // stateless-between-calls contract on every path.
         uint256 leftover = IERC20(tokenIn).balanceOf(address(this));
         if (leftover != 0) {
             IERC20(tokenIn).safeTransfer(msg.sender, leftover);

--- a/src/swappers/PSMSwapper.sol
+++ b/src/swappers/PSMSwapper.sol
@@ -179,7 +179,7 @@ contract PSMSwapper is ISwapper {
     ///      Calculates max gem purchasable from amountIn accounting for PSM fees (tout),
     ///      then pulls ONLY the exact charge (gemAmt * conversionFactor * (WAD + tout) / WAD)
     ///      via transferFrom so the floor-division remainder stays with the caller
-    ///      rather than being stranded in this adapter (bailsec #70).
+    ///      rather than being stranded in this adapter.
     function _buyGem(uint256 amountIn, address receiver) internal returns (uint256 amountOut) {
         uint256 tout = IPSM(protocol).tout();
         uint256 gemAmt = (amountIn * WAD) / (conversionFactor * (WAD + tout));

--- a/src/swappers/PSMSwapper.sol
+++ b/src/swappers/PSMSwapper.sol
@@ -128,6 +128,8 @@ contract PSMSwapper is ISwapper {
     ) external override returns (uint256 amountOut) {
         if (_tokenIn != tokenIn || _tokenOut != tokenOut) revert InvalidToken();
 
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
+
         if (route == Route.SELL_GEM) {
             amountOut = _sellGem(amountIn, receiver);
         } else if (route == Route.BUY_GEM) {

--- a/src/swappers/PSMSwapper.sol
+++ b/src/swappers/PSMSwapper.sol
@@ -128,21 +128,32 @@ contract PSMSwapper is ISwapper {
     ) external override returns (uint256 amountOut) {
         if (_tokenIn != tokenIn || _tokenOut != tokenOut) revert InvalidToken();
 
-        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
-
+        // Per-route pull pattern. BUY_GEM computes the exact PSM charge
+        // upfront and pulls only that (rounding remainder stays with caller);
+        // the other routes consume the full amountIn so we pull it here.
         if (route == Route.SELL_GEM) {
+            IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
             amountOut = _sellGem(amountIn, receiver);
         } else if (route == Route.BUY_GEM) {
             amountOut = _buyGem(amountIn, receiver);
         } else if (route == Route.DAI_TO_USDS) {
+            IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
             amountOut = _daiToUsds(amountIn, receiver);
             minAmountOut = amountIn; // 1:1 converter, enforce exact output
         } else {
+            IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
             amountOut = _usdsToDai(amountIn, receiver);
             minAmountOut = amountIn; // 1:1 converter, enforce exact output
         }
 
         if (amountOut < minAmountOut) revert InsufficientOutput(minAmountOut, amountOut);
+
+        // Defense-in-depth: flush any residual tokenIn back to the caller so
+        // the adapter upholds the stateless invariant on every route.
+        uint256 leftover = IERC20(tokenIn).balanceOf(address(this));
+        if (leftover != 0) {
+            IERC20(tokenIn).safeTransfer(msg.sender, leftover);
+        }
     }
 
     // ============================================
@@ -165,21 +176,23 @@ contract PSMSwapper is ISwapper {
     }
 
     /// @dev Buy gem (e.g., USDC) with DAI/USDS via PSM.
-    ///      Calculates max gem purchasable from amountIn accounting for PSM fees (tout).
-    ///      PSM pulls DAI/USDS from this contract and sends gem to this contract,
-    ///      which then forwards to receiver.
+    ///      Calculates max gem purchasable from amountIn accounting for PSM fees (tout),
+    ///      then pulls ONLY the exact charge (gemAmt * conversionFactor * (WAD + tout) / WAD)
+    ///      via transferFrom so the floor-division remainder stays with the caller
+    ///      rather than being stranded in this adapter (bailsec #70).
     function _buyGem(uint256 amountIn, address receiver) internal returns (uint256 amountOut) {
         uint256 tout = IPSM(protocol).tout();
         uint256 gemAmt = (amountIn * WAD) / (conversionFactor * (WAD + tout));
         if (gemAmt == 0) revert InsufficientOutput(1, 0);
 
-        IERC20(tokenIn).forceApprove(protocol, amountIn);
+        uint256 actualPulled = (gemAmt * conversionFactor * (WAD + tout)) / WAD;
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), actualPulled);
+        IERC20(tokenIn).forceApprove(protocol, actualPulled);
 
         uint256 balBefore = IERC20(tokenOut).balanceOf(address(this));
         IPSM(protocol).buyGem(address(this), gemAmt);
         amountOut = IERC20(tokenOut).balanceOf(address(this)) - balBefore;
 
-        // Reset approval for leftover (rounding may leave dust approved)
         IERC20(tokenIn).forceApprove(protocol, 0);
 
         IERC20(tokenOut).safeTransfer(receiver, amountOut);

--- a/src/swappers/UniswapV3SwapperAdapter.sol
+++ b/src/swappers/UniswapV3SwapperAdapter.sol
@@ -117,5 +117,15 @@ contract UniswapV3SwapperAdapter is ISwapper {
                 ISwapRouter.ExactInputParams(path, receiver, block.timestamp, amountIn, minAmountOut)
             );
         }
+
+        // Zero the router allowance and return any unused tokenIn to the
+        // caller. On a partial fill (shallow pool reaching MIN/MAX tick)
+        // the router pulls only the consumed amount, leaving the rest
+        // sitting in this contract and an equivalent allowance open.
+        IERC20(tokenIn).forceApprove(router, 0);
+        uint256 leftover = IERC20(tokenIn).balanceOf(address(this));
+        if (leftover != 0) {
+            IERC20(tokenIn).safeTransfer(msg.sender, leftover);
+        }
     }
 }

--- a/src/swappers/UniswapV3SwapperAdapter.sol
+++ b/src/swappers/UniswapV3SwapperAdapter.sol
@@ -88,6 +88,7 @@ contract UniswapV3SwapperAdapter is ISwapper {
     ) external override returns (uint256 amountOut) {
         if (tokenIn == address(0) || tokenOut == address(0)) revert InvalidToken();
 
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
         IERC20(tokenIn).forceApprove(router, amountIn);
 
         if (base == address(0) || tokenIn == base || tokenOut == base) {

--- a/src/swappers/UniswapV4SwapperAdapter.sol
+++ b/src/swappers/UniswapV4SwapperAdapter.sol
@@ -225,8 +225,8 @@ contract UniswapV4SwapperAdapter is ISwapper {
 
         // Recover any unconsumed tokenIn back to originalCaller. Leaving a
         // positive tokenIn delta would cause unlock to revert with
-        // CurrencyNotSettled (bailsec #76) and donate the surplus to the
-        // PoolManager singleton.
+        // CurrencyNotSettled and donate the surplus to the PoolManager
+        // singleton.
         uint256 unusedTokenIn = amountIn - consumed;
         if (unusedTokenIn != 0) {
             IV4PoolManager(poolManager).take(tokenIn, originalCaller, unusedTokenIn);

--- a/src/swappers/UniswapV4SwapperAdapter.sol
+++ b/src/swappers/UniswapV4SwapperAdapter.sol
@@ -203,11 +203,12 @@ contract UniswapV4SwapperAdapter is ISwapper {
 
         uint256 amountOut;
         uint256 consumed;
+        uint256 unusedBase;
 
         if (base == address(0) || tokenIn == base || tokenOut == base) {
             (amountOut, consumed) = _singleHop(tokenIn, tokenOut, amountIn);
         } else {
-            (amountOut, consumed) = _multiHop(tokenIn, tokenOut, amountIn);
+            (amountOut, consumed, unusedBase) = _multiHop(tokenIn, tokenOut, amountIn);
         }
 
         if (amountOut < minAmountOut) revert InsufficientOutput(minAmountOut, amountOut);
@@ -229,6 +230,13 @@ contract UniswapV4SwapperAdapter is ISwapper {
         uint256 unusedTokenIn = amountIn - consumed;
         if (unusedTokenIn != 0) {
             IV4PoolManager(poolManager).take(tokenIn, originalCaller, unusedTokenIn);
+        }
+
+        // If hop 2 stops at the tick limit, hop 1 may have produced more base
+        // than hop 2 consumed. Return that intermediate residue to the caller
+        // so the unlock has no unsettled positive base delta.
+        if (unusedBase != 0) {
+            IV4PoolManager(poolManager).take(base, originalCaller, unusedBase);
         }
 
         // Defensive fallback: return any tokenIn that ended up locally (should
@@ -280,15 +288,17 @@ contract UniswapV4SwapperAdapter is ISwapper {
         consumed = uint256(uint128(-inputDelta));
     }
 
-    /// @dev Execute a two-hop exact-input swap: tokenIn → base → tokenOut
-    ///      Base token deltas net to zero within the PoolManager's accounting.
+    /// @dev Execute a two-hop exact-input swap: tokenIn → base → tokenOut.
+    ///      Base token deltas net to zero when hop 2 consumes the full hop-1 output;
+    ///      otherwise the unused base is returned to the original caller.
     /// @return amountOut Final output amount
     /// @return consumed tokenIn consumed by hop 1 (may be less than amountIn on a shallow pool)
+    /// @return unusedBase base token produced by hop 1 but not consumed by hop 2
     function _multiHop(
         address tokenIn,
         address tokenOut,
         uint256 amountIn
-    ) internal returns (uint256 amountOut, uint256 consumed) {
+    ) internal returns (uint256 amountOut, uint256 consumed, uint256 unusedBase) {
         // ── Hop 1: tokenIn → base ──
         bool zfo1 = tokenIn < base;
         (address c0_1, address c1_1) = zfo1 ? (tokenIn, base) : (base, tokenIn);
@@ -316,5 +326,8 @@ contract UniswapV4SwapperAdapter is ISwapper {
 
         // Extract final output amount (positive delta)
         amountOut = uint256(int256(zfo2 ? int128(delta2) : int128(delta2 >> 128)));
+        int128 inputDelta2 = zfo2 ? int128(delta2 >> 128) : int128(delta2);
+        uint256 baseConsumed = uint256(uint128(-inputDelta2));
+        unusedBase = baseAmount - baseConsumed;
     }
 }

--- a/src/swappers/UniswapV4SwapperAdapter.sol
+++ b/src/swappers/UniswapV4SwapperAdapter.sol
@@ -174,6 +174,8 @@ contract UniswapV4SwapperAdapter is ISwapper {
     ) external override returns (uint256 amountOut) {
         if (tokenIn == address(0) || tokenOut == address(0)) revert InvalidToken();
 
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
+
         bytes memory result = IV4PoolManager(poolManager).unlock(
             abi.encode(tokenIn, tokenOut, amountIn, minAmountOut, receiver)
         );

--- a/src/swappers/UniswapV4SwapperAdapter.sol
+++ b/src/swappers/UniswapV4SwapperAdapter.sol
@@ -176,41 +176,67 @@ contract UniswapV4SwapperAdapter is ISwapper {
 
         IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
 
+        // Thread msg.sender through as originalCaller so unlockCallback can
+        // return any unused tokenIn (partial-fill residue) to the party that
+        // approved us, not to address(this).
         bytes memory result = IV4PoolManager(poolManager).unlock(
-            abi.encode(tokenIn, tokenOut, amountIn, minAmountOut, receiver)
+            abi.encode(msg.sender, tokenIn, tokenOut, amountIn, minAmountOut, receiver)
         );
         amountOut = abi.decode(result, (uint256));
     }
 
     /// @notice Callback invoked by PoolManager during unlock(); executes swaps and settles
     /// @dev Only callable by the PoolManager. Reverts with UnauthorizedCallback otherwise.
-    /// @param data ABI-encoded (tokenIn, tokenOut, amountIn, minAmountOut, receiver)
+    /// @param data ABI-encoded (originalCaller, tokenIn, tokenOut, amountIn, minAmountOut, receiver)
     /// @return ABI-encoded amountOut
     function unlockCallback(bytes calldata data) external returns (bytes memory) {
         if (msg.sender != poolManager) revert UnauthorizedCallback();
 
-        (address tokenIn, address tokenOut, uint256 amountIn, uint256 minAmountOut, address receiver) = abi.decode(
-            data,
-            (address, address, uint256, uint256, address)
-        );
+        (
+            address originalCaller,
+            address tokenIn,
+            address tokenOut,
+            uint256 amountIn,
+            uint256 minAmountOut,
+            address receiver
+        ) = abi.decode(data, (address, address, address, uint256, uint256, address));
 
         uint256 amountOut;
+        uint256 consumed;
 
         if (base == address(0) || tokenIn == base || tokenOut == base) {
-            amountOut = _singleHop(tokenIn, tokenOut, amountIn);
+            (amountOut, consumed) = _singleHop(tokenIn, tokenOut, amountIn);
         } else {
-            amountOut = _multiHop(tokenIn, tokenOut, amountIn);
+            (amountOut, consumed) = _multiHop(tokenIn, tokenOut, amountIn);
         }
 
         if (amountOut < minAmountOut) revert InsufficientOutput(minAmountOut, amountOut);
 
-        // Settle input: sync balance snapshot → transfer tokens → settle delta
+        // Settle input: sync balance snapshot → transfer tokens → settle delta.
+        // We transfer the full amountIn to the PoolManager; any surplus over
+        // `consumed` is reclaimed below via take(tokenIn, originalCaller, ...).
         IV4PoolManager(poolManager).sync(tokenIn);
         IERC20(tokenIn).safeTransfer(poolManager, amountIn);
         IV4PoolManager(poolManager).settle();
 
         // Take output directly to receiver
         IV4PoolManager(poolManager).take(tokenOut, receiver, amountOut);
+
+        // Recover any unconsumed tokenIn back to originalCaller. Leaving a
+        // positive tokenIn delta would cause unlock to revert with
+        // CurrencyNotSettled (bailsec #76) and donate the surplus to the
+        // PoolManager singleton.
+        uint256 unusedTokenIn = amountIn - consumed;
+        if (unusedTokenIn != 0) {
+            IV4PoolManager(poolManager).take(tokenIn, originalCaller, unusedTokenIn);
+        }
+
+        // Defensive fallback: return any tokenIn that ended up locally (should
+        // be zero under the flow above) to the originalCaller.
+        uint256 localLeftover = IERC20(tokenIn).balanceOf(address(this));
+        if (localLeftover != 0) {
+            IERC20(tokenIn).safeTransfer(originalCaller, localLeftover);
+        }
 
         return abi.encode(amountOut);
     }
@@ -219,8 +245,14 @@ contract UniswapV4SwapperAdapter is ISwapper {
     // INTERNAL FUNCTIONS
     // ============================================
 
-    /// @dev Execute a single-hop exact-input swap and return the output amount
-    function _singleHop(address tokenIn, address tokenOut, uint256 amountIn) internal returns (uint256 amountOut) {
+    /// @dev Execute a single-hop exact-input swap
+    /// @return amountOut Amount of output token received
+    /// @return consumed Amount of tokenIn actually consumed by the pool
+    function _singleHop(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn
+    ) internal returns (uint256 amountOut, uint256 consumed) {
         // Select pool config: if tokenIn IS the base, use second-hop config
         uint24 poolFee = (base != address(0) && tokenIn == base) ? feeOut : fee;
         int24 poolTickSpacing = (base != address(0) && tokenIn == base) ? tickSpacingOut : tickSpacing;
@@ -241,13 +273,22 @@ contract UniswapV4SwapperAdapter is ISwapper {
         );
 
         // Extract output from packed BalanceDelta (upper 128 = amount0, lower 128 = amount1)
-        // Output is the positive delta: amount1 for zeroForOne, amount0 for !zeroForOne
+        // Output is the positive delta: amount1 for zeroForOne, amount0 for !zeroForOne.
+        // Consumed is |negative delta| on tokenIn: amount0 for zeroForOne, amount1 otherwise.
         amountOut = uint256(int256(zeroForOne ? int128(delta) : int128(delta >> 128)));
+        int128 inputDelta = zeroForOne ? int128(delta >> 128) : int128(delta);
+        consumed = uint256(uint128(-inputDelta));
     }
 
     /// @dev Execute a two-hop exact-input swap: tokenIn → base → tokenOut
     ///      Base token deltas net to zero within the PoolManager's accounting.
-    function _multiHop(address tokenIn, address tokenOut, uint256 amountIn) internal returns (uint256 amountOut) {
+    /// @return amountOut Final output amount
+    /// @return consumed tokenIn consumed by hop 1 (may be less than amountIn on a shallow pool)
+    function _multiHop(
+        address tokenIn,
+        address tokenOut,
+        uint256 amountIn
+    ) internal returns (uint256 amountOut, uint256 consumed) {
         // ── Hop 1: tokenIn → base ──
         bool zfo1 = tokenIn < base;
         (address c0_1, address c1_1) = zfo1 ? (tokenIn, base) : (base, tokenIn);
@@ -258,8 +299,10 @@ contract UniswapV4SwapperAdapter is ISwapper {
             ""
         );
 
-        // Extract base amount received (positive delta)
+        // Extract base amount received (positive delta) and tokenIn consumed
         uint256 baseAmount = uint256(int256(zfo1 ? int128(delta1) : int128(delta1 >> 128)));
+        int128 inputDelta1 = zfo1 ? int128(delta1 >> 128) : int128(delta1);
+        consumed = uint256(uint128(-inputDelta1));
 
         // ── Hop 2: base → tokenOut ──
         bool zfo2 = base < tokenOut;

--- a/src/swappers/UniswapV4SwapperAdapter.sol
+++ b/src/swappers/UniswapV4SwapperAdapter.sol
@@ -203,7 +203,7 @@ contract UniswapV4SwapperAdapter is ISwapper {
 
         uint256 amountOut;
         uint256 consumed;
-        uint256 unusedBase;
+        uint256 unusedBase = 0;
 
         if (base == address(0) || tokenIn == base || tokenOut == base) {
             (amountOut, consumed) = _singleHop(tokenIn, tokenOut, amountIn);

--- a/test/integration/swappers/CurveSwapperIntegration.t.sol
+++ b/test/integration/swappers/CurveSwapperIntegration.t.sol
@@ -90,7 +90,7 @@ contract CurveSwapperIntegrationTest is BaseSwapperIntegrationTest {
         _simulateProfit(profit);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         _clearMocks();
 

--- a/test/integration/swappers/PSMSwapperIntegration.t.sol
+++ b/test/integration/swappers/PSMSwapperIntegration.t.sol
@@ -92,7 +92,7 @@ contract PSMSwapperIntegrationTest is BaseSwapperIntegrationTest {
         _simulateProfit(profit);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         _clearMocks();
 

--- a/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
@@ -164,7 +164,7 @@ contract UniswapV3MultiHopTest is Test {
         );
 
         deal(USDC, address(this), SWAP_AMOUNT_USDC);
-        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+        IERC20(USDC).approve(address(adapter), SWAP_AMOUNT_USDC);
 
         uint256 amountOut = adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, 0, swapReceiver);
 
@@ -183,7 +183,7 @@ contract UniswapV3MultiHopTest is Test {
         );
 
         deal(USDC, address(this), SWAP_AMOUNT_USDC);
-        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+        IERC20(USDC).approve(address(adapter), SWAP_AMOUNT_USDC);
 
         // Unreasonably high minAmountOut should revert
         vm.expectRevert();
@@ -220,7 +220,7 @@ contract UniswapV3MultiHopTest is Test {
         );
 
         deal(USDC, address(this), SWAP_AMOUNT_USDC);
-        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+        IERC20(USDC).approve(address(adapter), SWAP_AMOUNT_USDC);
 
         uint256 amountOut = adapter.swap(USDC, WETH, SWAP_AMOUNT_USDC, 0, swapReceiver);
 
@@ -243,7 +243,7 @@ contract UniswapV3MultiHopTest is Test {
         );
 
         deal(WETH, address(this), SWAP_AMOUNT_WETH);
-        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+        IERC20(WETH).approve(address(adapter), SWAP_AMOUNT_WETH);
 
         uint256 amountOut = adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, 0, swapReceiver);
 
@@ -264,7 +264,7 @@ contract UniswapV3MultiHopTest is Test {
         );
 
         deal(WETH, address(this), SWAP_AMOUNT_WETH);
-        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+        IERC20(WETH).approve(address(adapter), SWAP_AMOUNT_WETH);
 
         // Should succeed because it uses feeOut (3000), not fee (10000)
         uint256 amountOut = adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, 0, swapReceiver);

--- a/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
@@ -101,7 +101,7 @@ contract UniswapV3SwapperIntegrationTest is BaseSwapperIntegrationTest {
         _simulateProfit(profit);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         _clearMocks();
 
@@ -366,7 +366,7 @@ contract UniswapV3MultiHopTest is Test {
 
         // Report, swap (multi-hop USDC→WETH→DAI), forward
         vm.prank(keeper);
-        uint256 daiOut = fwd.reportSwapAndForward(stratAddr, 10_000, 0);
+        uint256 daiOut = fwd.reportSwapAndForward(stratAddr, 10_000, 0, block.timestamp + 1 hours);
         vm.clearMockedCalls();
 
         assertGt(daiOut, 0, "Multi-hop through forwarder should produce DAI");

--- a/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
@@ -316,7 +316,14 @@ contract UniswapV3MultiHopTest is Test {
             mgmt
         );
 
-        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(multiHopAdapter), predictedStrat);
+        SwappingYieldForwarder fwd = new SwappingYieldForwarder(
+            recv,
+            keeper,
+            DAI,
+            address(multiHopAdapter),
+            predictedStrat,
+            0
+        );
         require(address(fwd) == predictedFwd, "Forwarder address mismatch");
 
         vm.startPrank(mgmt);

--- a/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
@@ -295,11 +295,29 @@ contract UniswapV3MultiHopTest is Test {
         address keeper = address(0xCAFE);
         address recv = address(0xBEEF);
 
-        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(multiHopAdapter));
-
         MorphoCompounderStrategyFactory fac = new MorphoCompounderStrategyFactory{
             salt: keccak256("OCT_MORPHO_COMPOUNDER_STRATEGY_VAULT_FACTORY_V1")
         }();
+
+        // Predict addresses to resolve the forwarder <-> strategy cycle: forwarder needs
+        // the strategy as its vault reference, strategy needs the forwarder as keeper/donation.
+        address predictedFwd = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        address predictedStrat = fac.computeStrategyAddress(
+            fac.YS_USDC(),
+            fac.USDC(),
+            "MorphoCompounder Donating Strategy",
+            "osMORPHO",
+            mgmt,
+            predictedFwd,
+            address(0xA3),
+            predictedFwd,
+            false,
+            address(impl),
+            mgmt
+        );
+
+        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(multiHopAdapter), predictedStrat);
+        require(address(fwd) == predictedFwd, "Forwarder address mismatch");
 
         vm.startPrank(mgmt);
         address stratAddr = fac.createStrategy(
@@ -313,6 +331,7 @@ contract UniswapV3MultiHopTest is Test {
             address(impl)
         );
         vm.stopPrank();
+        require(stratAddr == predictedStrat, "Strategy address mismatch");
 
         // Deposit
         address usr = address(0x1234);

--- a/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
@@ -108,7 +108,7 @@ contract UniswapV4SwapperIntegrationTest is BaseSwapperIntegrationTest {
         _simulateProfit(profit);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         _clearMocks();
 
@@ -405,7 +405,7 @@ contract UniswapV4MultiHopTest is Test {
 
         // Report, swap (USDC→DAI via V4), forward
         vm.prank(keeper);
-        uint256 daiOut = fwd.reportSwapAndForward(stratAddr, 10_000, 0);
+        uint256 daiOut = fwd.reportSwapAndForward(stratAddr, 10_000, 0, block.timestamp + 1 hours);
         vm.clearMockedCalls();
 
         assertGt(daiOut, 0, "Forwarder should produce DAI via swap");

--- a/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
@@ -335,11 +335,28 @@ contract UniswapV4MultiHopTest is Test {
         address keeper = address(0xCAFE);
         address recv = address(0xBEEF);
 
-        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(swapAdapter));
-
         MorphoCompounderStrategyFactory fac = new MorphoCompounderStrategyFactory{
             salt: keccak256("OCT_MORPHO_COMPOUNDER_STRATEGY_VAULT_FACTORY_V1")
         }();
+
+        // Predict addresses to resolve the forwarder <-> strategy cycle.
+        address predictedFwd = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        address predictedStrat = fac.computeStrategyAddress(
+            fac.YS_USDC(),
+            fac.USDC(),
+            "MorphoCompounder Donating Strategy",
+            "osMORPHO",
+            mgmt,
+            predictedFwd,
+            address(0xA3),
+            predictedFwd,
+            false,
+            address(impl),
+            mgmt
+        );
+
+        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(swapAdapter), predictedStrat);
+        require(address(fwd) == predictedFwd, "Forwarder address mismatch");
 
         vm.startPrank(mgmt);
         address stratAddr = fac.createStrategy(
@@ -353,6 +370,7 @@ contract UniswapV4MultiHopTest is Test {
             address(impl)
         );
         vm.stopPrank();
+        require(stratAddr == predictedStrat, "Strategy address mismatch");
 
         // Deposit
         address usr = address(0x1234);

--- a/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
@@ -179,7 +179,7 @@ contract UniswapV4MultiHopTest is Test {
         );
 
         deal(WETH, address(this), SWAP_AMOUNT_WETH);
-        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+        IERC20(WETH).approve(address(adapter), SWAP_AMOUNT_WETH);
 
         uint256 amountOut = adapter.swap(WETH, DAI, SWAP_AMOUNT_WETH, 0, swapReceiver);
 
@@ -202,7 +202,7 @@ contract UniswapV4MultiHopTest is Test {
         );
 
         deal(WETH, address(this), SWAP_AMOUNT_WETH);
-        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+        IERC20(WETH).approve(address(adapter), SWAP_AMOUNT_WETH);
 
         // Unreasonably high minAmountOut should revert
         vm.expectRevert();
@@ -249,7 +249,7 @@ contract UniswapV4MultiHopTest is Test {
         );
 
         deal(WETH, address(this), SWAP_AMOUNT_WETH);
-        IERC20(WETH).transfer(address(adapter), SWAP_AMOUNT_WETH);
+        IERC20(WETH).approve(address(adapter), SWAP_AMOUNT_WETH);
 
         uint256 amountOut = adapter.swap(WETH, USDC, SWAP_AMOUNT_WETH, 0, swapReceiver);
 
@@ -276,7 +276,7 @@ contract UniswapV4MultiHopTest is Test {
         );
 
         deal(USDC, address(this), SWAP_AMOUNT_USDC);
-        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+        IERC20(USDC).approve(address(adapter), SWAP_AMOUNT_USDC);
 
         uint256 amountOut = adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, 0, swapReceiver);
 
@@ -300,7 +300,7 @@ contract UniswapV4MultiHopTest is Test {
         );
 
         deal(USDC, address(this), SWAP_AMOUNT_USDC);
-        IERC20(USDC).transfer(address(adapter), SWAP_AMOUNT_USDC);
+        IERC20(USDC).approve(address(adapter), SWAP_AMOUNT_USDC);
 
         // Should succeed because it uses feeOut/tickSpacingOut, not fee/tickSpacing
         uint256 amountOut = adapter.swap(USDC, DAI, SWAP_AMOUNT_USDC, 0, swapReceiver);

--- a/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
@@ -355,7 +355,14 @@ contract UniswapV4MultiHopTest is Test {
             mgmt
         );
 
-        SwappingYieldForwarder fwd = new SwappingYieldForwarder(recv, keeper, DAI, address(swapAdapter), predictedStrat);
+        SwappingYieldForwarder fwd = new SwappingYieldForwarder(
+            recv,
+            keeper,
+            DAI,
+            address(swapAdapter),
+            predictedStrat,
+            0
+        );
         require(address(fwd) == predictedFwd, "Forwarder address mismatch");
 
         vm.startPrank(mgmt);

--- a/test/integration/swappers/base/BaseSwapperIntegrationTest.sol
+++ b/test/integration/swappers/base/BaseSwapperIntegrationTest.sol
@@ -96,7 +96,8 @@ abstract contract BaseSwapperIntegrationTest is Test {
             keeperEOA,
             _targetAsset(),
             address(swapper),
-            predictedStrategy
+            predictedStrategy,
+            0
         );
         require(address(forwarder) == predictedForwarder, "Forwarder address mismatch");
 

--- a/test/integration/swappers/base/BaseSwapperIntegrationTest.sol
+++ b/test/integration/swappers/base/BaseSwapperIntegrationTest.sol
@@ -218,7 +218,7 @@ abstract contract BaseSwapperIntegrationTest is Test {
         uint256 receiverTargetBefore = ERC20(_targetAsset()).balanceOf(receiver);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         _clearMocks();
 
@@ -235,7 +235,7 @@ abstract contract BaseSwapperIntegrationTest is Test {
         _depositAndReport(DEPOSIT_AMOUNT);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         assertEq(assetsOut, 0, "Should return 0 when no profit");
         assertEq(ERC20(_targetAsset()).balanceOf(receiver), 0, "Receiver gets nothing");
@@ -247,14 +247,14 @@ abstract contract BaseSwapperIntegrationTest is Test {
         // First profit cycle
         _simulateProfit(500e6);
         vm.prank(keeperEOA);
-        uint256 assets1 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assets1 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
         _clearMocks();
         assertGt(assets1, 0, "First report should yield target assets");
 
         // Second profit cycle
         _simulateProfit(1_500e6);
         vm.prank(keeperEOA);
-        uint256 assets2 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assets2 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
         _clearMocks();
         assertGt(assets2, 0, "Second report should yield target assets");
 
@@ -274,7 +274,7 @@ abstract contract BaseSwapperIntegrationTest is Test {
         emit SwappingYieldForwarder.YieldSwappedAndForwarded(address(strategy), receiver, 0, 0, 0);
 
         vm.prank(keeperEOA);
-        forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         _clearMocks();
     }
@@ -290,6 +290,6 @@ abstract contract BaseSwapperIntegrationTest is Test {
     function _test_onlyKeeper_reportSwapAndForward() internal {
         vm.prank(address(0x1111));
         vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
-        forwarder.reportSwapAndForward(address(strategy), 0, 0);
+        forwarder.reportSwapAndForward(address(strategy), 0, 0, block.timestamp + 1 hours);
     }
 }

--- a/test/integration/swappers/base/BaseSwapperIntegrationTest.sol
+++ b/test/integration/swappers/base/BaseSwapperIntegrationTest.sol
@@ -66,14 +66,41 @@ abstract contract BaseSwapperIntegrationTest is Test {
         // 2. Deploy swapper (concrete test provides this)
         ISwapper swapper = _deploySwapper();
 
-        // 3. Deploy SwappingYieldForwarder
-        forwarder = new SwappingYieldForwarder(receiver, keeperEOA, _targetAsset(), address(swapper));
-
-        // 4. Deploy MorphoCompounder strategy via factory with forwarder as keeper AND donation address
+        // 3. Deploy the factory
         factory = new MorphoCompounderStrategyFactory{
             salt: keccak256("OCT_MORPHO_COMPOUNDER_STRATEGY_VAULT_FACTORY_V1")
         }();
 
+        // 4. Predict the forwarder's CREATE address (next contract deployed by this test),
+        //    then predict the strategy's CREATE2 address using the predicted forwarder
+        //    as keeper/donation (both feed into the factory's salt hash). This breaks the
+        //    forwarder <-> strategy circular dependency.
+        address predictedForwarder = vm.computeCreateAddress(address(this), vm.getNonce(address(this)));
+        address predictedStrategy = factory.computeStrategyAddress(
+            factory.YS_USDC(),
+            factory.USDC(),
+            "MorphoCompounder Donating Strategy",
+            "osMORPHO",
+            management,
+            predictedForwarder,
+            emergencyAdmin,
+            predictedForwarder,
+            false,
+            address(implementation),
+            management
+        );
+
+        // 5. Deploy SwappingYieldForwarder with the predicted strategy as its vault
+        forwarder = new SwappingYieldForwarder(
+            receiver,
+            keeperEOA,
+            _targetAsset(),
+            address(swapper),
+            predictedStrategy
+        );
+        require(address(forwarder) == predictedForwarder, "Forwarder address mismatch");
+
+        // 6. Deploy the strategy with forwarder as keeper AND donation address
         vm.startPrank(management);
         address strategyAddr = factory.createStrategy(
             "MorphoCompounder Donating Strategy",
@@ -86,6 +113,7 @@ abstract contract BaseSwapperIntegrationTest is Test {
             address(implementation)
         );
         vm.stopPrank();
+        require(strategyAddr == predictedStrategy, "Strategy address mismatch: vault wiring broken");
 
         strategy = MorphoCompounderStrategy(strategyAddr);
 

--- a/test/mocks/MockSwapper.sol
+++ b/test/mocks/MockSwapper.sol
@@ -1,12 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ISwapper } from "src/core/interfaces/ISwapper.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
 /// @notice Mock swapper for unit testing SwappingYieldForwarder
-/// @dev Receives input tokens (ignored) and mints output tokens at a configurable rate
+/// @dev Pulls tokenIn via transferFrom (pull-pattern ISwapper semantic) and
+///      mints output tokens at a configurable rate.
 contract MockSwapper is ISwapper {
+    using SafeERC20 for IERC20;
+
     address public immutable outputToken;
     uint256 public exchangeRate; // WAD (1e18 = 1:1)
 
@@ -18,12 +23,13 @@ contract MockSwapper is ISwapper {
     }
 
     function swap(
-        address,
+        address tokenIn,
         address,
         uint256 amountIn,
         uint256 minAmountOut,
         address receiver
     ) external override returns (uint256 amountOut) {
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
         amountOut = (amountIn * exchangeRate) / 1e18;
         if (amountOut < minAmountOut) revert InsufficientOutput(minAmountOut, amountOut);
         ERC20Mock(outputToken).mint(receiver, amountOut);

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -841,6 +841,36 @@ contract SwappingYieldForwarderTest is Test {
         vm.expectRevert(abi.encodeWithSelector(SwappingYieldForwarder.InsufficientSwapOutput.selector, 5e18, 1));
         forwarder.reportSwapAndForward(address(strategy), 10_000, 5e18, block.timestamp + 1 hours);
     }
+
+    /// @notice A pull-pattern swapper may consume less than `assetsIn` and leave
+    ///         residual input with the forwarder. Authorized recovery flushes it
+    ///         to the immutable receiver, while the forwarder must not retain a
+    ///         live swapper allowance after the successful swap.
+    function test_reportSwapAndForward_partialPullResidueRecoverableAndAllowanceCleared() public {
+        PartialPullSwapper partialPull = new PartialPullSwapper(address(targetAsset), 6_000);
+        vm.prank(management);
+        forwarder.setSwapper(address(partialPull));
+
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+        _simulateProfit(10e18);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
+
+        uint256 residual = asset.balanceOf(address(forwarder));
+        assertGt(assetsOut, 0, "partial pull still produces output");
+        assertGt(residual, 0, "unpulled input should remain recoverable at forwarder");
+        assertEq(asset.allowance(address(forwarder), address(partialPull)), 0, "swapper allowance must be cleared");
+
+        uint256 receiverAssetBefore = asset.balanceOf(receiver);
+        vm.prank(management);
+        forwarder.forwardToken(address(asset));
+
+        assertEq(asset.balanceOf(address(forwarder)), 0, "forwarder residual must be flushed");
+        assertEq(asset.balanceOf(receiver), receiverAssetBefore + residual, "receiver gets residual input");
+    }
 }
 
 /// @dev A swapper that lies about amountOut to exercise the forwarder's post-swap check.
@@ -892,5 +922,34 @@ contract MixedDecimalSwapper {
             : amountIn * (10 ** (outDecimals - inDecimals));
         if (amountOut < minAmountOut) revert Insufficient(minAmountOut, amountOut);
         MockERC20(outputToken).mint(receiver, amountOut);
+    }
+}
+
+/// @dev Pull-pattern swapper that intentionally consumes only part of amountIn.
+contract PartialPullSwapper {
+    using SafeERC20 for IERC20;
+
+    uint256 internal constant BPS = 10_000;
+
+    address public immutable outputToken;
+    uint256 public immutable pullBps;
+
+    constructor(address _outputToken, uint256 _pullBps) {
+        outputToken = _outputToken;
+        pullBps = _pullBps;
+    }
+
+    function swap(
+        address tokenIn,
+        address,
+        uint256 amountIn,
+        uint256 minAmountOut,
+        address receiver
+    ) external returns (uint256) {
+        uint256 pulled = (amountIn * pullBps) / BPS;
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), pulled);
+        if (pulled < minAmountOut) revert MockSwapper.InsufficientOutput(minAmountOut, pulled);
+        ERC20Mock(outputToken).mint(receiver, pulled);
+        return pulled;
     }
 }

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -15,6 +15,7 @@ import { MockStrategy } from "test/mocks/core/tokenized-strategies/MockStrategy.
 import { MockYieldSource } from "test/mocks/core/tokenized-strategies/MockYieldSource.sol";
 import { MockSwapper } from "test/mocks/MockSwapper.sol";
 import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
+import { MockERC20 } from "test/mocks/MockERC20.sol";
 
 contract SwappingYieldForwarderTest is Test {
     SwappingYieldForwarder public forwarder;
@@ -58,7 +59,8 @@ contract SwappingYieldForwarderTest is Test {
             keeperEOA,
             address(targetAsset),
             address(swapper),
-            predictedStrategy
+            predictedStrategy,
+            0
         );
 
         // Deploy strategy with forwarder as both keeper and donation address
@@ -130,29 +132,54 @@ contract SwappingYieldForwarderTest is Test {
         assertEq(forwarder.vault(), address(strategy));
     }
 
+    function test_constructor_setsMinSlippageBps() public {
+        SwappingYieldForwarder fwd = new SwappingYieldForwarder(
+            receiver,
+            keeperEOA,
+            address(targetAsset),
+            address(swapper),
+            address(strategy),
+            9_900
+        );
+
+        assertEq(fwd.minSlippageBps(), 9_900);
+    }
+
     function test_constructor_revertsOnZeroReceiver() public {
         vm.expectRevert(YieldForwarder.InvalidReceiver.selector);
-        new SwappingYieldForwarder(address(0), keeperEOA, address(targetAsset), address(swapper), address(strategy));
+        new SwappingYieldForwarder(address(0), keeperEOA, address(targetAsset), address(swapper), address(strategy), 0);
     }
 
     function test_constructor_revertsOnZeroKeeper() public {
         vm.expectRevert(YieldForwarder.InvalidKeeper.selector);
-        new SwappingYieldForwarder(receiver, address(0), address(targetAsset), address(swapper), address(strategy));
+        new SwappingYieldForwarder(receiver, address(0), address(targetAsset), address(swapper), address(strategy), 0);
     }
 
     function test_constructor_revertsOnZeroTargetAsset() public {
         vm.expectRevert(SwappingYieldForwarder.InvalidTargetAsset.selector);
-        new SwappingYieldForwarder(receiver, keeperEOA, address(0), address(swapper), address(strategy));
+        new SwappingYieldForwarder(receiver, keeperEOA, address(0), address(swapper), address(strategy), 0);
     }
 
     function test_constructor_revertsOnZeroSwapper() public {
         vm.expectRevert(SwappingYieldForwarder.InvalidSwapper.selector);
-        new SwappingYieldForwarder(receiver, keeperEOA, address(targetAsset), address(0), address(strategy));
+        new SwappingYieldForwarder(receiver, keeperEOA, address(targetAsset), address(0), address(strategy), 0);
     }
 
     function test_constructor_revertsOnZeroVault() public {
         vm.expectRevert(SwappingYieldForwarder.InvalidVault.selector);
-        new SwappingYieldForwarder(receiver, keeperEOA, address(targetAsset), address(swapper), address(0));
+        new SwappingYieldForwarder(receiver, keeperEOA, address(targetAsset), address(swapper), address(0), 0);
+    }
+
+    function test_constructor_revertsOnInvalidMinSlippageBps() public {
+        vm.expectRevert(SwappingYieldForwarder.InvalidSlippageBps.selector);
+        new SwappingYieldForwarder(
+            receiver,
+            keeperEOA,
+            address(targetAsset),
+            address(swapper),
+            address(strategy),
+            10_001
+        );
     }
 
     // ═══════════════════════════════════════════════════════════
@@ -449,6 +476,262 @@ contract SwappingYieldForwarderTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════
+    // setMinSlippageBps — ADMIN SLIPPAGE FLOOR (bailsec #67)
+    // ═══════════════════════════════════════════════════════════
+
+    function test_constructor_zeroMinSlippageBps_disablesFloor() public view {
+        assertEq(forwarder.minSlippageBps(), 0, "Constructor floor 0 disables the floor");
+    }
+
+    function test_setMinSlippageBps_revertsOnNonManagement() public {
+        vm.prank(address(0xBAD));
+        vm.expectRevert(SwappingYieldForwarder.OnlyVaultManagement.selector);
+        forwarder.setMinSlippageBps(9_900);
+    }
+
+    function test_setMinSlippageBps_revertsAboveMaxBps() public {
+        vm.prank(management);
+        vm.expectRevert(SwappingYieldForwarder.InvalidSlippageBps.selector);
+        forwarder.setMinSlippageBps(10_001);
+    }
+
+    function test_setMinSlippageBps_updatesState() public {
+        vm.expectEmit(false, false, false, true);
+        emit SwappingYieldForwarder.MinSlippageBpsUpdated(0, 9_900);
+
+        vm.prank(management);
+        forwarder.setMinSlippageBps(9_900);
+
+        assertEq(forwarder.minSlippageBps(), 9_900);
+    }
+
+    /// @notice When a floor is set, the keeper cannot pass a minAmountOut below
+    ///         (assetsIn * floor / MAX_BPS). Regression for bailsec #67.
+    function test_reportSwapAndForward_enforcesSlippageFloor() public {
+        vm.prank(management);
+        forwarder.setMinSlippageBps(9_900); // 99% floor
+
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+        uint256 profit = 10e18;
+        _simulateProfit(profit);
+
+        // minAmountOut = 0 is below the floor of assetsIn * 9_900 / 10_000
+        vm.prank(keeperEOA);
+        vm.expectRevert(
+            abi.encodeWithSelector(SwappingYieldForwarder.SlippageFloorTooLoose.selector, (profit * 9_900) / 10_000, 0)
+        );
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+    }
+
+    /// @notice A constructor-supplied floor is active before any management call.
+    function test_reportSwapAndForward_constructorFloor_enforcesImmediately() public {
+        (SwappingYieldForwarder fwd, IMockStrategy strat, MockYieldSource src) = _deployFixtureWithFloor(9_900);
+
+        asset.mint(user, DEPOSIT_AMOUNT);
+        vm.startPrank(user);
+        asset.approve(address(strat), DEPOSIT_AMOUNT);
+        strat.deposit(DEPOSIT_AMOUNT, user);
+        vm.stopPrank();
+
+        vm.prank(address(fwd));
+        strat.report();
+        uint256 profit = 10e18;
+        asset.mint(address(src), profit);
+
+        vm.prank(keeperEOA);
+        vm.expectRevert(
+            abi.encodeWithSelector(SwappingYieldForwarder.SlippageFloorTooLoose.selector, (profit * 9_900) / 10_000, 0)
+        );
+        fwd.reportSwapAndForward(address(strat), 10_000, 0);
+    }
+
+    /// @notice Codex P1 regression — USDC(6) -> USDS(18), 99% floor.
+    ///         Without decimals normalization the floor is computed in input-asset units
+    ///         (~990_000 wei for 1 USDC of profit), and a `minAmountOut` of 1e17 wei
+    ///         (a laughable 0.0001 USDS for 1 USDC of value) silently clears the check.
+    ///         With normalization the floor becomes 9.9e17 in target units, and the
+    ///         same minAmountOut reverts.
+    function test_reportSwapAndForward_floor_lowToHighDecimals_enforcesNormalizedFloor() public {
+        (
+            SwappingYieldForwarder fwd,
+            IMockStrategy strat,
+            MockERC20 assetMix,
+            ,
+            MockYieldSource yieldSrc
+        ) = _deployMixedDecimalFixture(6, 18);
+
+        vm.prank(management);
+        fwd.setMinSlippageBps(9_900);
+
+        uint256 depositAmt = 100e6;
+        uint256 profit = 1e6;
+        assetMix.mint(user, depositAmt);
+        vm.startPrank(user);
+        assetMix.approve(address(strat), depositAmt);
+        strat.deposit(depositAmt, user);
+        vm.stopPrank();
+        vm.prank(address(fwd));
+        strat.report();
+        assetMix.mint(address(yieldSrc), profit);
+
+        // Normalized floor = (1e6 * 10**12) * 9_900 / 10_000 = 9.9e17 (target units).
+        // Pre-fix floor (raw, no scaling) = 1e6 * 9_900 / 10_000 = 990_000 — so
+        // minAmountOut = 1e17 sits between the two and distinguishes the fix.
+        vm.prank(keeperEOA);
+        vm.expectRevert(
+            abi.encodeWithSelector(SwappingYieldForwarder.SlippageFloorTooLoose.selector, 9.9e17, 1e17)
+        );
+        fwd.reportSwapAndForward(address(strat), 10_000, 1e17);
+    }
+
+    /// @notice Codex P1 regression — USDS(18) -> USDC(6), 99% floor.
+    ///         Without normalization the floor is 9.9e17 (18-dec input units), which is
+    ///         orders of magnitude above any realistic USDC `minAmountOut`, turning every
+    ///         valid swap into a DoS. With normalization the floor is 990_000 (6-dec
+    ///         target units) and a `minAmountOut` of 1e6 (1 USDC) clears it.
+    function test_reportSwapAndForward_floor_highToLowDecimals_doesNotDos() public {
+        (
+            SwappingYieldForwarder fwd,
+            IMockStrategy strat,
+            MockERC20 assetMix,
+            ,
+            MockYieldSource yieldSrc
+        ) = _deployMixedDecimalFixture(18, 6);
+
+        vm.prank(management);
+        fwd.setMinSlippageBps(9_900);
+
+        uint256 depositAmt = 100e18;
+        uint256 profit = 1e18;
+        assetMix.mint(user, depositAmt);
+        vm.startPrank(user);
+        assetMix.approve(address(strat), depositAmt);
+        strat.deposit(depositAmt, user);
+        vm.stopPrank();
+        vm.prank(address(fwd));
+        strat.report();
+        assetMix.mint(address(yieldSrc), profit);
+
+        // Normalized floor = (1e18 / 10**12) * 9_900 / 10_000 = 990_000 (target units).
+        // Keeper passes minAmountOut = 1e6 (1 USDC), which clears the correct floor.
+        // Pre-fix: floor would be 9.9e17 and the same call would revert (DoS).
+        vm.prank(keeperEOA);
+        uint256 assetsOut = fwd.reportSwapAndForward(address(strat), 10_000, 1e6);
+        assertGt(assetsOut, 0, "swap should succeed when floor is correctly normalized");
+    }
+
+    /// @dev Internal helper: deploys a fresh forwarder + strategy pair whose asset
+    ///      and targetAsset have arbitrary decimals. Reuses the existing
+    ///      `receiver`/`keeperEOA`/`management`/`implementation` fixtures.
+    function _deployMixedDecimalFixture(
+        uint8 inDec,
+        uint8 outDec
+    )
+        internal
+        returns (
+            SwappingYieldForwarder fwd,
+            IMockStrategy strat,
+            MockERC20 assetMix,
+            MockERC20 targetMix,
+            MockYieldSource yieldSrc
+        )
+    {
+        assetMix = new MockERC20(inDec);
+        targetMix = new MockERC20(outDec);
+        yieldSrc = new MockYieldSource(address(assetMix));
+        MixedDecimalSwapper mixSwapper = new MixedDecimalSwapper(address(targetMix), inDec, outDec);
+
+        uint256 baseNonce = vm.getNonce(address(this));
+        address predictedStrat = vm.computeCreateAddress(address(this), baseNonce + 1);
+
+        fwd = new SwappingYieldForwarder(
+            receiver,
+            keeperEOA,
+            address(targetMix),
+            address(mixSwapper),
+            predictedStrat,
+            0
+        );
+
+        strat = IMockStrategy(
+            address(
+                new MockStrategy(
+                    address(assetMix),
+                    address(yieldSrc),
+                    management,
+                    address(fwd),
+                    emergencyAdmin,
+                    address(fwd),
+                    address(implementation)
+                )
+            )
+        );
+        require(address(strat) == predictedStrat, "mixed-decimal fixture address mismatch");
+
+        vm.startPrank(management);
+        strat.setKeeper(address(fwd));
+        strat.setEmergencyAdmin(emergencyAdmin);
+        strat.setPendingManagement(management);
+        strat.acceptManagement();
+        vm.stopPrank();
+    }
+
+    /// @notice A constructor floor of 0 preserves the prior "keeper sets slippage"
+    ///         behaviour -- any minAmountOut including 0 is accepted.
+    function test_reportSwapAndForward_zeroFloor_acceptsZeroMinAmountOut() public {
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+        _simulateProfit(10e18);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        assertGt(assetsOut, 0);
+    }
+
+    function _deployFixtureWithFloor(
+        uint16 floorBps
+    ) internal returns (SwappingYieldForwarder fwd, IMockStrategy strat, MockYieldSource src) {
+        src = new MockYieldSource(address(asset));
+
+        uint256 baseNonce = vm.getNonce(address(this));
+        address predictedStrat = vm.computeCreateAddress(address(this), baseNonce + 1);
+
+        fwd = new SwappingYieldForwarder(
+            receiver,
+            keeperEOA,
+            address(targetAsset),
+            address(swapper),
+            predictedStrat,
+            floorBps
+        );
+
+        strat = IMockStrategy(
+            address(
+                new MockStrategy(
+                    address(asset),
+                    address(src),
+                    management,
+                    address(fwd),
+                    emergencyAdmin,
+                    address(fwd),
+                    address(implementation)
+                )
+            )
+        );
+        require(address(strat) == predictedStrat, "floor fixture address mismatch");
+
+        vm.startPrank(management);
+        strat.setKeeper(address(fwd));
+        strat.setEmergencyAdmin(emergencyAdmin);
+        strat.setPendingManagement(management);
+        strat.acceptManagement();
+        vm.stopPrank();
+    }
+
+    // ═══════════════════════════════════════════════════════════
     // POST-SWAP minAmountOut RE-CHECK (defense-in-depth)
     // ═══════════════════════════════════════════════════════════
 
@@ -467,9 +750,7 @@ contract SwappingYieldForwarderTest is Test {
         _simulateProfit(10e18);
 
         vm.prank(keeperEOA);
-        vm.expectRevert(
-            abi.encodeWithSelector(SwappingYieldForwarder.InsufficientSwapOutput.selector, 5e18, 1)
-        );
+        vm.expectRevert(abi.encodeWithSelector(SwappingYieldForwarder.InsufficientSwapOutput.selector, 5e18, 1));
         forwarder.reportSwapAndForward(address(strategy), 10_000, 5e18);
     }
 }
@@ -484,15 +765,44 @@ contract DishonestSwapper {
         outputToken = _outputToken;
     }
 
+    function swap(address tokenIn, address, uint256 amountIn, uint256, address receiver) external returns (uint256) {
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
+        ERC20Mock(outputToken).mint(receiver, amountIn);
+        return 1; // lies: reports 1 wei despite minting full amount
+    }
+}
+
+/// @dev Mock swapper for mixed-decimal targets (MockERC20 output). Models a
+///      1:1-value conversion across a decimals gap: 1e{inDec} of tokenIn ->
+///      1e{outDec} of tokenOut. Required because MockSwapper hardcodes an
+///      ERC20Mock cast on the output token, which doesn't support custom decimals.
+contract MixedDecimalSwapper {
+    using SafeERC20 for IERC20;
+
+    address payable public immutable outputToken;
+    uint8 public immutable inDecimals;
+    uint8 public immutable outDecimals;
+
+    error Insufficient(uint256 expected, uint256 actual);
+
+    constructor(address _outputToken, uint8 _inDecimals, uint8 _outDecimals) {
+        outputToken = payable(_outputToken);
+        inDecimals = _inDecimals;
+        outDecimals = _outDecimals;
+    }
+
     function swap(
         address tokenIn,
         address,
         uint256 amountIn,
-        uint256,
+        uint256 minAmountOut,
         address receiver
-    ) external returns (uint256) {
+    ) external returns (uint256 amountOut) {
         IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
-        ERC20Mock(outputToken).mint(receiver, amountIn);
-        return 1; // lies: reports 1 wei despite minting full amount
+        amountOut = inDecimals >= outDecimals
+            ? amountIn / (10 ** (inDecimals - outDecimals))
+            : amountIn * (10 ** (outDecimals - inDecimals));
+        if (amountOut < minAmountOut) revert Insufficient(minAmountOut, amountOut);
+        MockERC20(outputToken).mint(receiver, amountOut);
     }
 }

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -183,6 +183,51 @@ contract SwappingYieldForwarderTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════
+    // forwardToken — AUTHORIZED RECOVERY
+    // ═══════════════════════════════════════════════════════════
+
+    function test_forwardToken_managementCanForwardToReceiver() public {
+        asset.mint(address(forwarder), 3e18);
+
+        vm.prank(management);
+        forwarder.forwardToken(address(asset));
+
+        assertEq(asset.balanceOf(address(forwarder)), 0, "forwarder residual must be flushed");
+        assertEq(asset.balanceOf(receiver), 3e18, "receiver gets recovered balance");
+    }
+
+    function test_forwardToken_keeperCanForwardToReceiver() public {
+        asset.mint(address(forwarder), 5e18);
+
+        vm.prank(keeperEOA);
+        forwarder.forwardToken(address(asset));
+
+        assertEq(asset.balanceOf(address(forwarder)), 0, "forwarder residual must be flushed");
+        assertEq(asset.balanceOf(receiver), 5e18, "receiver gets recovered balance");
+    }
+
+    function test_forwardToken_revertsWhenNeitherKeeperNorManagement() public {
+        asset.mint(address(forwarder), 7e18);
+
+        vm.prank(user);
+        vm.expectRevert(SwappingYieldForwarder.OnlyVaultManagement.selector);
+        forwarder.forwardToken(address(asset));
+
+        assertEq(asset.balanceOf(address(forwarder)), 7e18, "unauthorized call keeps balance");
+        assertEq(asset.balanceOf(receiver), 0, "receiver gets nothing");
+    }
+
+    function test_forwardToken_emitsTokenForwardedEvent() public {
+        asset.mint(address(forwarder), 11e18);
+
+        vm.expectEmit(true, true, false, true);
+        emit SwappingYieldForwarder.TokenForwarded(address(asset), receiver, 11e18);
+
+        vm.prank(keeperEOA);
+        forwarder.forwardToken(address(asset));
+    }
+
+    // ═══════════════════════════════════════════════════════════
     // reportAndForward — NO-SWAP FALLBACK PATH
     // ═══════════════════════════════════════════════════════════
 

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -310,7 +310,7 @@ contract SwappingYieldForwarderTest is Test {
     }
 
     function test_reportSwapAndForward_revertsOnExpiredDeadline() public {
-        // Bailsec #68: freshness check runs before any other work so a keeper transaction
+        // Freshness check runs before any other work so a keeper transaction
         // that lands one block too late fails cheaply with ExpiredDeadline instead of
         // settling against a moved market.
         uint256 staleDeadline = block.timestamp - 1;
@@ -509,7 +509,7 @@ contract SwappingYieldForwarderTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════
-    // setSwapper — VAULT MANAGEMENT (bailsec #72 / #75)
+    // setSwapper — VAULT MANAGEMENT
     // ═══════════════════════════════════════════════════════════
 
     function test_setSwapper_revertsOnNonManagementCaller() public {
@@ -566,7 +566,7 @@ contract SwappingYieldForwarderTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════
-    // setMinSlippageBps — ADMIN SLIPPAGE FLOOR (bailsec #67)
+    // setMinSlippageBps — ADMIN SLIPPAGE FLOOR
     // ═══════════════════════════════════════════════════════════
 
     function test_constructor_zeroMinSlippageBps_disablesFloor() public view {
@@ -596,7 +596,7 @@ contract SwappingYieldForwarderTest is Test {
     }
 
     /// @notice When a floor is set, the keeper cannot pass a minAmountOut below
-    ///         (assetsIn * floor / MAX_BPS). Regression for bailsec #67.
+    ///         (assetsIn * floor / MAX_BPS).
     function test_reportSwapAndForward_enforcesSlippageFloor() public {
         vm.prank(management);
         forwarder.setMinSlippageBps(9_900); // 99% floor

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -249,7 +249,7 @@ contract SwappingYieldForwarderTest is Test {
         _simulateProfit(profit);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         assertGt(assetsOut, 0, "Should swap and forward nonzero target assets");
         assertEq(targetAsset.balanceOf(receiver), assetsOut, "Receiver should get target asset");
@@ -261,7 +261,52 @@ contract SwappingYieldForwarderTest is Test {
     function test_reportSwapAndForward_revertsWhenNotKeeper() public {
         vm.prank(address(0x1111));
         vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
-        forwarder.reportSwapAndForward(address(strategy), 0, 0);
+        forwarder.reportSwapAndForward(address(strategy), 0, 0, block.timestamp + 1 hours);
+    }
+
+    function test_reportSwapAndForward_revertsOnExpiredDeadline() public {
+        // Bailsec #68: freshness check runs before any other work so a keeper transaction
+        // that lands one block too late fails cheaply with ExpiredDeadline instead of
+        // settling against a moved market.
+        uint256 staleDeadline = block.timestamp - 1;
+
+        vm.prank(keeperEOA);
+        vm.expectRevert(
+            abi.encodeWithSelector(SwappingYieldForwarder.ExpiredDeadline.selector, staleDeadline, block.timestamp)
+        );
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 0, staleDeadline);
+    }
+
+    function test_reportSwapAndForward_revertsOnDeadlineBoundary() public {
+        // `block.timestamp == deadline` is accepted (require-eq semantics); `deadline + 1`
+        // in the past is the tightest stale window and must revert.
+        uint256 exactNow = block.timestamp;
+
+        // Exactly at deadline: must not revert on the deadline check. We expect the
+        // call to succeed through to the no-profit return of 0 (strategy is pristine).
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, exactNow);
+        assertEq(assetsOut, 0, "equal-timestamp deadline must pass the freshness gate");
+
+        // One second past: must revert with ExpiredDeadline.
+        vm.warp(block.timestamp + 2);
+        vm.prank(keeperEOA);
+        vm.expectRevert(
+            abi.encodeWithSelector(SwappingYieldForwarder.ExpiredDeadline.selector, exactNow, block.timestamp)
+        );
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 0, exactNow);
+    }
+
+    function test_reportSwapAndForward_deadlineCheckedBeforeKeeperGate() public {
+        // A non-keeper with an expired deadline must hit ExpiredDeadline first — cheaper
+        // revert path and matches the ordering documented on the function.
+        uint256 staleDeadline = block.timestamp - 1;
+
+        vm.prank(address(0x1111)); // not keeper
+        vm.expectRevert(
+            abi.encodeWithSelector(SwappingYieldForwarder.ExpiredDeadline.selector, staleDeadline, block.timestamp)
+        );
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 0, staleDeadline);
     }
 
     function test_reportSwapAndForward_zeroProfit_returnsZero() public {
@@ -270,7 +315,7 @@ contract SwappingYieldForwarderTest is Test {
         strategy.report();
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         assertEq(assetsOut, 0, "Should return 0 when no profit");
         assertEq(targetAsset.balanceOf(receiver), 0, "Receiver should get nothing");
@@ -287,7 +332,7 @@ contract SwappingYieldForwarderTest is Test {
         emit SwappingYieldForwarder.YieldSwappedAndForwarded(address(strategy), receiver, 0, 0, 0);
 
         vm.prank(keeperEOA);
-        forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
     }
 
     function test_reportSwapAndForward_multipleReports() public {
@@ -298,13 +343,13 @@ contract SwappingYieldForwarderTest is Test {
         // First profit cycle
         _simulateProfit(5e18);
         vm.prank(keeperEOA);
-        uint256 assets1 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assets1 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
         assertGt(assets1, 0, "First report should yield target assets");
 
         // Second profit cycle
         _simulateProfit(15e18);
         vm.prank(keeperEOA);
-        uint256 assets2 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assets2 = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
         assertGt(assets2, 0, "Second report should yield target assets");
 
         assertEq(targetAsset.balanceOf(receiver), assets1 + assets2, "Receiver should accumulate all payouts");
@@ -320,7 +365,7 @@ contract SwappingYieldForwarderTest is Test {
         // minAmountOut too high should revert (swapper enforces it)
         vm.prank(keeperEOA);
         vm.expectRevert();
-        forwarder.reportSwapAndForward(address(strategy), 10_000, type(uint256).max);
+        forwarder.reportSwapAndForward(address(strategy), 10_000, type(uint256).max, block.timestamp + 1 hours);
     }
 
     function test_reportSwapAndForward_lossScenario_noSharesMinted() public {
@@ -333,7 +378,7 @@ contract SwappingYieldForwarderTest is Test {
         yieldSource.simulateLoss(5e18);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         assertEq(assetsOut, 0, "Loss report should return 0");
         assertEq(targetAsset.balanceOf(receiver), 0, "Receiver gets nothing on loss");
@@ -360,7 +405,7 @@ contract SwappingYieldForwarderTest is Test {
         emit SwappingYieldForwarder.YieldSwappedAndForwarded(address(strategy), receiver, 0, 0, 0);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         assertEq(assetsOut, 0, "Should return 0 when redeem returns 0 assets");
         assertEq(targetAsset.balanceOf(receiver), 0, "Receiver gets nothing");
@@ -382,7 +427,7 @@ contract SwappingYieldForwarderTest is Test {
         _simulateProfit(profit);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         assertGt(assetsOut, 0, "Should always forward positive target assets for positive profit");
         assertEq(strategy.balanceOf(address(forwarder)), 0, "Forwarder should redeem all shares");
@@ -468,7 +513,7 @@ contract SwappingYieldForwarderTest is Test {
         _simulateProfit(10e18);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
 
         // New swapper at 2x rate: assetsOut should be roughly 2x the redeemed underlying
         assertGt(assetsOut, 0);
@@ -522,7 +567,7 @@ contract SwappingYieldForwarderTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(SwappingYieldForwarder.SlippageFloorTooLoose.selector, (profit * 9_900) / 10_000, 0)
         );
-        forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
     }
 
     /// @notice A constructor-supplied floor is active before any management call.
@@ -544,7 +589,7 @@ contract SwappingYieldForwarderTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(SwappingYieldForwarder.SlippageFloorTooLoose.selector, (profit * 9_900) / 10_000, 0)
         );
-        fwd.reportSwapAndForward(address(strat), 10_000, 0);
+        fwd.reportSwapAndForward(address(strat), 10_000, 0, block.timestamp + 1 hours);
     }
 
     /// @notice Codex P1 regression — USDC(6) -> USDS(18), 99% floor.
@@ -580,10 +625,8 @@ contract SwappingYieldForwarderTest is Test {
         // Pre-fix floor (raw, no scaling) = 1e6 * 9_900 / 10_000 = 990_000 — so
         // minAmountOut = 1e17 sits between the two and distinguishes the fix.
         vm.prank(keeperEOA);
-        vm.expectRevert(
-            abi.encodeWithSelector(SwappingYieldForwarder.SlippageFloorTooLoose.selector, 9.9e17, 1e17)
-        );
-        fwd.reportSwapAndForward(address(strat), 10_000, 1e17);
+        vm.expectRevert(abi.encodeWithSelector(SwappingYieldForwarder.SlippageFloorTooLoose.selector, 9.9e17, 1e17));
+        fwd.reportSwapAndForward(address(strat), 10_000, 1e17, block.timestamp + 1 hours);
     }
 
     /// @notice Codex P1 regression — USDS(18) -> USDC(6), 99% floor.
@@ -618,7 +661,7 @@ contract SwappingYieldForwarderTest is Test {
         // Keeper passes minAmountOut = 1e6 (1 USDC), which clears the correct floor.
         // Pre-fix: floor would be 9.9e17 and the same call would revert (DoS).
         vm.prank(keeperEOA);
-        uint256 assetsOut = fwd.reportSwapAndForward(address(strat), 10_000, 1e6);
+        uint256 assetsOut = fwd.reportSwapAndForward(address(strat), 10_000, 1e6, block.timestamp + 1 hours);
         assertGt(assetsOut, 0, "swap should succeed when floor is correctly normalized");
     }
 
@@ -687,7 +730,7 @@ contract SwappingYieldForwarderTest is Test {
         _simulateProfit(10e18);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0, block.timestamp + 1 hours);
         assertGt(assetsOut, 0);
     }
 
@@ -751,7 +794,7 @@ contract SwappingYieldForwarderTest is Test {
 
         vm.prank(keeperEOA);
         vm.expectRevert(abi.encodeWithSelector(SwappingYieldForwarder.InsufficientSwapOutput.selector, 5e18, 1));
-        forwarder.reportSwapAndForward(address(strategy), 10_000, 5e18);
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 5e18, block.timestamp + 1 hours);
     }
 }
 

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.25;
 
 import { Test, Vm } from "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
 import { SwappingYieldForwarder } from "src/core/SwappingYieldForwarder.sol";
@@ -45,8 +46,20 @@ contract SwappingYieldForwarderTest is Test {
         // Deploy swapper (1:1 rate)
         swapper = new MockSwapper(address(targetAsset), 1e18);
 
-        // Deploy SwappingYieldForwarder
-        forwarder = new SwappingYieldForwarder(receiver, keeperEOA, address(targetAsset), address(swapper));
+        // Break the forwarder <-> strategy circular reference by predicting the
+        // strategy's CREATE address. Forwarder needs the vault at construction,
+        // strategy needs the forwarder as keeper/donation at construction.
+        uint256 baseNonce = vm.getNonce(address(this));
+        address predictedStrategy = vm.computeCreateAddress(address(this), baseNonce + 1);
+
+        // Deploy SwappingYieldForwarder with the predicted strategy as its vault source
+        forwarder = new SwappingYieldForwarder(
+            receiver,
+            keeperEOA,
+            address(targetAsset),
+            address(swapper),
+            predictedStrategy
+        );
 
         // Deploy strategy with forwarder as both keeper and donation address
         strategy = IMockStrategy(
@@ -62,6 +75,7 @@ contract SwappingYieldForwarderTest is Test {
                 )
             )
         );
+        assertEq(address(strategy), predictedStrategy, "Predicted strategy address must match actual");
 
         vm.startPrank(management);
         strategy.setKeeper(address(forwarder));
@@ -112,24 +126,33 @@ contract SwappingYieldForwarderTest is Test {
         assertEq(address(forwarder.swapper()), address(swapper));
     }
 
+    function test_constructor_setsVault() public view {
+        assertEq(forwarder.vault(), address(strategy));
+    }
+
     function test_constructor_revertsOnZeroReceiver() public {
         vm.expectRevert(YieldForwarder.InvalidReceiver.selector);
-        new SwappingYieldForwarder(address(0), keeperEOA, address(targetAsset), address(swapper));
+        new SwappingYieldForwarder(address(0), keeperEOA, address(targetAsset), address(swapper), address(strategy));
     }
 
     function test_constructor_revertsOnZeroKeeper() public {
         vm.expectRevert(YieldForwarder.InvalidKeeper.selector);
-        new SwappingYieldForwarder(receiver, address(0), address(targetAsset), address(swapper));
+        new SwappingYieldForwarder(receiver, address(0), address(targetAsset), address(swapper), address(strategy));
     }
 
     function test_constructor_revertsOnZeroTargetAsset() public {
         vm.expectRevert(SwappingYieldForwarder.InvalidTargetAsset.selector);
-        new SwappingYieldForwarder(receiver, keeperEOA, address(0), address(swapper));
+        new SwappingYieldForwarder(receiver, keeperEOA, address(0), address(swapper), address(strategy));
     }
 
     function test_constructor_revertsOnZeroSwapper() public {
         vm.expectRevert(SwappingYieldForwarder.InvalidSwapper.selector);
-        new SwappingYieldForwarder(receiver, keeperEOA, address(targetAsset), address(0));
+        new SwappingYieldForwarder(receiver, keeperEOA, address(targetAsset), address(0), address(strategy));
+    }
+
+    function test_constructor_revertsOnZeroVault() public {
+        vm.expectRevert(SwappingYieldForwarder.InvalidVault.selector);
+        new SwappingYieldForwarder(receiver, keeperEOA, address(targetAsset), address(swapper), address(0));
     }
 
     // ═══════════════════════════════════════════════════════════
@@ -366,5 +389,110 @@ contract SwappingYieldForwarderTest is Test {
 
     function test_strategyKeeperIsForwarder() public view {
         assertEq(strategy.keeper(), address(forwarder), "Strategy keeper should be forwarder");
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // setSwapper — VAULT MANAGEMENT (bailsec #72 / #75)
+    // ═══════════════════════════════════════════════════════════
+
+    function test_setSwapper_revertsOnNonManagementCaller() public {
+        MockSwapper newSwapper = new MockSwapper(address(targetAsset), 1e18);
+        vm.prank(address(0xBAD));
+        vm.expectRevert(SwappingYieldForwarder.OnlyVaultManagement.selector);
+        forwarder.setSwapper(address(newSwapper));
+    }
+
+    function test_setSwapper_revertsOnKeeperCaller() public {
+        MockSwapper newSwapper = new MockSwapper(address(targetAsset), 1e18);
+        vm.prank(keeperEOA);
+        vm.expectRevert(SwappingYieldForwarder.OnlyVaultManagement.selector);
+        forwarder.setSwapper(address(newSwapper));
+    }
+
+    function test_setSwapper_revertsOnZeroAddress() public {
+        vm.prank(management);
+        vm.expectRevert(SwappingYieldForwarder.InvalidSwapper.selector);
+        forwarder.setSwapper(address(0));
+    }
+
+    function test_setSwapper_rotatesSwapperFromManagement() public {
+        MockSwapper newSwapper = new MockSwapper(address(targetAsset), 1e18);
+
+        vm.expectEmit(true, true, false, false);
+        emit SwappingYieldForwarder.SwapperUpdated(address(swapper), address(newSwapper));
+
+        vm.prank(management);
+        forwarder.setSwapper(address(newSwapper));
+
+        assertEq(address(forwarder.swapper()), address(newSwapper));
+    }
+
+    /// @notice After rotation, reportSwapAndForward routes through the new swapper.
+    function test_setSwapper_newSwapperUsedOnNextSwap() public {
+        ERC20Mock newTargetMintedBy = targetAsset; // same target asset, different adapter
+        MockSwapper newSwapper = new MockSwapper(address(newTargetMintedBy), 2e18); // 2x rate
+
+        vm.prank(management);
+        forwarder.setSwapper(address(newSwapper));
+
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+        _simulateProfit(10e18);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = forwarder.reportSwapAndForward(address(strategy), 10_000, 0);
+
+        // New swapper at 2x rate: assetsOut should be roughly 2x the redeemed underlying
+        assertGt(assetsOut, 0);
+        assertEq(targetAsset.balanceOf(receiver), assetsOut);
+    }
+
+    // ═══════════════════════════════════════════════════════════
+    // POST-SWAP minAmountOut RE-CHECK (defense-in-depth)
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice A buggy swapper that under-reports assetsOut must be caught by
+    ///         the forwarder's own threshold check, even if the swapper itself
+    ///         doesn't revert. Regression for the defense-in-depth guard.
+    function test_reportSwapAndForward_revertsWhenSwapperReportsBelowMin() public {
+        // Install a dishonest swapper that mints the full output but returns 1 wei.
+        DishonestSwapper dishonest = new DishonestSwapper(address(targetAsset));
+        vm.prank(management);
+        forwarder.setSwapper(address(dishonest));
+
+        _depositIntoStrategy(user, DEPOSIT_AMOUNT);
+        vm.prank(address(forwarder));
+        strategy.report();
+        _simulateProfit(10e18);
+
+        vm.prank(keeperEOA);
+        vm.expectRevert(
+            abi.encodeWithSelector(SwappingYieldForwarder.InsufficientSwapOutput.selector, 5e18, 1)
+        );
+        forwarder.reportSwapAndForward(address(strategy), 10_000, 5e18);
+    }
+}
+
+/// @dev A swapper that lies about amountOut to exercise the forwarder's post-swap check.
+contract DishonestSwapper {
+    using SafeERC20 for IERC20;
+
+    address public immutable outputToken;
+
+    constructor(address _outputToken) {
+        outputToken = _outputToken;
+    }
+
+    function swap(
+        address tokenIn,
+        address,
+        uint256 amountIn,
+        uint256,
+        address receiver
+    ) external returns (uint256) {
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
+        ERC20Mock(outputToken).mint(receiver, amountIn);
+        return 1; // lies: reports 1 wei despite minting full amount
     }
 }

--- a/test/unit/core/SwappingYieldForwarderMirror.t.sol
+++ b/test/unit/core/SwappingYieldForwarderMirror.t.sol
@@ -1,0 +1,204 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { SwappingYieldForwarder } from "src/core/SwappingYieldForwarder.sol";
+import { MockSwapper } from "test/mocks/MockSwapper.sol";
+
+/// @notice Strategy mock whose convertToAssets uses floor((shares * totalAssets) / totalSupply)
+///         and whose redeem reverts with ZERO_ASSETS if the preview rounds to zero. Mirrors
+///         the real TokenizedStrategy.redeem guard so we can reproduce the pre-fix DoS
+///         (1 wei share dust on a loss-impaired strategy bricks reportSwapAndForward).
+contract LossImpairedStrategy is ERC20Mock {
+    ERC20Mock public immutable underlying;
+    uint256 public totalAssetsStored;
+    bool public reported;
+    bool public redeemCalled;
+
+    constructor(address _underlying) {
+        underlying = ERC20Mock(_underlying);
+    }
+
+    function asset() external view returns (address) {
+        return address(underlying);
+    }
+
+    function setTotalAssets(uint256 v) external {
+        totalAssetsStored = v;
+    }
+
+    function maxRedeem(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function convertToAssets(uint256 shares) external view returns (uint256) {
+        uint256 ts = totalSupply();
+        if (ts == 0) return shares;
+        return (shares * totalAssetsStored) / ts;
+    }
+
+    function report() external returns (uint256, uint256) {
+        reported = true;
+        return (0, 0);
+    }
+
+    function redeem(uint256 shares, address receiver, address owner, uint256) external returns (uint256 assets) {
+        redeemCalled = true;
+        uint256 ts = totalSupply();
+        assets = ts == 0 ? shares : (shares * totalAssetsStored) / ts;
+        require(assets > 0, "ZERO_ASSETS");
+        _burn(owner, shares);
+        totalAssetsStored -= assets;
+        underlying.mint(receiver, assets);
+    }
+}
+
+/// @notice Programmable strategy mock for the Bailsec #62 maxRedeem cap path. 1:1 rate
+///         means non-zero shares always yield non-zero assets, so the #61 guard never
+///         fires here and we isolate the cap behaviour.
+contract MockStrategy is ERC20Mock {
+    ERC20Mock public immutable underlying;
+    uint256 internal _maxRedeemValue;
+    bool public reported;
+    uint256 public constant REDEEM_RATE = 1;
+
+    constructor(address _underlying) {
+        underlying = ERC20Mock(_underlying);
+    }
+
+    function asset() external view returns (address) {
+        return address(underlying);
+    }
+
+    function setMaxRedeem(uint256 value) external {
+        _maxRedeemValue = value;
+    }
+
+    function maxRedeem(address) external view returns (uint256) {
+        return _maxRedeemValue;
+    }
+
+    function convertToAssets(uint256 shares) external pure returns (uint256) {
+        return shares * REDEEM_RATE;
+    }
+
+    function report() external returns (uint256, uint256) {
+        reported = true;
+        return (0, 0);
+    }
+
+    function redeem(uint256 shares, address receiver, address owner, uint256) external returns (uint256 assets) {
+        require(shares <= _maxRedeemValue, "MAX_REDEEM");
+        _burn(owner, shares);
+        assets = shares * REDEEM_RATE;
+        underlying.mint(receiver, assets);
+    }
+}
+
+/// @notice Mock vault that exposes management() so the SwappingYieldForwarder constructor
+///         and onlyVaultManagement modifier are satisfied. Not exercised by these tests.
+contract MockVault {
+    address public management;
+
+    constructor(address _management) {
+        management = _management;
+    }
+}
+
+/// @notice Bailsec #61 / #62 mirror guards on SwappingYieldForwarder.reportSwapAndForward.
+///         Both guards were added to YieldForwarder.reportAndForward in the sibling #415 PR
+///         and must be mirrored on the swapping variant so external vault liquidity shortfalls
+///         (maxRedeem < balance) and loss-impaired dust (convertToAssets rounds to zero) do
+///         not revert the outer call and roll back report() side effects.
+contract SwappingYieldForwarderMirrorTest is Test {
+    SwappingYieldForwarder internal swappingForwarder;
+    ERC20Mock internal underlying;
+    ERC20Mock internal targetAsset;
+    MockVault internal vault;
+
+    address internal receiver = address(0xBEEF);
+    address internal keeperEOA = address(0xCAFE);
+
+    function setUp() public {
+        underlying = new ERC20Mock();
+        targetAsset = new ERC20Mock();
+        vault = new MockVault(address(this));
+
+        MockSwapper swapper = new MockSwapper(address(targetAsset), 1e18);
+        swappingForwarder = new SwappingYieldForwarder(
+            receiver,
+            keeperEOA,
+            address(targetAsset),
+            address(swapper),
+            address(vault),
+            0
+        );
+    }
+
+    function _impair(
+        LossImpairedStrategy s,
+        address shareholder,
+        uint256 shareholderShares,
+        address forwarderAddr,
+        uint256 dust
+    ) internal {
+        s.mint(shareholder, shareholderShares);
+        s.mint(forwarderAddr, dust);
+        s.setTotalAssets(shareholderShares - 1);
+    }
+
+    // --- Bailsec #61 mirror: ZERO_ASSETS skip on loss-impaired strategy ---
+
+    /// @notice Dust share on a loss-impaired strategy must not revert reportSwapAndForward.
+    ///         report() commits, no swap is attempted, dust stays at forwarder.
+    function test_reportSwapAndForward_dustOnLossImpaired_skipsRedeem() public {
+        LossImpairedStrategy s = new LossImpairedStrategy(address(underlying));
+        _impair(s, address(0xA11CE), 1_000 ether, address(swappingForwarder), 1);
+
+        assertEq(s.convertToAssets(1), 0, "precondition: dust rounds to zero");
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = swappingForwarder.reportSwapAndForward(address(s), 0, 0);
+
+        assertEq(assetsOut, 0, "no swap output");
+        assertEq(s.balanceOf(address(swappingForwarder)), 1, "dust share retained");
+        assertEq(targetAsset.balanceOf(receiver), 0, "receiver gets nothing");
+        assertTrue(s.reported(), "report() commits on swapping variant");
+        assertFalse(s.redeemCalled(), "redeem must be skipped, not called-and-failed");
+    }
+
+    // --- Bailsec #62 mirror: maxRedeem cap ---
+
+    /// @notice maxRedeem < balance. Pre-fix this would revert inside redeem and roll back
+    ///         report(). Post-fix: shares capped at maxRedeem, report() commits, residual
+    ///         shares stay for a later call, swap runs on the capped amount.
+    function test_reportSwapAndForward_maxRedeemBelowBalance_capsAtMaxRedeem() public {
+        MockStrategy s = new MockStrategy(address(underlying));
+        s.mint(address(swappingForwarder), 100 ether);
+        s.setMaxRedeem(40 ether);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = swappingForwarder.reportSwapAndForward(address(s), 0, 0);
+
+        assertEq(assetsOut, 40 ether, "output matches capped redeem");
+        assertEq(s.balanceOf(address(swappingForwarder)), 60 ether, "residual shares retained");
+        assertEq(targetAsset.balanceOf(receiver), 40 ether, "receiver gets swapped output");
+        assertTrue(s.reported(), "report() commits on swapping variant");
+    }
+
+    /// @notice maxRedeem == 0: skip redeem AND skip swap, report() still commits.
+    function test_reportSwapAndForward_maxRedeemZero_skipsRedeemAndSwap() public {
+        MockStrategy s = new MockStrategy(address(underlying));
+        s.mint(address(swappingForwarder), 100 ether);
+        s.setMaxRedeem(0);
+
+        vm.prank(keeperEOA);
+        uint256 assetsOut = swappingForwarder.reportSwapAndForward(address(s), 0, 0);
+
+        assertEq(assetsOut, 0, "no swap when redeem is skipped");
+        assertEq(s.balanceOf(address(swappingForwarder)), 100 ether, "all shares retained");
+        assertEq(targetAsset.balanceOf(receiver), 0, "receiver gets nothing");
+        assertTrue(s.reported(), "report() still commits");
+    }
+}

--- a/test/unit/core/SwappingYieldForwarderMirror.t.sol
+++ b/test/unit/core/SwappingYieldForwarderMirror.t.sol
@@ -159,7 +159,7 @@ contract SwappingYieldForwarderMirrorTest is Test {
         assertEq(s.convertToAssets(1), 0, "precondition: dust rounds to zero");
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = swappingForwarder.reportSwapAndForward(address(s), 0, 0);
+        uint256 assetsOut = swappingForwarder.reportSwapAndForward(address(s), 0, 0, block.timestamp + 1 hours);
 
         assertEq(assetsOut, 0, "no swap output");
         assertEq(s.balanceOf(address(swappingForwarder)), 1, "dust share retained");
@@ -179,7 +179,7 @@ contract SwappingYieldForwarderMirrorTest is Test {
         s.setMaxRedeem(40 ether);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = swappingForwarder.reportSwapAndForward(address(s), 0, 0);
+        uint256 assetsOut = swappingForwarder.reportSwapAndForward(address(s), 0, 0, block.timestamp + 1 hours);
 
         assertEq(assetsOut, 40 ether, "output matches capped redeem");
         assertEq(s.balanceOf(address(swappingForwarder)), 60 ether, "residual shares retained");
@@ -194,7 +194,7 @@ contract SwappingYieldForwarderMirrorTest is Test {
         s.setMaxRedeem(0);
 
         vm.prank(keeperEOA);
-        uint256 assetsOut = swappingForwarder.reportSwapAndForward(address(s), 0, 0);
+        uint256 assetsOut = swappingForwarder.reportSwapAndForward(address(s), 0, 0, block.timestamp + 1 hours);
 
         assertEq(assetsOut, 0, "no swap when redeem is skipped");
         assertEq(s.balanceOf(address(swappingForwarder)), 100 ether, "all shares retained");

--- a/test/unit/core/SwappingYieldForwarderMirror.t.sol
+++ b/test/unit/core/SwappingYieldForwarderMirror.t.sol
@@ -54,8 +54,8 @@ contract LossImpairedStrategy is ERC20Mock {
     }
 }
 
-/// @notice Programmable strategy mock for the Bailsec #62 maxRedeem cap path. 1:1 rate
-///         means non-zero shares always yield non-zero assets, so the #61 guard never
+/// @notice Programmable strategy mock for the maxRedeem cap path. 1:1 rate
+///         means non-zero shares always yield non-zero assets, so the zero-asset guard never
 ///         fires here and we isolate the cap behaviour.
 contract MockStrategy is ERC20Mock {
     ERC20Mock public immutable underlying;
@@ -106,8 +106,8 @@ contract MockVault {
     }
 }
 
-/// @notice Bailsec #61 / #62 mirror guards on SwappingYieldForwarder.reportSwapAndForward.
-///         Both guards were added to YieldForwarder.reportAndForward in the sibling #415 PR
+/// @notice Mirror guards on SwappingYieldForwarder.reportSwapAndForward.
+///         Both guards were added to YieldForwarder.reportAndForward in the sibling forwarder PR
 ///         and must be mirrored on the swapping variant so external vault liquidity shortfalls
 ///         (maxRedeem < balance) and loss-impaired dust (convertToAssets rounds to zero) do
 ///         not revert the outer call and roll back report() side effects.
@@ -148,7 +148,7 @@ contract SwappingYieldForwarderMirrorTest is Test {
         s.setTotalAssets(shareholderShares - 1);
     }
 
-    // --- Bailsec #61 mirror: ZERO_ASSETS skip on loss-impaired strategy ---
+    // --- Zero-asset skip on loss-impaired strategy ---
 
     /// @notice Dust share on a loss-impaired strategy must not revert reportSwapAndForward.
     ///         report() commits, no swap is attempted, dust stays at forwarder.
@@ -168,7 +168,7 @@ contract SwappingYieldForwarderMirrorTest is Test {
         assertFalse(s.redeemCalled(), "redeem must be skipped, not called-and-failed");
     }
 
-    // --- Bailsec #62 mirror: maxRedeem cap ---
+    // --- maxRedeem cap ---
 
     /// @notice maxRedeem < balance. Pre-fix this would revert inside redeem and roll back
     ///         report(). Post-fix: shares capped at maxRedeem, report() commits, residual

--- a/test/unit/swappers/CurveSwapper.t.sol
+++ b/test/unit/swappers/CurveSwapper.t.sol
@@ -102,7 +102,8 @@ contract CurveSwapperTest is Test {
         CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
 
         uint256 amountIn = 1000e18;
-        tokenIn.mint(address(s), amountIn);
+        tokenIn.mint(address(this), amountIn);
+        tokenIn.approve(address(s), amountIn);
 
         uint256 amountOut = s.swap(address(tokenIn), address(tokenOut), amountIn, 0, receiver);
 
@@ -114,7 +115,8 @@ contract CurveSwapperTest is Test {
         CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
 
         uint256 amountIn = 1000e18;
-        tokenIn.mint(address(s), amountIn);
+        tokenIn.mint(address(this), amountIn);
+        tokenIn.approve(address(s), amountIn);
 
         // Pool enforces minAmountOut via the mock
         pool.setSlippage(50); // 50% output
@@ -131,7 +133,8 @@ contract CurveSwapperTest is Test {
         amountIn = bound(amountIn, 1, 1e30);
         CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
 
-        tokenIn.mint(address(s), amountIn);
+        tokenIn.mint(address(this), amountIn);
+        tokenIn.approve(address(s), amountIn);
         uint256 amountOut = s.swap(address(tokenIn), address(tokenOut), amountIn, 0, receiver);
 
         assertEq(amountOut, amountIn, "1:1 mock output");

--- a/test/unit/swappers/CurveSwapper.t.sol
+++ b/test/unit/swappers/CurveSwapper.t.sol
@@ -140,6 +140,38 @@ contract CurveSwapperTest is Test {
         assertEq(amountOut, amountIn, "1:1 mock output");
         assertEq(tokenOut.balanceOf(receiver), amountOut);
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // ZERO-RESIDUE INVARIANT (cantina #1)
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice The adapter must hold zero tokenIn after any swap call, even
+    ///         when pre-existing balance (a donation, or pool pull semantics
+    ///         leaving surplus) is present at entry. Regression for cantina #1.
+    function test_swap_flushesPreExistingTokenInBalance() public {
+        CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
+
+        // Simulate a prior donation / leftover of 7e18 sitting in the adapter.
+        uint256 donation = 7e18;
+        tokenIn.mint(address(s), donation);
+
+        uint256 amountIn = 100e18;
+        tokenIn.mint(address(this), amountIn);
+        tokenIn.approve(address(s), amountIn);
+
+        uint256 callerBalBefore = tokenIn.balanceOf(address(this));
+
+        uint256 amountOut = s.swap(address(tokenIn), address(tokenOut), amountIn, 0, receiver);
+
+        assertEq(amountOut, amountIn, "Output follows 1:1 mock");
+        assertEq(tokenIn.balanceOf(address(s)), 0, "Adapter must hold zero tokenIn after swap");
+        // Caller paid amountIn, received back the donation via the residue flush.
+        assertEq(
+            tokenIn.balanceOf(address(this)),
+            callerBalBefore - amountIn + donation,
+            "Caller should receive the prior donation back via the flush"
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════

--- a/test/unit/swappers/CurveSwapper.t.sol
+++ b/test/unit/swappers/CurveSwapper.t.sol
@@ -142,12 +142,12 @@ contract CurveSwapperTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════
-    // ZERO-RESIDUE INVARIANT (cantina #1)
+    // ZERO-RESIDUE INVARIANT
     // ═══════════════════════════════════════════════════════════
 
     /// @notice The adapter must hold zero tokenIn after any swap call, even
     ///         when pre-existing balance (a donation, or pool pull semantics
-    ///         leaving surplus) is present at entry. Regression for cantina #1.
+    ///         leaving surplus) is present at entry.
     function test_swap_flushesPreExistingTokenInBalance() public {
         CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
 

--- a/test/unit/swappers/PSMSwapper.t.sol
+++ b/test/unit/swappers/PSMSwapper.t.sol
@@ -325,7 +325,7 @@ contract PSMSwapperTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════
-    // BUY_GEM ROUNDING DUST (bailsec #70)
+    // BUY_GEM ROUNDING DUST
     // ═══════════════════════════════════════════════════════════
 
     /// @notice The gemAmt computation in BUY_GEM floor-divides, so when
@@ -333,7 +333,7 @@ contract PSMSwapperTest is Test {
     ///         PSM charges strictly less than amountIn. The residue must
     ///         stay with the caller, not sit inside the adapter where an
     ///         attacker could sweep it via a follow-up swap() call.
-    ///         Regression for bailsec #70.
+    ///         Regression for rounding dust on the buy-gem route.
     function test_swap_buyGem_roundingDustStaysWithCaller() public {
         MockPSM mockPSM = new MockPSM(address(dai), address(gem));
         mockPSM.setTout(0);

--- a/test/unit/swappers/PSMSwapper.t.sol
+++ b/test/unit/swappers/PSMSwapper.t.sol
@@ -323,6 +323,46 @@ contract PSMSwapperTest is Test {
         vm.expectRevert(abi.encodeWithSelector(PSMSwapper.NonOneToOneConversion.selector, amountIn, amountIn - 1));
         s.swap(address(usds), address(dai), amountIn, 0, receiver);
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // BUY_GEM ROUNDING DUST (bailsec #70)
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice The gemAmt computation in BUY_GEM floor-divides, so when
+    ///         amountIn isn't cleanly divisible by conversionFactor the
+    ///         PSM charges strictly less than amountIn. The residue must
+    ///         stay with the caller, not sit inside the adapter where an
+    ///         attacker could sweep it via a follow-up swap() call.
+    ///         Regression for bailsec #70.
+    function test_swap_buyGem_roundingDustStaysWithCaller() public {
+        MockPSM mockPSM = new MockPSM(address(dai), address(gem));
+        mockPSM.setTout(0);
+
+        PSMSwapper s = new PSMSwapper(
+            address(mockPSM),
+            PSMSwapper.Route.BUY_GEM,
+            address(dai),
+            address(gem),
+            CONVERSION_FACTOR
+        );
+
+        // amountIn = 1000e18 + 1 wei; conversionFactor = 1e12; tout = 0.
+        // gemAmt = floor(amountIn * WAD / (cf * WAD)) = 1e6 (dust = 1 wei DAI)
+        uint256 amountIn = 1000e18 + 1;
+        uint256 expectedGemAmt = 1_000_000_000; // 1e9 (= 1000e6)
+        uint256 actualPulled = 1000e18; // = gemAmt * cf * (WAD + 0) / WAD
+        uint256 expectedDust = amountIn - actualPulled; // 1 wei
+
+        dai.mint(address(this), amountIn);
+        dai.approve(address(s), amountIn);
+
+        uint256 amountOut = s.swap(address(dai), address(gem), amountIn, 0, receiver);
+
+        assertEq(amountOut, expectedGemAmt, "Output should be the floor-divided gem amount");
+        assertEq(gem.balanceOf(receiver), amountOut, "Receiver gets gem");
+        assertEq(dai.balanceOf(address(s)), 0, "Adapter must hold zero DAI after swap");
+        assertEq(dai.balanceOf(address(this)), expectedDust, "Rounding dust must stay with caller");
+    }
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -334,6 +374,9 @@ contract MockPSM {
     ERC20Mock public tokenIn;
     ERC20Mock public tokenOut;
     uint256 public tout_;
+    uint256 public mockConversionFactor = 1e12; // must match PSMSwapper constructor
+
+    uint256 internal constant WAD = 1e18;
 
     constructor(address _tokenIn, address _tokenOut) {
         tokenIn = ERC20Mock(_tokenIn);
@@ -342,6 +385,10 @@ contract MockPSM {
 
     function setTout(uint256 _tout) external {
         tout_ = _tout;
+    }
+
+    function setConversionFactor(uint256 _cf) external {
+        mockConversionFactor = _cf;
     }
 
     function tout() external view returns (uint256) {
@@ -356,9 +403,12 @@ contract MockPSM {
         tokenOut.mint(usr, gemAmt);
     }
 
-    /// @dev buyGem: caller sends DAI, PSM sends gem to caller
+    /// @dev buyGem: caller sends DAI, PSM sends gem to caller.
+    ///      Matches real PSM: pulls gemAmt * conversionFactor * (WAD + tout) / WAD of
+    ///      the input token, so the adapter must have approved at least that much.
     function buyGem(address usr, uint256 gemAmt) external {
-        // Mint gem to usr
+        uint256 daiAmount = (gemAmt * mockConversionFactor * (WAD + tout_)) / WAD;
+        tokenIn.transferFrom(msg.sender, address(this), daiAmount);
         tokenOut.mint(usr, gemAmt);
     }
 }

--- a/test/unit/swappers/PSMSwapper.t.sol
+++ b/test/unit/swappers/PSMSwapper.t.sol
@@ -102,7 +102,8 @@ contract PSMSwapperTest is Test {
         PSMSwapper s = new PSMSwapper(address(mockPSM), PSMSwapper.Route.SELL_GEM, address(gem), address(dai), 0);
 
         uint256 amountIn = 1000e18;
-        gem.mint(address(s), amountIn);
+        gem.mint(address(this), amountIn);
+        gem.approve(address(s), amountIn);
 
         uint256 amountOut = s.swap(address(gem), address(dai), amountIn, 0, receiver);
 
@@ -123,7 +124,8 @@ contract PSMSwapperTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        dai.mint(address(s), amountIn);
+        dai.mint(address(this), amountIn);
+        dai.approve(address(s), amountIn);
 
         uint256 amountOut = s.swap(address(dai), address(gem), amountIn, 0, receiver);
 
@@ -147,7 +149,8 @@ contract PSMSwapperTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        dai.mint(address(s), amountIn);
+        dai.mint(address(this), amountIn);
+        dai.approve(address(s), amountIn);
 
         uint256 amountOut = s.swap(address(dai), address(gem), amountIn, 0, receiver);
 
@@ -167,7 +170,8 @@ contract PSMSwapperTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        dai.mint(address(s), amountIn);
+        dai.mint(address(this), amountIn);
+        dai.approve(address(s), amountIn);
 
         // minAmountOut = amountIn: 1:1 conversion, exact output enforced internally
         uint256 amountOut = s.swap(address(dai), address(usds), amountIn, amountIn, receiver);
@@ -187,7 +191,8 @@ contract PSMSwapperTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        usds.mint(address(s), amountIn);
+        usds.mint(address(this), amountIn);
+        usds.approve(address(s), amountIn);
 
         // minAmountOut = amountIn: 1:1 conversion, exact output enforced internally
         uint256 amountOut = s.swap(address(usds), address(dai), amountIn, amountIn, receiver);
@@ -209,7 +214,8 @@ contract PSMSwapperTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        dai.mint(address(s), amountIn);
+        dai.mint(address(this), amountIn);
+        dai.approve(address(s), amountIn);
 
         // Expected gem = 1000e6, require more
         uint256 tooHigh = 2000e6;
@@ -231,7 +237,8 @@ contract PSMSwapperTest is Test {
 
         // amountIn too small: 999 wei of DAI with 1e12 conversion = gemAmt truncates to 0
         uint256 tinyAmount = CONVERSION_FACTOR - 1;
-        dai.mint(address(s), tinyAmount);
+        dai.mint(address(this), tinyAmount);
+        dai.approve(address(s), tinyAmount);
 
         vm.expectRevert(abi.encodeWithSelector(PSMSwapper.InsufficientOutput.selector, 1, 0));
         s.swap(address(dai), address(gem), tinyAmount, 0, receiver);
@@ -248,7 +255,8 @@ contract PSMSwapperTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        dai.mint(address(s), amountIn);
+        dai.mint(address(this), amountIn);
+        dai.approve(address(s), amountIn);
 
         // Caller passes 0 as minAmountOut, but contract enforces amountIn internally
         uint256 amountOut = s.swap(address(dai), address(usds), amountIn, 0, receiver);
@@ -266,7 +274,8 @@ contract PSMSwapperTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        usds.mint(address(s), amountIn);
+        usds.mint(address(this), amountIn);
+        usds.approve(address(s), amountIn);
 
         // Caller passes 0 as minAmountOut, but contract enforces amountIn internally
         uint256 amountOut = s.swap(address(usds), address(dai), amountIn, 0, receiver);
@@ -289,7 +298,8 @@ contract PSMSwapperTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        dai.mint(address(s), amountIn);
+        dai.mint(address(this), amountIn);
+        dai.approve(address(s), amountIn);
 
         vm.expectRevert(abi.encodeWithSelector(PSMSwapper.NonOneToOneConversion.selector, amountIn, amountIn - 1));
         s.swap(address(dai), address(usds), amountIn, 0, receiver);
@@ -307,7 +317,8 @@ contract PSMSwapperTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        usds.mint(address(s), amountIn);
+        usds.mint(address(this), amountIn);
+        usds.approve(address(s), amountIn);
 
         vm.expectRevert(abi.encodeWithSelector(PSMSwapper.NonOneToOneConversion.selector, amountIn, amountIn - 1));
         s.swap(address(usds), address(dai), amountIn, 0, receiver);

--- a/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
@@ -152,13 +152,12 @@ contract UniswapV3SwapperAdapterTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════
-    // SWAP — PARTIAL FILL RESIDUE (bailsec #73, #74)
+    // SWAP — PARTIAL FILL RESIDUE
     // ═══════════════════════════════════════════════════════════
 
     /// @notice A partial fill (router pulls less than amountIn) must leave the
     ///         adapter with zero balance, zero router allowance, and the unused
-    ///         tokenIn returned to the caller. Regression test for bailsec
-    ///         #73 (sweepable residue) and #74 (hanging approval).
+    ///         tokenIn returned to the caller.
     function test_swap_partialFill_returnsLeftoverAndZerosApproval() public {
         UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(0), 0);
 

--- a/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.25;
 
 import { Test } from "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import { ISwapRouter } from "@tokenized-strategy-periphery/interfaces/Uniswap/V3/ISwapRouter.sol";
 
@@ -149,6 +150,42 @@ contract UniswapV3SwapperAdapterTest is Test {
         assertEq(tokenB.balanceOf(receiver), amountOut);
         assertTrue(router.lastWasMultiHop(), "Should have used multi-hop path");
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — PARTIAL FILL RESIDUE (bailsec #73, #74)
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice A partial fill (router pulls less than amountIn) must leave the
+    ///         adapter with zero balance, zero router allowance, and the unused
+    ///         tokenIn returned to the caller. Regression test for bailsec
+    ///         #73 (sweepable residue) and #74 (hanging approval).
+    function test_swap_partialFill_returnsLeftoverAndZerosApproval() public {
+        UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(0), 0);
+
+        uint256 amountIn = 1000e18;
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
+
+        // Simulate shallow pool: router consumes 70% of amountIn and leaves
+        // the rest approved-but-not-pulled (equivalent to hitting MIN/MAX tick).
+        router.setConsumedBps(7000);
+        router.setOutputToken(address(tokenB));
+
+        uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);
+
+        uint256 consumed = (amountIn * 7000) / 10_000;
+        uint256 leftover = amountIn - consumed;
+
+        assertEq(amountOut, consumed, "amountOut should reflect consumed input");
+        assertEq(tokenB.balanceOf(receiver), amountOut, "Receiver should get output");
+        assertEq(tokenA.balanceOf(address(s)), 0, "Adapter must hold zero tokenIn after swap");
+        assertEq(
+            IERC20(address(tokenA)).allowance(address(s), address(router)),
+            0,
+            "Adapter must have zero router allowance after swap"
+        );
+        assertEq(tokenA.balanceOf(address(this)), leftover, "Caller must receive unused tokenIn");
+    }
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -159,21 +196,43 @@ contract MockUniRouter {
     address public outputToken;
     uint24 public lastFee;
     bool public lastWasMultiHop;
+    uint256 public consumedBps = 10_000; // default: 100% consumption (full fill)
+
+    uint256 internal constant BPS = 10_000;
 
     function setOutputToken(address _token) external {
         outputToken = _token;
     }
 
+    /// @notice Control how much of amountIn the mock "consumes" from the caller.
+    ///         10_000 = full fill (default). Values below simulate a shallow
+    ///         pool reaching MIN/MAX tick where the real router pulls only
+    ///         the consumed amount via its pay callback.
+    function setConsumedBps(uint256 _bps) external {
+        consumedBps = _bps;
+    }
+
     function exactInputSingle(ISwapRouter.ExactInputSingleParams calldata params) external returns (uint256 amountOut) {
         lastFee = params.fee;
         lastWasMultiHop = false;
-        amountOut = params.amountIn;
+        uint256 consumed = (params.amountIn * consumedBps) / BPS;
+        // Simulate real router pulling only the consumed input from the caller.
+        ERC20Mock(params.tokenIn).transferFrom(msg.sender, address(this), consumed);
+        amountOut = consumed;
         ERC20Mock(outputToken).mint(params.recipient, amountOut);
     }
 
     function exactInput(ISwapRouter.ExactInputParams calldata params) external returns (uint256 amountOut) {
         lastWasMultiHop = true;
-        amountOut = params.amountIn;
+        // First token in the path is tokenIn
+        address tokenIn;
+        bytes calldata path = params.path;
+        assembly {
+            tokenIn := shr(96, calldataload(path.offset))
+        }
+        uint256 consumed = (params.amountIn * consumedBps) / BPS;
+        ERC20Mock(tokenIn).transferFrom(msg.sender, address(this), consumed);
+        amountOut = consumed;
         ERC20Mock(outputToken).mint(params.recipient, amountOut);
     }
 }

--- a/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
@@ -78,7 +78,8 @@ contract UniswapV3SwapperAdapterTest is Test {
         UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(0), 0);
 
         uint256 amountIn = 1000e18;
-        tokenA.mint(address(s), amountIn);
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
 
         router.setOutputToken(address(tokenB));
 
@@ -97,7 +98,8 @@ contract UniswapV3SwapperAdapterTest is Test {
         UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
 
         uint256 amountIn = 500e18;
-        tokenA.mint(address(s), amountIn);
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
         router.setOutputToken(address(baseToken));
 
         uint256 amountOut = s.swap(address(tokenA), address(baseToken), amountIn, 0, receiver);
@@ -117,7 +119,8 @@ contract UniswapV3SwapperAdapterTest is Test {
         UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
 
         uint256 amountIn = 500e18;
-        baseToken.mint(address(s), amountIn);
+        baseToken.mint(address(this), amountIn);
+        baseToken.approve(address(s), amountIn);
         router.setOutputToken(address(tokenB));
 
         uint256 amountOut = s.swap(address(baseToken), address(tokenB), amountIn, 0, receiver);
@@ -136,7 +139,8 @@ contract UniswapV3SwapperAdapterTest is Test {
         UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(baseToken), FEE_OUT);
 
         uint256 amountIn = 1000e18;
-        tokenA.mint(address(s), amountIn);
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
         router.setOutputToken(address(tokenB));
 
         uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);

--- a/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
@@ -366,14 +366,14 @@ contract UniswapV4SwapperAdapterTest is Test {
     }
 
     // ═══════════════════════════════════════════════════════════
-    // SWAP — PARTIAL FILL RESIDUE (bailsec #76)
+    // SWAP — PARTIAL FILL RESIDUE
     // ═══════════════════════════════════════════════════════════
 
     /// @notice When the pool consumes less than amountIn (liquidity exhausted
     ///         at the tick limit), the adapter must take the surplus tokenIn
     ///         delta back to the original caller. Without the fix,
     ///         unlock reverts with CurrencyNotSettled and the surplus is
-    ///         stranded in the PoolManager singleton. Regression for bailsec #76.
+    ///         stranded in the PoolManager singleton.
     function test_swap_partialFill_takesUnusedTokenInBack() public {
         UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
             address(pm),

--- a/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
@@ -406,6 +406,45 @@ contract UniswapV4SwapperAdapterTest is Test {
         // PoolManager ends up with exactly `consumed` (its share of the swap settlement)
         assertEq(tokenA.balanceOf(address(pm)), consumed, "PoolManager keeps only the consumed amount");
     }
+
+    /// @notice In a multi-hop swap, hop 2 can also consume less than the base
+    ///         amount produced by hop 1. The unused base must be taken back to
+    ///         the original caller or PoolManager accounting remains unsettled.
+    function test_swap_multiHop_secondHopPartial_takesUnusedBaseBack() public {
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(baseToken),
+            FEE_OUT,
+            TICK_SPACING_OUT,
+            address(0)
+        );
+
+        uint256 amountIn = 1000e18;
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
+
+        // Hop 1 consumes all tokenA and produces baseToken. Hop 2 consumes only
+        // 70% of that base output, leaving the remaining 30% as a positive base
+        // delta that must be taken back.
+        pm.setConsumedBpsForCall(1, 10_000);
+        pm.setConsumedBpsForCall(2, 7_000);
+        pm.setOutputToken(address(tokenB));
+        baseToken.mint(address(pm), amountIn);
+
+        uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);
+
+        uint256 baseConsumed = (amountIn * 7_000) / 10_000;
+        uint256 unusedBase = amountIn - baseConsumed;
+
+        assertEq(amountOut, baseConsumed, "amountOut should equal consumed base at 1:1 rate");
+        assertEq(tokenB.balanceOf(receiver), amountOut, "receiver gets final output");
+        assertEq(baseToken.balanceOf(address(this)), unusedBase, "caller receives unused base");
+        assertEq(baseToken.balanceOf(address(s)), 0, "adapter must hold zero base after swap");
+        assertEq(tokenA.balanceOf(address(this)), 0, "caller spent all original input");
+    }
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -418,6 +457,7 @@ contract MockV4PoolManager {
     address public outputToken;
     uint256 public outputRate = 1e18; // 1:1 by default (1e18 = 100%)
     uint256 public consumedBps = 10_000; // default: full fill (100% of amountIn consumed)
+    mapping(uint256 callIndex => uint256 bps) public consumedBpsForCall;
 
     uint256 internal constant BPS = 10_000;
 
@@ -440,6 +480,13 @@ contract MockV4PoolManager {
     ///         reaches MIN/MAX tick with unconsumed input remaining.
     function setConsumedBps(uint256 _bps) external {
         consumedBps = _bps;
+    }
+
+    /// @notice Override consumed bps for one swap call inside the next unlock.
+    /// @param callIndex 1-based index of the swap call within unlock()
+    /// @param _bps Consumed bps for that call; 0 means use the global value
+    function setConsumedBpsForCall(uint256 callIndex, uint256 _bps) external {
+        consumedBpsForCall[callIndex] = _bps;
     }
 
     function resetSwapCallCount() external {
@@ -466,7 +513,11 @@ contract MockV4PoolManager {
         swapCallCount++;
 
         uint256 absAmountIn = uint256(-params.amountSpecified); // amountSpecified is negative for exactInput
-        uint256 consumed = (absAmountIn * consumedBps) / BPS;
+        uint256 callConsumedBps = consumedBpsForCall[swapCallCount];
+        if (callConsumedBps == 0) {
+            callConsumedBps = consumedBps;
+        }
+        uint256 consumed = (absAmountIn * callConsumedBps) / BPS;
         uint256 amountOut = (consumed * outputRate) / 1e18;
 
         int128 inputDelta = -int128(int256(consumed)); // negative: caller pays consumed

--- a/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
@@ -364,6 +364,48 @@ contract UniswapV4SwapperAdapterTest is Test {
 
         assertFalse(pm.lastZeroForOne(), "tokenIn > tokenOut should be zeroForOne=false");
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // SWAP — PARTIAL FILL RESIDUE (bailsec #76)
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice When the pool consumes less than amountIn (liquidity exhausted
+    ///         at the tick limit), the adapter must take the surplus tokenIn
+    ///         delta back to the original caller. Without the fix,
+    ///         unlock reverts with CurrencyNotSettled and the surplus is
+    ///         stranded in the PoolManager singleton. Regression for bailsec #76.
+    function test_swap_partialFill_takesUnusedTokenInBack() public {
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
+
+        uint256 amountIn = 1000e18;
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
+
+        // Simulate partial fill at 70% and 1:1 rate
+        pm.setConsumedBps(7000);
+        pm.setOutputToken(address(tokenB));
+
+        uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);
+
+        uint256 consumed = (amountIn * 7000) / 10_000;
+        uint256 unused = amountIn - consumed;
+
+        assertEq(amountOut, consumed, "amountOut should equal consumed at 1:1 rate");
+        assertEq(tokenB.balanceOf(receiver), amountOut, "Receiver should get output");
+        assertEq(tokenA.balanceOf(address(s)), 0, "Adapter must hold zero tokenIn after swap");
+        assertEq(tokenA.balanceOf(address(this)), unused, "Caller must receive unused tokenIn");
+        // PoolManager ends up with exactly `consumed` (its share of the swap settlement)
+        assertEq(tokenA.balanceOf(address(pm)), consumed, "PoolManager keeps only the consumed amount");
+    }
 }
 
 // ═══════════════════════════════════════════════════════════
@@ -375,6 +417,9 @@ contract UniswapV4SwapperAdapterTest is Test {
 contract MockV4PoolManager {
     address public outputToken;
     uint256 public outputRate = 1e18; // 1:1 by default (1e18 = 100%)
+    uint256 public consumedBps = 10_000; // default: full fill (100% of amountIn consumed)
+
+    uint256 internal constant BPS = 10_000;
 
     // Tracked for assertions
     uint24 public lastPoolFee;
@@ -388,6 +433,13 @@ contract MockV4PoolManager {
 
     function setOutputRate(uint256 _rate) external {
         outputRate = _rate;
+    }
+
+    /// @notice Control how much of amountSpecified the mock swap consumes.
+    ///         10_000 = full fill; below that simulates a shallow pool that
+    ///         reaches MIN/MAX tick with unconsumed input remaining.
+    function setConsumedBps(uint256 _bps) external {
+        consumedBps = _bps;
     }
 
     function resetSwapCallCount() external {
@@ -414,9 +466,10 @@ contract MockV4PoolManager {
         swapCallCount++;
 
         uint256 absAmountIn = uint256(-params.amountSpecified); // amountSpecified is negative for exactInput
-        uint256 amountOut = (absAmountIn * outputRate) / 1e18;
+        uint256 consumed = (absAmountIn * consumedBps) / BPS;
+        uint256 amountOut = (consumed * outputRate) / 1e18;
 
-        int128 inputDelta = -int128(int256(absAmountIn)); // negative: caller pays
+        int128 inputDelta = -int128(int256(consumed)); // negative: caller pays consumed
         int128 outputDelta = int128(int256(amountOut)); // positive: caller receives
 
         int128 d0;
@@ -441,9 +494,17 @@ contract MockV4PoolManager {
         return 0;
     }
 
-    /// @dev Mints output tokens to the recipient, simulating PM token release
-    function take(address /* currency */, address to, uint256 amount) external {
-        ERC20Mock(outputToken).mint(to, amount);
+    /// @dev Pays `amount` of `currency` to `to`. For the configured outputToken
+    ///      we mint (simulating release from the pool's reserves); for any
+    ///      other currency (e.g. tokenIn surplus on a partial fill) we
+    ///      transfer from this contract's balance, modelling the real PM
+    ///      releasing a positive delta from its reserves.
+    function take(address currency, address to, uint256 amount) external {
+        if (currency == outputToken) {
+            ERC20Mock(outputToken).mint(to, amount);
+        } else {
+            ERC20Mock(currency).transfer(to, amount);
+        }
     }
 }
 

--- a/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
@@ -183,7 +183,8 @@ contract UniswapV4SwapperAdapterTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        tokenA.mint(address(s), amountIn);
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
 
         pm.setOutputToken(address(tokenB));
 
@@ -210,7 +211,8 @@ contract UniswapV4SwapperAdapterTest is Test {
         );
 
         uint256 amountIn = 500e18;
-        tokenA.mint(address(s), amountIn);
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
         pm.setOutputToken(address(baseToken));
 
         uint256 amountOut = s.swap(address(tokenA), address(baseToken), amountIn, 0, receiver);
@@ -239,7 +241,8 @@ contract UniswapV4SwapperAdapterTest is Test {
         );
 
         uint256 amountIn = 500e18;
-        baseToken.mint(address(s), amountIn);
+        baseToken.mint(address(this), amountIn);
+        baseToken.approve(address(s), amountIn);
         pm.setOutputToken(address(tokenB));
 
         uint256 amountOut = s.swap(address(baseToken), address(tokenB), amountIn, 0, receiver);
@@ -268,7 +271,8 @@ contract UniswapV4SwapperAdapterTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        tokenA.mint(address(s), amountIn);
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
         pm.setOutputToken(address(tokenB));
 
         uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);
@@ -295,7 +299,8 @@ contract UniswapV4SwapperAdapterTest is Test {
         );
 
         uint256 amountIn = 1000e18;
-        tokenA.mint(address(s), amountIn);
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
         pm.setOutputToken(address(tokenB));
         pm.setOutputRate(5e17); // 50% output rate
 
@@ -325,7 +330,8 @@ contract UniswapV4SwapperAdapterTest is Test {
         address low = address(tokenA) < address(tokenB) ? address(tokenA) : address(tokenB);
         address high = address(tokenA) < address(tokenB) ? address(tokenB) : address(tokenA);
 
-        ERC20Mock(low).mint(address(s), amountIn);
+        ERC20Mock(low).mint(address(this), amountIn);
+        ERC20Mock(low).approve(address(s), amountIn);
         pm.setOutputToken(high);
 
         s.swap(low, high, amountIn, 0, receiver);
@@ -350,7 +356,8 @@ contract UniswapV4SwapperAdapterTest is Test {
         address low = address(tokenA) < address(tokenB) ? address(tokenA) : address(tokenB);
         address high = address(tokenA) < address(tokenB) ? address(tokenB) : address(tokenA);
 
-        ERC20Mock(high).mint(address(s), amountIn);
+        ERC20Mock(high).mint(address(this), amountIn);
+        ERC20Mock(high).approve(address(s), amountIn);
         pm.setOutputToken(low);
 
         s.swap(high, low, amountIn, 0, receiver);

--- a/verification/kontrol/MockForwarderStrategy.k.sol
+++ b/verification/kontrol/MockForwarderStrategy.k.sol
@@ -17,6 +17,8 @@ pragma solidity ^0.8.0;
  *        slot 6: expectedBalanceOfAccount -- only this account has shares
  *        slot 7: lastRedeemOwner    -- captures owner arg from redeem()
  *        slot 8: lastRedeemMaxLoss  -- captures maxLoss arg from redeem()
+ *        slot 9: mockMaxRedeem      -- returned by maxRedeem()
+ *        slot 10: mockConvertToAssets -- returned by convertToAssets()
  */
 contract MockForwarderStrategy {
     uint256 public mockShareBalance;
@@ -28,6 +30,8 @@ contract MockForwarderStrategy {
     address public expectedBalanceOfAccount;
     address public lastRedeemOwner;
     uint256 public lastRedeemMaxLoss;
+    uint256 public mockMaxRedeem;
+    uint256 public mockConvertToAssets;
 
     /// @notice No-op report that still records the caller
     function report() external returns (uint256, uint256) {
@@ -42,6 +46,16 @@ contract MockForwarderStrategy {
         }
 
         return mockShareBalance;
+    }
+
+    /// @notice Mock ERC-4626 maxRedeem guard used by SwappingYieldForwarder
+    function maxRedeem(address) external view returns (uint256) {
+        return mockMaxRedeem;
+    }
+
+    /// @notice Mock ERC-4626 convertToAssets guard used by SwappingYieldForwarder
+    function convertToAssets(uint256) external view returns (uint256) {
+        return mockConvertToAssets;
     }
 
     /// @notice Mock redeem that captures arguments and zeroes share balance

--- a/verification/kontrol/MockForwarderSwapper.k.sol
+++ b/verification/kontrol/MockForwarderSwapper.k.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
 /**
  * @title MockForwarderSwapper
  * @notice Minimal ISwapper mock for Kontrol formal verification of SwappingYieldForwarder
- * @dev Controllable swap return value with argument capture for property assertions.
+ * @dev Pull-pattern compatible: pulls tokenIn from msg.sender via transferFrom,
+ *      captures arguments, and returns a controllable swap output value.
  *
  *      Storage layout (all plain slots, no ERC-7201):
  *        slot 0: mockSwapReturn    -- returned by swap()
@@ -15,6 +19,8 @@ pragma solidity ^0.8.0;
  *        slot 5: lastMinAmountOut  -- captures minAmountOut arg
  */
 contract MockForwarderSwapper {
+    using SafeERC20 for IERC20;
+
     uint256 public mockSwapReturn;
     address public lastSwapReceiver;
     address public lastTokenIn;
@@ -22,7 +28,7 @@ contract MockForwarderSwapper {
     uint256 public lastAmountIn;
     uint256 public lastMinAmountOut;
 
-    /// @notice Mock swap that captures arguments and returns controllable output
+    /// @notice Mock swap that pulls tokenIn, captures arguments, and returns a controllable output
     function swap(
         address tokenIn,
         address tokenOut,
@@ -30,6 +36,7 @@ contract MockForwarderSwapper {
         uint256 minAmountOut,
         address receiver
     ) external returns (uint256) {
+        IERC20(tokenIn).safeTransferFrom(msg.sender, address(this), amountIn);
         lastTokenIn = tokenIn;
         lastTokenOut = tokenOut;
         lastAmountIn = amountIn;

--- a/verification/kontrol/SYFSetup.k.sol
+++ b/verification/kontrol/SYFSetup.k.sol
@@ -42,8 +42,16 @@ contract SYFSetup is KontrolTest {
         mockStrategy = new MockForwarderStrategy();
         mockSwapper = new MockForwarderSwapper();
 
-        // Deploy SwappingYieldForwarder with concrete immutables
-        syfForwarder = new SwappingYieldForwarder(_receiver, _keeper, address(targetAsset), address(mockSwapper));
+        // Deploy SwappingYieldForwarder with concrete immutables. The mock strategy
+        // doubles as the vault reference; its symbolic management() is not exercised
+        // in the current proofs (they don't call setSwapper).
+        syfForwarder = new SwappingYieldForwarder(
+            _receiver,
+            _keeper,
+            address(targetAsset),
+            address(mockSwapper),
+            address(mockStrategy)
+        );
 
         // ============================================
         // MAKE MOCK STRATEGY STORAGE SYMBOLIC

--- a/verification/kontrol/SYFSetup.k.sol
+++ b/verification/kontrol/SYFSetup.k.sol
@@ -50,7 +50,8 @@ contract SYFSetup is KontrolTest {
             _keeper,
             address(targetAsset),
             address(mockSwapper),
-            address(mockStrategy)
+            address(mockStrategy),
+            0
         );
 
         // ============================================

--- a/verification/kontrol/SYFSetup.k.sol
+++ b/verification/kontrol/SYFSetup.k.sol
@@ -66,9 +66,11 @@ contract SYFSetup is KontrolTest {
         // Set symbolic share balance and redeem return
         uint256 shareBalance = freshUInt256Bounded();
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, shareBalance);
+        _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, shareBalance);
 
         uint256 redeemReturn = freshUInt256Bounded();
         _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, redeemReturn);
+        _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, redeemReturn);
 
         // Clear argument capture slots
         _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);

--- a/verification/kontrol/SYFTest.k.sol
+++ b/verification/kontrol/SYFTest.k.sol
@@ -26,7 +26,7 @@ contract SYFTest is SYFSetup {
 
         vm.prank(nonKeeper);
         vm.expectRevert(YieldForwarder.OnlyKeeper.selector);
-        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0, block.timestamp + 1 hours);
     }
 
     /// @notice swap() is always called with the hardcoded receiver as output recipient
@@ -38,7 +38,7 @@ contract SYFTest is SYFSetup {
         vm.assume(redeemReturn > 0);
 
         vm.prank(_keeper);
-        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0, block.timestamp + 1 hours);
 
         // Assert: swap was called with receiver == forwarder.receiver()
         address lastReceiver = _loadAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT);
@@ -54,7 +54,7 @@ contract SYFTest is SYFSetup {
         vm.assume(redeemReturn > 0);
 
         vm.prank(_keeper);
-        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0, block.timestamp + 1 hours);
 
         // Assert: forwarder's source asset balance is 0 (all transferred to swapper)
         uint256 forwarderBalance = sourceAsset.balanceOf(address(syfForwarder));
@@ -75,7 +75,7 @@ contract SYFTest is SYFSetup {
         _storeUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT, sentinel);
 
         vm.prank(_keeper);
-        uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+        uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0, block.timestamp + 1 hours);
 
         // Assert: returned 0
         assertEq(assetsOut, 0);
@@ -104,7 +104,7 @@ contract SYFTest is SYFSetup {
         _storeMappingUInt256(address(sourceAsset), ERC20_BALANCES_SLOT, uint256(uint160(address(syfForwarder))), 0, 0);
 
         vm.prank(_keeper);
-        uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0);
+        uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0, block.timestamp + 1 hours);
 
         // Assert: returned 0
         assertEq(assetsOut, 0);
@@ -125,7 +125,7 @@ contract SYFTest is SYFSetup {
         uint256 minAmountOut = freshUInt256Bounded();
 
         vm.prank(_keeper);
-        syfForwarder.reportSwapAndForward(address(mockStrategy), maxLoss, minAmountOut);
+        syfForwarder.reportSwapAndForward(address(mockStrategy), maxLoss, minAmountOut, block.timestamp + 1 hours);
 
         // Assert: tokenIn == sourceAsset (strategy's underlying)
         address lastTokenIn = _loadAddress(address(mockSwapper), MSWP_LAST_TOKEN_IN_SLOT);

--- a/verification/kontrol/SharedStateSlots.k.sol
+++ b/verification/kontrol/SharedStateSlots.k.sol
@@ -132,6 +132,8 @@ uint256 constant MFS_LAST_REPORT_CALLER_SLOT = 5;
 uint256 constant MFS_EXPECTED_BALANCE_OF_ACCOUNT_SLOT = 6;
 uint256 constant MFS_LAST_OWNER_SLOT = 7;
 uint256 constant MFS_LAST_MAX_LOSS_SLOT = 8;
+uint256 constant MFS_MAX_REDEEM_SLOT = 9;
+uint256 constant MFS_CONVERT_TO_ASSETS_SLOT = 10;
 
 // ============================================
 // MockForwarderSwapper (MSWP_) constants


### PR DESCRIPTION
## Summary

Coordinated swapper-area refactor implementing the architecture decision from `BAILSEC_RESOLUTION.md` under "Architecture decision: swapper pull-pattern migration".

The PR migrates `ISwapper` / `SwappingYieldForwarder` to the pull pattern for Cantina 2, wires the swapping controls through the vault `management()` role for Bailsec 67, 72, and 75, and keeps the follow-up audit fixes split as one fix per commit for reviewer traceability.

Latest history rewrite keeps the ownership boundary clean: PR 415 owns base `YieldForwarder` recovery and base 61/62 guards; this PR owns only the swapping-path equivalents. `SwappingYieldForwarder.forwardToken(address)` is not permissionless: only the keeper or current vault management can flush arbitrary ERC-20 residue to the immutable receiver. `SwappingYieldForwarder` also clears the swapper allowance after a successful swap, and the V4 adapter handles both first-hop unused input and second-hop unused base on partial fills.

Ferit's slippage-floor review is addressed by making the initial `minSlippageBps` an explicit constructor argument. A non-zero value is enforced from the first `reportSwapAndForward` call; `0` is now an intentional deployment opt-out, not an accidental unset default. Vault management can still update the floor later.

## Findings closed

| Ref | Resolution | Commit |
|---|---|---|
| Cantina 2 | Pull-pattern `ISwapper` migration | `bf343b99` |
| Cantina 2 hardening | Swapping-only authorized `forwardToken(address)` recovery for returned input residue | `a4d2f2ba` |
| Cantina 2 hardening | Clear `SwappingYieldForwarder` swapper allowance after successful swaps | `8c5bc4c7` |
| Bailsec 61, 62 | Mirror `maxRedeem` cap and zero-asset skip in `reportSwapAndForward` | `5e0cf2d9` |
| Bailsec 67 | Constructor-configured, management-updatable slippage floor on `reportSwapAndForward` | `7d15ab07` |
| Bailsec 68 | Require caller-supplied fresh deadline for `reportSwapAndForward` | `d4d463cf` |
| Bailsec 70 | Make PSM buy-gem route compute the exact PSM charge and pull only the needed amount | `fd44d30b` |
| Bailsec 72, 75 | Make swapper routing admin-settable through vault management | `2fd5f3eb` |
| Bailsec 73, 74 | Return V3 unused `tokenIn` and clear the router approval | `fd521810` |
| Bailsec 76 | Return first-hop unused `tokenIn` from V4 partial fills | `77356cc1` |
| Bailsec 76 hardening | Return second-hop unused base from V4 multi-hop partial fills | `cf380bc0` |
| Review hardening | Update Kontrol mock/setup for `maxRedeem` and `convertToAssets` calls | `79ffca79` |
| Comment cleanup | Remove audit labels from source comments | `cb3c45f5` |
| Slither CI | Explicitly initialize V4 `unusedBase` on single-hop paths | `bf6a1d85` |
| Cantina 1 | Enforce zero-residue behavior for Curve; other adapters inherit the pull-pattern residue fixes | `d82fccab` |

## Shape

- **Pull semantic**: `SwappingYieldForwarder` now `forceApprove`s the swapper instead of pre-transferring. Every adapter starts with `safeTransferFrom(msg.sender, this, amountIn)` and returns unused input to the original caller before exiting.
- **Swapping-forwarder recovery**: `SwappingYieldForwarder.forwardToken(address)` is destination-locked to the immutable receiver and callable only by keeper or vault management. Base `YieldForwarder.forwardToken(address)` is not in this PR; it lives in PR 415.
- **Forwarder allowance hygiene**: after a successful `swap()`, `SwappingYieldForwarder` resets the current swapper allowance to zero.
- **Per-adapter tails**:
  - V3: `forceApprove(router, 0)` plus return of leftover input after the router call.
  - V4: `take(tokenIn, originalCaller, amountIn - consumed)` for first-hop partial fills, and `take(base, originalCaller, unusedBase)` when hop two consumes less base than hop one produced.
  - PSM buy-gem: computes the actual charge up front and pulls only that amount, so floor-division dust stays with the caller.
  - Curve: explicit post-swap flush guard for unusual residue cases.
- **Admin source**: `setSwapper(address)`, `setMinSlippageBps(uint16)`, and swapping-forwarder `forwardToken(address)` authorization read `ITokenizedStrategy(vault).management()` at call time, so vault management rotations flow automatically without parallel admin state in the forwarder.
- **Defense in depth**: the forwarder re-checks `assetsOut >= minAmountOut` after `swap()` returns, independent of the swapper's own check.
- **Slippage floor**: `minSlippageBps` is set in the constructor, non-zero values enforce `minAmountOut >= normalized assetsIn floor` before swap execution, and constructor value `0` is an explicit opt-out.

## Notion updates

The Notion findings table has no dedicated PR property, so the relevant rows were updated through the `Commit` column and page notes while preserving `Status = In review` and `Action = FIX`:

- `C-2`: `a4d2f2ba` for swapping-only recovery, plus `8c5bc4c7` for allowance cleanup.
- `61`: base fix in PR 415 is `31080126`; swapping-path mirror here is `5e0cf2d9`.
- `62`: base fix in PR 415 is `5dd76827`; swapping-path mirror here is `5e0cf2d9`.
- `67`: `7d15ab07` for constructor-configured slippage floor; `0` is an explicit opt-out and non-zero values are enforced from the first report.
- `68`: `d4d463cf` for caller-supplied deadlines.
- `76`: `77356cc1` for first-hop unused input and `cf380bc0` for second-hop unused-base reconciliation.

## Test plan

- [x] `yarn slither:ci` - 0 results
- [x] `forge test --match-path 'test/unit/core/SwappingYieldForwarder*.t.sol'` - 54/54 PASS
- [x] `forge test --match-path 'test/unit/swappers/*.t.sol'` - 62/62 PASS
- [x] `forge test --match-path 'verification/kontrol/*.k.sol'` - compile check; no Forge tests in these harness files
- [x] `yarn build` - clean
- [x] `bash script/check-natspec.sh` - clean
- [x] `yarn format:check` - clean
- [x] `node_modules/.bin/commitlint --from origin/develop --to HEAD` - exit 0; warning-only notes on older long commit messages
- [x] `git diff --check origin/develop...HEAD` - clean
- [ ] Fork integration tests with mainnet RPC
- [ ] Kontrol proofs in the Kontrol pipeline

## Adversarial review status

Re-run against final local tip `bf6a1d85`:

- Base `YieldForwarder` is untouched by PR 417. Its permissionless recovery fix is only in PR 415.
- `SwappingYieldForwarder.forwardToken(address)` is not open access: it allows only keeper or vault management and always sends to the immutable receiver.
- Forwarder residual input is recoverable through authorized swapping-forwarder `forwardToken`, and the swapper allowance is cleared after successful swaps.
- V4 multi-hop partial fills now reconcile hop-two unused base back to the original caller.
- Kontrol's `MockForwarderStrategy` exposes `maxRedeem(address)` and `convertToAssets(uint256)`, and `SYFSetup` initializes those symbolic return values.
- The slippage floor is intentional at deployment: non-zero constructor values are active immediately, while constructor value `0` is an explicit opt-out.
