### PR TITLE
fix(yield-donating): Bailsec audit fixes (52, 54, 55, 57, 59, 60)

### DIFF
--- a/scripts/sol-semver.mjs
+++ b/scripts/sol-semver.mjs
@@ -587,6 +587,30 @@ async function prepareWorktreeAsync(worktreeDir) {
   await runAsync("forge", ["build", "--skip", "test", "--skip", "script"], { cwd: worktreeDir });
 }
 
+function overlayUnversionedChangedSourceFiles(worktrees, oldRef, newRef) {
+  const { changedFiles } = gatherChangedSolidityFiles(oldRef, newRef);
+  const overlaid = [];
+
+  for (const sourcePath of changedFiles) {
+    const oldPath = path.join(worktrees.old, sourcePath);
+    const newPath = path.join(worktrees.new, sourcePath);
+    if (!fs.existsSync(oldPath) || !fs.existsSync(newPath)) {
+      continue;
+    }
+
+    const oldSource = fs.readFileSync(oldPath, "utf8");
+    const newSource = fs.readFileSync(newPath, "utf8");
+    if (sourceDeclaresApiVersion(oldSource) || sourceDeclaresApiVersion(newSource)) {
+      continue;
+    }
+
+    fs.copyFileSync(newPath, oldPath);
+    overlaid.push(sourcePath);
+  }
+
+  return overlaid;
+}
+
 function inspectAbi(worktreeDir, contractId) {
   return runJson("forge", ["inspect", contractId, "abi", "--json"], { cwd: worktreeDir });
 }
@@ -1433,9 +1457,20 @@ async function main() {
       prepareWorktreeAsync(worktrees.old),
       prepareWorktreeAsync(worktrees.new)
     ]);
-    const buildFailure = buildResults.find((r) => r.status === "rejected");
-    if (buildFailure) {
-      throw buildFailure.reason;
+    const oldBuildFailed = buildResults[0].status === "rejected";
+    const newBuildFailed = buildResults[1].status === "rejected";
+    if (newBuildFailed) {
+      throw buildResults[1].reason;
+    }
+    if (oldBuildFailed) {
+      const overlaid = overlayUnversionedChangedSourceFiles(worktrees, oldRef, newRef);
+      if (overlaid.length === 0) {
+        throw buildResults[0].reason;
+      }
+      console.error(
+        `Old ref build failed; retrying after overlaying unversioned changed source files: ${overlaid.join(", ")}`
+      );
+      await prepareWorktreeAsync(worktrees.old);
     }
 
     if (opts.command === "diff") {

--- a/src/core/SwappingYieldForwarder.sol
+++ b/src/core/SwappingYieldForwarder.sol
@@ -129,12 +129,6 @@ contract SwappingYieldForwarder is YieldForwarder {
     /// @param newBps New floor
     event MinSlippageBpsUpdated(uint16 oldBps, uint16 newBps);
 
-    /// @notice Emitted when an arbitrary token balance is forwarded to the receiver
-    /// @param token Address of the token whose balance was flushed
-    /// @param receiver Address that received the token balance
-    /// @param amount Amount of the token transferred
-    event TokenForwarded(address indexed token, address indexed receiver, uint256 amount);
-
     // ============================================
     // STATE
     // ============================================
@@ -327,22 +321,10 @@ contract SwappingYieldForwarder is YieldForwarder {
         emit YieldSwappedAndForwarded(strategy, receiver, shares, assetsIn, assetsOut);
     }
 
-    /**
-     * @notice Forwards the full balance of an arbitrary ERC-20 token to the immutable receiver
-     * @dev Allows either the keeper or the vault management role to recover token balances
-     *      that are outside the normal report/swap pipeline. The caller chooses only the token;
-     *      the destination remains fixed to `receiver`.
-     * @param token ERC-20 token whose balance should be flushed to the receiver
-     */
-    function forwardToken(address token) external nonReentrant {
+    /// @inheritdoc YieldForwarder
+    function _authorizeForwardToken() internal view override {
         if (msg.sender != keeper && msg.sender != ITokenizedStrategy(vault).management()) {
             revert OnlyVaultManagement();
         }
-
-        uint256 balance = IERC20(token).balanceOf(address(this));
-        if (balance == 0) return;
-
-        IERC20(token).safeTransfer(receiver, balance);
-        emit TokenForwarded(token, receiver, balance);
     }
 }

--- a/src/strategies/yieldDonating/ERC4626Strategy.sol
+++ b/src/strategies/yieldDonating/ERC4626Strategy.sol
@@ -113,16 +113,22 @@ contract ERC4626Strategy is BaseHealthCheck {
      */
     function _deployFunds(uint256 _amount) internal override {
         IERC20(asset).forceApprove(targetVault, _amount);
-        IERC4626(targetVault).deposit(_amount, address(this));
+        // Assert the target vault credited shares. A zero-share outcome (e.g., high PPS combined
+        // with a tiny deposit, or a misbehaving downstream vault) would consume the asset without
+        // recognising a position, silently stranding funds.
+        uint256 shares = IERC4626(targetVault).deposit(_amount, address(this));
+        require(shares > 0, "ERC4626Strategy: zero shares minted");
         IERC20(asset).forceApprove(targetVault, 0);
     }
 
     /**
      * @dev Withdraws assets from ERC4626 vault
      * @param _amount Amount of assets to withdraw in asset base units
+     * @custom:security `withdraw` returns shares burned, not assets received.
+     *                  `TokenizedStrategy._withdraw` measures the post-call
+     *                  asset balance and applies the caller's max-loss limit.
      */
     function _freeFunds(uint256 _amount) internal override {
-        // Withdraw the requested amount from the vault
         IERC4626(targetVault).withdraw(_amount, address(this), address(this));
     }
 

--- a/src/strategies/yieldDonating/ERC4626Strategy.sol
+++ b/src/strategies/yieldDonating/ERC4626Strategy.sol
@@ -141,7 +141,9 @@ contract ERC4626Strategy is BaseHealthCheck {
     function _harvestAndReport() internal view override returns (uint256 _totalAssets) {
         // get strategy's balance in the vault (shares)
         uint256 shares = IERC4626(targetVault).balanceOf(address(this));
-        uint256 vaultAssets = IERC4626(targetVault).convertToAssets(shares);
+        // EIP-4626 requires previewRedeem to reflect any exit-fee policy the target vault enforces;
+        // convertToAssets returns the gross value and would overstate totalAssets for fee-charging vaults.
+        uint256 vaultAssets = IERC4626(targetVault).previewRedeem(shares);
 
         uint256 idleAssets = IERC20(asset).balanceOf(address(this));
 

--- a/src/strategies/yieldDonating/ERC4626Strategy.sol
+++ b/src/strategies/yieldDonating/ERC4626Strategy.sol
@@ -34,7 +34,10 @@ contract ERC4626Strategy is BaseHealthCheck {
 
     /**
      * @notice Initializes the ERC4626 strategy
-     * @dev Validates asset matches target vault's asset and approves max allowance
+     * @dev Validates asset matches target vault's asset. Approval is issued
+     *      per-deposit inside {_deployFunds} and explicitly cleared after the
+     *      target vault call, so no standing allowance against the external
+     *      (upgradeable) target vault exists between calls.
      * @param _targetVault Address of the ERC4626 vault this strategy deposits into
      * @param _asset Address of the underlying asset (must match target vault's asset)
      * @param _name Strategy display name (e.g., "Octant ERC4626 Strategy")
@@ -72,7 +75,6 @@ contract ERC4626Strategy is BaseHealthCheck {
     {
         // make sure asset is target vault's asset
         require(IERC4626(_targetVault).asset() == _asset, "Asset mismatch with target vault");
-        IERC20(_asset).forceApprove(_targetVault, type(uint256).max);
         targetVault = _targetVault;
     }
 
@@ -104,7 +106,9 @@ contract ERC4626Strategy is BaseHealthCheck {
      * @param _amount Amount of assets to deploy in asset base units
      */
     function _deployFunds(uint256 _amount) internal override {
+        IERC20(asset).forceApprove(targetVault, _amount);
         IERC4626(targetVault).deposit(_amount, address(this));
+        IERC20(asset).forceApprove(targetVault, 0);
     }
 
     /**

--- a/src/strategies/yieldDonating/ERC4626Strategy.sol
+++ b/src/strategies/yieldDonating/ERC4626Strategy.sol
@@ -85,6 +85,12 @@ contract ERC4626Strategy is BaseHealthCheck {
      */
     function availableDepositLimit(address /*_owner*/) public view override returns (uint256) {
         uint256 vaultLimit = IERC4626(targetVault).maxDeposit(address(this));
+        // Preserve the ERC-4626 "infinite capacity" sentinel; subtracting the
+        // idle balance would clobber `type(uint256).max` into `uint256.max - idle`,
+        // which `TokenizedStrategy._maxMint` no longer recognises as unbounded
+        // and routes through `_convertToShares` (risking mulDiv overflow off
+        // 1:1 PPS).
+        if (vaultLimit == type(uint256).max) return type(uint256).max;
         uint256 idleBalance = IERC20(asset).balanceOf(address(this));
         return vaultLimit > idleBalance ? vaultLimit - idleBalance : 0;
     }

--- a/src/strategies/yieldDonating/ERC4626Strategy.sol
+++ b/src/strategies/yieldDonating/ERC4626Strategy.sol
@@ -23,7 +23,26 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
  *      - Works with any standard ERC4626 vault (Spark, Yearn v3, etc.)
  *      - Vault must have manipulation-resistant convertToAssets implementation
  *
+ *      INTEGRATOR WARNING — per-target audit required:
+ *      ERC-4626 compliance is a spec-level claim. Several production vaults that
+ *      advertise conformance still have edge cases that break the semantics this
+ *      strategy relies on (in particular `availableDepositLimit` /
+ *      `availableWithdrawLimit`, which trust the target vault's `maxDeposit` /
+ *      `maxWithdraw` at face value):
+ *        - MetaMorpho-style vaults can return `maxDeposit == 0` as a normal
+ *          operating state while their curator reallocates liquidity across
+ *          markets. Deposits must be expected to fail with "deposit more than
+ *          max" during those windows even though the strategy code is correct.
+ *        - Euler-V2-style vaults' `max*` values can be inaccurate once hooks are
+ *          installed on the vault — the vault's own documentation notes that
+ *          "some hook configurations may cause the vault to not be fully
+ *          ERC-4626 compliant".
+ *      Every target vault MUST be studied and audited individually before this
+ *      strategy is deployed against it. Do not treat ERC-4626 conformance as a
+ *      blanket security guarantee.
+ *
  * @custom:security ERC4626 vault convertToAssets must be manipulation-resistant
+ * @custom:security Target vault must be audited individually before deployment
  */
 contract ERC4626Strategy is BaseHealthCheck {
     using SafeERC20 for IERC20;

--- a/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
+++ b/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
@@ -158,7 +158,9 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
     function _harvestAndReport() internal view override returns (uint256 _totalAssets) {
         // Get strategy's share balance in the compounder vault
         uint256 shares = ITokenizedStrategy(compounderVault).balanceOf(address(this));
-        uint256 vaultAssets = ITokenizedStrategy(compounderVault).convertToAssets(shares);
+        // EIP-4626 requires previewRedeem to reflect any exit-fee policy the target vault enforces;
+        // convertToAssets returns the gross value and would overstate totalAssets for fee-charging vaults.
+        uint256 vaultAssets = ITokenizedStrategy(compounderVault).previewRedeem(shares);
 
         // Include idle funds as per BaseStrategy specification
         uint256 idleAssets = IERC20(asset).balanceOf(address(this));

--- a/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
+++ b/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
@@ -129,15 +129,20 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
      */
     function _deployFunds(uint256 _amount) internal override {
         IERC20(asset).forceApprove(compounderVault, _amount);
-        ITokenizedStrategy(compounderVault).deposit(_amount, address(this));
+        // Assert the target vault credited shares. A zero-share outcome (e.g., high PPS combined
+        // with a tiny deposit, or a misbehaving downstream vault) would consume the asset without
+        // recognising a position, silently stranding funds.
+        uint256 shares = ITokenizedStrategy(compounderVault).deposit(_amount, address(this));
+        require(shares > 0, "MorphoCompounderStrategy: zero shares minted");
         IERC20(asset).forceApprove(compounderVault, 0);
     }
 
     /**
      * @dev Withdraws assets from Morpho compounder vault
      * @param _amount Amount of assets to withdraw in asset base units
-     * @custom:security maxLoss set to 100% (10_000 BPS) to prevent revert cascades
-     *                  MultistrategyVault enforces actual loss limits via updateDebt
+     * @custom:security Target `withdraw` returns shares burned, not assets received.
+     *                  `TokenizedStrategy._withdraw` measures the post-call asset
+     *                  balance and applies the caller's max-loss limit.
      */
     function _freeFunds(uint256 _amount) internal override {
         ITokenizedStrategy(compounderVault).withdraw(_amount, address(this), address(this), 10_000);

--- a/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
+++ b/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
@@ -101,6 +101,12 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
         // This is because maxDeposit chains through: this strategy → Morpho Steakhouse → SteakHouse USDC,
         // and SteakHouse USDC's maxDeposit may overstate capacity when duplicate markets exist.
         uint256 vaultLimit = ITokenizedStrategy(compounderVault).maxDeposit(address(this));
+        // Preserve the ERC-4626 "infinite capacity" sentinel; subtracting the
+        // idle balance would clobber `type(uint256).max` into `uint256.max - idle`,
+        // which `TokenizedStrategy._maxMint` no longer recognises as unbounded
+        // and routes through `_convertToShares` (risking mulDiv overflow off
+        // 1:1 PPS).
+        if (vaultLimit == type(uint256).max) return type(uint256).max;
         uint256 idleBalance = IERC20(asset).balanceOf(address(this));
         return vaultLimit > idleBalance ? vaultLimit - idleBalance : 0;
     }

--- a/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
+++ b/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
@@ -40,7 +40,10 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
 
     /**
      * @notice Initializes the Morpho compounder strategy
-     * @dev Validates asset matches Morpho vault's asset and approves max allowance
+     * @dev Validates asset matches Morpho vault's asset. Approval is issued
+     *      per-deposit inside {_deployFunds} and explicitly cleared after the
+     *      compounder vault call, so no standing allowance against the external
+     *      (upgradeable) compounder vault exists between calls.
      * @param _compounderVault Address of the Morpho compounder vault to deposit into
      * @param _asset Address of the underlying asset (must match compounder vault's asset)
      * @param _name Strategy display name (e.g., "Octant Morpho USDC Strategy")
@@ -78,7 +81,6 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
     {
         // make sure asset is Morpho's asset
         require(ITokenizedStrategy(_compounderVault).asset() == _asset, "Asset mismatch with compounder vault");
-        IERC20(_asset).forceApprove(_compounderVault, type(uint256).max);
         compounderVault = _compounderVault;
     }
 
@@ -120,7 +122,9 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
      * @param _amount Amount of assets to deploy in asset base units
      */
     function _deployFunds(uint256 _amount) internal override {
+        IERC20(asset).forceApprove(compounderVault, _amount);
         ITokenizedStrategy(compounderVault).deposit(_amount, address(this));
+        IERC20(asset).forceApprove(compounderVault, 0);
     }
 
     /**

--- a/src/strategies/yieldDonating/SparkStrategy.sol
+++ b/src/strategies/yieldDonating/SparkStrategy.sol
@@ -33,7 +33,8 @@ contract SparkStrategy is ERC4626Strategy {
 
     /**
      * @notice Initializes the Spark strategy
-     * @dev Validates asset matches target vault's asset and approves max allowance
+     * @dev Inherits ERC4626Strategy's per-deposit approval flow, which clears
+     *      target-vault allowance after each deploy.
      * @param _targetVault Address of the Spark ERC4626 vault this strategy deposits into
      * @param _asset Address of the underlying asset (must match target vault's asset)
      * @param _name Strategy display name (e.g., "Spark USDC Strategy")

--- a/src/strategies/yieldDonating/YearnV3Strategy.sol
+++ b/src/strategies/yieldDonating/YearnV3Strategy.sol
@@ -150,6 +150,10 @@ contract YearnV3Strategy is BaseHealthCheck {
     /**
      * @dev Emergency withdrawal after strategy shutdown
      * @param _amount Amount of assets to withdraw in asset base units
+     * @custom:security Delegates to `_freeFunds`, which calls the Yearn v3 vault
+     *                  with `maxLoss = 10_000` BPS (100%). This preserves the
+     *                  shared `emergencyWithdraw(uint256)` ABI; emergency admins
+     *                  must assess acceptable Yearn loss off-chain before calling.
      */
     function _emergencyWithdraw(uint256 _amount) internal override {
         _freeFunds(_amount);

--- a/src/strategies/yieldDonating/YearnV3Strategy.sol
+++ b/src/strategies/yieldDonating/YearnV3Strategy.sol
@@ -97,6 +97,10 @@ contract YearnV3Strategy is BaseHealthCheck {
         // the maxDeposit value may be inflated when the underlying chain reaches vaults with duplicate
         // markets in their supplyQueue (like SteakHouse USDC). This could cause temporary DoS for deposits
         uint256 vaultLimit = ITokenizedStrategy(yearnVault).maxDeposit(address(this));
+        // Preserve the ERC-4626 "infinite capacity" sentinel so TokenizedStrategy._maxMint short-circuits
+        // the _convertToShares call; subtracting the idle balance would clobber the sentinel and cause
+        // maxMint() to overflow in the mulDiv when share price != 1.
+        if (vaultLimit == type(uint256).max) return type(uint256).max;
         uint256 idleBalance = IERC20(asset).balanceOf(address(this));
         return vaultLimit > idleBalance ? vaultLimit - idleBalance : 0;
     }

--- a/src/strategies/yieldDonating/YearnV3Strategy.sol
+++ b/src/strategies/yieldDonating/YearnV3Strategy.sol
@@ -161,7 +161,9 @@ contract YearnV3Strategy is BaseHealthCheck {
     function _harvestAndReport() internal view override returns (uint256 _totalAssets) {
         // get strategy's balance in the vault
         uint256 shares = ITokenizedStrategy(yearnVault).balanceOf(address(this));
-        uint256 vaultAssets = ITokenizedStrategy(yearnVault).convertToAssets(shares);
+        // EIP-4626 requires previewRedeem to reflect any exit-fee policy the target vault enforces;
+        // convertToAssets returns the gross value and would overstate totalAssets for fee-charging vaults.
+        uint256 vaultAssets = ITokenizedStrategy(yearnVault).previewRedeem(shares);
 
         uint256 idleAssets = IERC20(asset).balanceOf(address(this));
 

--- a/src/strategies/yieldDonating/YearnV3Strategy.sol
+++ b/src/strategies/yieldDonating/YearnV3Strategy.sol
@@ -39,7 +39,8 @@ contract YearnV3Strategy is BaseHealthCheck {
 
     /**
      * @notice Initializes the Yearn v3 strategy
-     * @dev Validates asset matches Yearn vault's asset and approves max allowance
+     * @dev Validates asset matches Yearn vault's asset. Approval is granted per-deposit
+     *      in `_deployFunds` and explicitly cleared after the Yearn vault call.
      * @param _yearnVault Address of the Yearn v3 vault this strategy deposits into
      * @param _asset Address of the underlying asset (must match Yearn vault's asset)
      * @param _name Strategy display name (e.g., "Octant Yearn USDC Strategy")
@@ -77,7 +78,6 @@ contract YearnV3Strategy is BaseHealthCheck {
     {
         // make sure asset is Yearn vault's asset
         require(ITokenizedStrategy(_yearnVault).asset() == _asset, "Asset mismatch with compounder vault");
-        IERC20(_asset).forceApprove(_yearnVault, type(uint256).max);
         yearnVault = _yearnVault;
     }
 
@@ -116,9 +116,14 @@ contract YearnV3Strategy is BaseHealthCheck {
     /**
      * @dev Deposits idle assets into Yearn v3 vault
      * @param _amount Amount of assets to deploy in asset base units
+     * @custom:security Approves exactly `_amount` and clears the allowance after
+     *                  `deposit`, leaving no standing claim against the strategy's
+     *                  idle balance even if a target vault under-pulls.
      */
     function _deployFunds(uint256 _amount) internal override {
+        IERC20(asset).forceApprove(yearnVault, _amount);
         ITokenizedStrategy(yearnVault).deposit(_amount, address(this));
+        IERC20(asset).forceApprove(yearnVault, 0);
     }
 
     /**

--- a/src/strategies/yieldDonating/YearnV3Strategy.sol
+++ b/src/strategies/yieldDonating/YearnV3Strategy.sol
@@ -126,23 +126,24 @@ contract YearnV3Strategy is BaseHealthCheck {
      */
     function _deployFunds(uint256 _amount) internal override {
         IERC20(asset).forceApprove(yearnVault, _amount);
-        ITokenizedStrategy(yearnVault).deposit(_amount, address(this));
+        // Assert the target vault credited shares. A zero-share outcome (e.g., high PPS combined
+        // with a tiny deposit, or a misbehaving downstream vault) would consume the asset without
+        // recognising a position, silently stranding funds.
+        uint256 shares = ITokenizedStrategy(yearnVault).deposit(_amount, address(this));
+        require(shares > 0, "YearnV3Strategy: zero shares minted");
         IERC20(asset).forceApprove(yearnVault, 0);
     }
 
     /**
      * @dev Withdraws assets from Yearn v3 vault
      * @param _amount Amount of assets to withdraw in asset base units
-     * @custom:security maxLoss set to 100% (10_000 BPS) to prevent revert cascades
-     *                  MultistrategyVault enforces actual loss limits via updateDebt
+     * @custom:security Target `withdraw` returns shares burned, not assets received.
+     *                  `TokenizedStrategy._withdraw` measures the post-call asset
+     *                  balance and applies the caller's max-loss limit. The Yearn
+     *                  call accepts 100% target-vault loss so the outer accounting
+     *                  can observe and enforce the realised result.
      */
     function _freeFunds(uint256 _amount) internal override {
-        // NOTE: maxLoss is set to 10_000 (100%) to ensure withdrawals don't revert when the Yearn vault
-        // has unrealized losses. This is necessary because:
-        // 1. When the TokenizedStrategy needs funds, it calls freeFunds() to withdraw from the underlying Yearn vault
-        // 2. Without accepting losses here, any slippage/loss in Yearn would cause the withdrawal to fail
-        // 3. The MultistrategyVault performs its own loss checks after withdrawal via updateDebt's maxLoss parameter
-        // This allows the strategy to always provide liquidity while loss protection is enforced at the vault level.
         ITokenizedStrategy(yearnVault).withdraw(_amount, address(this), address(this), 10_000);
     }
 

--- a/test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol
@@ -260,9 +260,18 @@ contract KpkERC4626StrategyTest is BaseYieldDonatingIntegrationTest {
 
         assertEq(idleBalance, idleAmount, "Strategy should have idle assets");
 
-        uint256 expectedLimit = kpkLimit > idleAmount ? kpkLimit - idleAmount : 0;
-        assertEq(limit, expectedLimit, "Available deposit limit should account for idle assets");
-        assertLt(limit, kpkLimit, "Available deposit limit should be less than KPK limit when idle assets exist");
+        // When the underlying vault advertises the ERC-4626 unbounded-capacity
+        // sentinel (e.g. Gearbox V3 PoolV3, KPK ETH Prime), `availableDepositLimit`
+        // must return `type(uint256).max` unchanged so `TokenizedStrategy._maxMint`
+        // keeps its sentinel-based fast path; subtracting the idle balance would
+        // clobber the sentinel and route through `_convertToShares`.
+        if (kpkLimit == type(uint256).max) {
+            assertEq(limit, type(uint256).max, "Sentinel must be preserved when KPK limit is unbounded");
+        } else {
+            uint256 expectedLimit = kpkLimit > idleAmount ? kpkLimit - idleAmount : 0;
+            assertEq(limit, expectedLimit, "Available deposit limit should account for idle assets");
+            assertLt(limit, kpkLimit, "Available deposit limit should be less than KPK limit when idle assets exist");
+        }
     }
 
     /// @notice Test deposit cap handling

--- a/test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol
@@ -166,7 +166,7 @@ contract KpkERC4626StrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 balanceOfKpkVault = IERC4626(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
             address(IERC4626(_compounderVault())),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, balanceOfKpkVault),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfKpkVault),
             abi.encode(depositAmount + profitAmount)
         );
 

--- a/test/integration/strategies/YieldDonating/MorphoCompounderStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/MorphoCompounderStrategy.t.sol
@@ -140,7 +140,7 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
         uint256 balanceOfMorphoVault = IERC4626(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
             address(IERC4626(_compounderVault())),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, balanceOfMorphoVault),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfMorphoVault),
             abi.encode(depositAmount + profitAmount)
         );
 
@@ -273,7 +273,7 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
 
     // ========== HARVEST OVERFLOW TESTS ==========
 
-    /// @notice Test that _harvestAndReport caps at type(uint256).max when convertToAssets overflows with idle
+    /// @notice Test that _harvestAndReport caps at type(uint256).max when previewRedeem overflows with idle
     function testHarvestOverflowFromVaultMorpho() public {
         _testHarvestOverflowFromVault();
     }
@@ -355,7 +355,7 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
 
         vm.mockCall(
             address(_compounderVault()),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, morphoSharesBefore),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, morphoSharesBefore),
             abi.encode(depositAmount + vaultProfit)
         );
 

--- a/test/integration/strategies/YieldDonating/SparkStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/SparkStrategy.t.sol
@@ -173,7 +173,7 @@ contract SparkDonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 balanceOfSparkVault = IERC4626(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
             address(IERC4626(_compounderVault())),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, balanceOfSparkVault),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfSparkVault),
             abi.encode(depositAmount + profitAmount)
         );
 
@@ -500,7 +500,7 @@ contract SparkDonatingStrategyTest is BaseYieldDonatingIntegrationTest {
 
     // ========== HARVEST OVERFLOW TESTS ==========
 
-    /// @notice Test that _harvestAndReport caps at type(uint256).max when convertToAssets overflows with idle
+    /// @notice Test that _harvestAndReport caps at type(uint256).max when previewRedeem overflows with idle
     function testHarvestOverflowFromVaultSpark() public {
         _testHarvestOverflowFromVault();
     }

--- a/test/integration/strategies/YieldDonating/YearnV3Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/YearnV3Strategy.t.sol
@@ -147,7 +147,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 balanceOfYearnVault = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, balanceOfYearnVault),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfYearnVault),
             abi.encode(depositAmount + profitAmount)
         );
 
@@ -256,7 +256,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 excessiveProfit = (depositAmount * 20) / 100; // 20% profit
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, balanceOfYearnVault),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfYearnVault),
             abi.encode(depositAmount + excessiveProfit)
         );
 
@@ -285,7 +285,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 loss = (depositAmount * 10) / 100; // 10% loss
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, balanceOfYearnVault),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfYearnVault),
             abi.encode(depositAmount - loss)
         );
 
@@ -317,7 +317,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 excessiveProfit = (depositAmount * 50) / 100; // 50% profit
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, balanceOfYearnVault),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfYearnVault),
             abi.encode(depositAmount + excessiveProfit)
         );
 
@@ -349,7 +349,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
 
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, yearnSharesBefore),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, yearnSharesBefore),
             abi.encode(depositAmount + vaultProfit)
         );
 
@@ -572,7 +572,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
 
     // ========== HARVEST OVERFLOW TESTS ==========
 
-    /// @notice Test that _harvestAndReport caps at type(uint256).max when convertToAssets overflows with idle
+    /// @notice Test that _harvestAndReport caps at type(uint256).max when previewRedeem overflows with idle
     function testHarvestOverflowFromVaultYearn() public {
         _testHarvestOverflowFromVault();
     }
@@ -599,7 +599,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
 
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, yearnSharesBefore),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, yearnSharesBefore),
             abi.encode(depositAmount - lossAmount)
         );
 
@@ -636,7 +636,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 yearnShares = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, yearnShares),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, yearnShares),
             abi.encode(remainingValue)
         );
 
@@ -688,7 +688,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 yearnShares = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, yearnShares),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, yearnShares),
             abi.encode(remainingValue)
         );
 
@@ -737,7 +737,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 yearnShares = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, yearnShares),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, yearnShares),
             abi.encode(depositAmount - lossAmount)
         );
 
@@ -774,7 +774,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 yearnShares = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector, yearnShares),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector, yearnShares),
             abi.encode(remainingValue)
         );
 

--- a/test/integration/strategies/YieldDonating/base/BaseYieldDonatingIntegrationTest.sol
+++ b/test/integration/strategies/YieldDonating/base/BaseYieldDonatingIntegrationTest.sol
@@ -421,8 +421,8 @@ abstract contract BaseYieldDonatingIntegrationTest is BaseIntegrationTest {
 
     // ========== HARVEST AND REPORT OVERFLOW TESTS ==========
 
-    /// @notice Test that _harvestAndReport returns type(uint256).max when vault convertToAssets overflows with idle
-    /// @dev Mocks convertToAssets on the compounder vault to return type(uint256).max, ensuring the
+    /// @notice Test that _harvestAndReport returns type(uint256).max when vault previewRedeem overflows with idle
+    /// @dev Mocks previewRedeem on the compounder vault to return type(uint256).max, ensuring the
     ///      overflow guard `if (vaultAssets > type(uint256).max - idleAssets) return type(uint256).max` is hit
     function _testHarvestOverflowFromVault() internal {
         uint256 depositAmount = 1000 * 10 ** uint256(_decimals());
@@ -441,11 +441,11 @@ abstract contract BaseYieldDonatingIntegrationTest is BaseIntegrationTest {
         // Airdrop idle assets to strategy so idleAssets > 0
         airdrop(ERC20(_asset()), address(vault), idleAmount);
 
-        // Mock convertToAssets on compounder vault to return type(uint256).max for any input
+        // Mock previewRedeem on compounder vault to return type(uint256).max for any input
         // This triggers the overflow guard: vaultAssets > type(uint256).max - idleAssets
         vm.mockCall(
             _compounderVault(),
-            abi.encodeWithSelector(IERC4626.convertToAssets.selector),
+            abi.encodeWithSelector(IERC4626.previewRedeem.selector),
             abi.encode(type(uint256).max)
         );
 

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -221,7 +221,7 @@ contract SwappingYieldForwarderTest is Test {
         asset.mint(address(forwarder), 11e18);
 
         vm.expectEmit(true, true, false, true);
-        emit SwappingYieldForwarder.TokenForwarded(address(asset), receiver, 11e18);
+        emit YieldForwarder.TokenForwarded(address(asset), receiver, 11e18);
 
         vm.prank(keeperEOA);
         forwarder.forwardToken(address(asset));

--- a/test/unit/strategies/yieldDonating/BailsecAvailableDepositLimitSentinel.t.sol
+++ b/test/unit/strategies/yieldDonating/BailsecAvailableDepositLimitSentinel.t.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { YearnV3Strategy } from "src/strategies/yieldDonating/YearnV3Strategy.sol";
+
+/// @notice Minimal vault that always advertises `type(uint256).max` as `maxDeposit`.
+/// @dev Mirrors the ERC-4626 "infinite capacity" sentinel returned by unrestricted Yearn/Morpho/Spark vaults.
+contract InfiniteCapacityVaultMock {
+    address public immutable asset;
+
+    constructor(address underlying) {
+        asset = underlying;
+    }
+
+    function maxDeposit(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function maxWithdraw(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function convertToAssets(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewRedeem(uint256) external pure returns (uint256) {
+        return 0;
+    }
+}
+
+/// @title Bailsec #52 -- `availableDepositLimit` must preserve the `type(uint256).max` sentinel
+/// @notice Pre-fix the function subtracts idle balance unconditionally, so `maxDeposit == uint256.max`
+///         becomes `uint256.max - idle`; `TokenizedStrategy._maxMint` then runs `_convertToShares` with
+///         that near-max assets argument and overflows in `mulDiv` whenever share price != 1.
+///         Post-fix the function returns the sentinel verbatim so `_maxMint` short-circuits.
+contract BailsecAvailableDepositLimitSentinelTest is Test {
+    ERC20Mock internal asset;
+    YieldDonatingTokenizedStrategy internal implementation;
+    InfiniteCapacityVaultMock internal yearnVault;
+    YearnV3Strategy internal strategy;
+
+    address internal management = address(0xA1);
+    address internal keeper = address(0xA2);
+    address internal emergencyAdmin = address(0xA3);
+    address internal donationAddress = address(0xA4);
+
+    uint256 internal constant IDLE_BALANCE = 1_000 ether;
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        yearnVault = new InfiniteCapacityVaultMock(address(asset));
+        implementation = new YieldDonatingTokenizedStrategy();
+
+        strategy = new YearnV3Strategy(
+            address(yearnVault),
+            address(asset),
+            "Octant Yearn Bailsec",
+            "osBailsecY",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
+        );
+
+        // Seed idle balance directly on the strategy so the pre-fix arithmetic clobbers the sentinel.
+        asset.mint(address(strategy), IDLE_BALANCE);
+    }
+
+    function test_bailsec_52_availableDepositLimit_preservesMaxSentinel() public view {
+        // Pre-fix this returns `type(uint256).max - IDLE_BALANCE`; post-fix it returns the sentinel
+        // so `TokenizedStrategy._maxMint` can short-circuit `_convertToShares`.
+        assertEq(
+            strategy.availableDepositLimit(address(0)),
+            type(uint256).max,
+            "availableDepositLimit must preserve the uint256.max sentinel when the target vault advertises infinite capacity"
+        );
+    }
+
+    function test_bailsec_52_maxMint_returnsMaxSentinel() public view {
+        // Pre-fix `_maxMint` enters the `_convertToShares(huge_value, ...)` branch and would overflow
+        // once share price != 1; post-fix it short-circuits and returns the sentinel directly.
+        assertEq(
+            ITokenizedStrategy(address(strategy)).maxMint(address(0xBEEF)),
+            type(uint256).max,
+            "maxMint must forward the uint256.max sentinel from availableDepositLimit"
+        );
+    }
+}

--- a/test/unit/strategies/yieldDonating/BailsecExactApprovalYearnV3.t.sol
+++ b/test/unit/strategies/yieldDonating/BailsecExactApprovalYearnV3.t.sol
@@ -1,0 +1,190 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { YearnV3Strategy } from "src/strategies/yieldDonating/YearnV3Strategy.sol";
+
+/// @notice Minimal Yearn-v3-shaped vault that mints 1:1 shares and pulls exactly `assets`.
+/// @dev Exposes just enough `ITokenizedStrategy` surface for the constructor + deposit + deploy
+///      flow; does not model real yield, fees, or withdrawals.
+contract PassthroughVaultMock {
+    address public immutable asset;
+
+    mapping(address => uint256) private _shares;
+
+    constructor(address underlying) {
+        asset = underlying;
+    }
+
+    function deposit(uint256 assets, address receiver) external returns (uint256) {
+        IERC20(asset).transferFrom(msg.sender, address(this), assets);
+        _shares[receiver] += assets;
+        return assets;
+    }
+
+    function balanceOf(address owner) external view returns (uint256) {
+        return _shares[owner];
+    }
+
+    function maxDeposit(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function maxWithdraw(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function convertToAssets(uint256 shares) external pure returns (uint256) {
+        return shares;
+    }
+
+    function previewRedeem(uint256 shares) external pure returns (uint256) {
+        return shares;
+    }
+}
+
+/// @notice Yearn-v3-shaped vault that intentionally pulls less than approved.
+/// @dev Models a broken or hostile target upgrade that returns non-zero shares
+///      without consuming the full allowance. The strategy must still clear the
+///      residual approval after the call.
+contract UnderPullVaultMock {
+    address public immutable asset;
+    uint256 public immutable pullAmount;
+
+    mapping(address => uint256) private _shares;
+
+    constructor(address underlying, uint256 _pullAmount) {
+        asset = underlying;
+        pullAmount = _pullAmount;
+    }
+
+    function deposit(uint256, address receiver) external returns (uint256) {
+        IERC20(asset).transferFrom(msg.sender, address(this), pullAmount);
+        _shares[receiver] += pullAmount;
+        return pullAmount;
+    }
+
+    function balanceOf(address owner) external view returns (uint256) {
+        return _shares[owner];
+    }
+
+    function maxDeposit(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function maxWithdraw(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function convertToAssets(uint256 shares) external pure returns (uint256) {
+        return shares;
+    }
+
+    function previewRedeem(uint256 shares) external pure returns (uint256) {
+        return shares;
+    }
+}
+
+/// @title Bailsec #50 / #60 -- `YearnV3Strategy` must not hold a standing max approval on its target
+/// @notice Pre-fix the constructor granted `type(uint256).max` on the asset to the Yearn vault,
+///         exposing the full idle balance to any hostile upgrade of the (upgradeable-proxy) vault.
+///         Post-fix the allowance is granted per-deploy in `_deployFunds` and explicitly cleared
+///         after the vault call, even if the target under-pulls.
+contract BailsecExactApprovalYearnV3Test is Test {
+    ERC20Mock internal asset;
+    YieldDonatingTokenizedStrategy internal implementation;
+    PassthroughVaultMock internal yearnVault;
+    YearnV3Strategy internal strategy;
+
+    address internal management = address(0xA1);
+    address internal keeper = address(0xA2);
+    address internal emergencyAdmin = address(0xA3);
+    address internal donationAddress = address(0xA4);
+    address internal user = address(0xBEEF);
+
+    uint256 internal constant DEPOSIT_AMOUNT = 1_000 ether;
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        yearnVault = new PassthroughVaultMock(address(asset));
+        implementation = new YieldDonatingTokenizedStrategy();
+
+        strategy = new YearnV3Strategy(
+            address(yearnVault),
+            address(asset),
+            "Octant Yearn Bailsec",
+            "osBailsecY",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
+        );
+    }
+
+    function test_bailsec_60_constructorLeavesNoStandingApproval() public view {
+        // Pre-fix this is `type(uint256).max`; post-fix the constructor no longer approves the vault.
+        assertEq(
+            asset.allowance(address(strategy), address(yearnVault)),
+            0,
+            "constructor must not leave a standing approval to the target vault"
+        );
+    }
+
+    function test_bailsec_60_deployFundsLeavesZeroAllowance() public {
+        asset.mint(user, DEPOSIT_AMOUNT);
+        vm.startPrank(user);
+        asset.approve(address(strategy), DEPOSIT_AMOUNT);
+        ITokenizedStrategy(address(strategy)).deposit(DEPOSIT_AMOUNT, user);
+        vm.stopPrank();
+
+        // Post-fix `_deployFunds` forceApproves exactly `_amount` and the vault pulls the full amount,
+        // so the resulting allowance is zero. Pre-fix the constructor approved `type(uint256).max` and
+        // the vault's pull only consumed `_amount`, leaving (max - amount) as a standing claim.
+        assertEq(
+            asset.allowance(address(strategy), address(yearnVault)),
+            0,
+            "allowance to the target vault must settle to zero after _deployFunds"
+        );
+    }
+
+    function test_bailsec_60_deployFundsClearsResidualAllowanceIfVaultUnderPulls() public {
+        uint256 pulled = DEPOSIT_AMOUNT / 2;
+        UnderPullVaultMock underPullVault = new UnderPullVaultMock(address(asset), pulled);
+        YearnV3Strategy underPullStrategy = new YearnV3Strategy(
+            address(underPullVault),
+            address(asset),
+            "Octant Yearn Bailsec UnderPull",
+            "osBailsecYUP",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
+        );
+
+        asset.mint(user, DEPOSIT_AMOUNT);
+        vm.startPrank(user);
+        asset.approve(address(underPullStrategy), DEPOSIT_AMOUNT);
+        ITokenizedStrategy(address(underPullStrategy)).deposit(DEPOSIT_AMOUNT, user);
+        vm.stopPrank();
+
+        assertEq(
+            asset.allowance(address(underPullStrategy), address(underPullVault)),
+            0,
+            "residual allowance must be cleared even if the target vault under-pulls"
+        );
+        assertEq(
+            asset.balanceOf(address(underPullStrategy)),
+            DEPOSIT_AMOUNT - pulled,
+            "mock invariant: unpulled assets remain idle on the strategy"
+        );
+    }
+}

--- a/test/unit/strategies/yieldDonating/BailsecPreviewRedeem.t.sol
+++ b/test/unit/strategies/yieldDonating/BailsecPreviewRedeem.t.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { ERC4626 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
+import { ERC4626Fees } from "@openzeppelin/contracts/mocks/docs/ERC4626Fees.sol";
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { ERC4626Strategy } from "src/strategies/yieldDonating/ERC4626Strategy.sol";
+import { YearnV3Strategy } from "src/strategies/yieldDonating/YearnV3Strategy.sol";
+import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
+
+/// @notice ERC4626 target vault that charges an exit fee, so `previewRedeem(shares)` < `convertToAssets(shares)`.
+/// @dev Uses OpenZeppelin's docs-level ERC4626Fees reference to keep fee accounting EIP-4626 compliant.
+contract ExitFeeVaultMock is ERC4626Fees {
+    uint256 private immutable _exitFeeBps;
+
+    constructor(
+        IERC20 underlying_,
+        string memory name_,
+        string memory symbol_,
+        uint256 exitFeeBps_
+    ) ERC20(name_, symbol_) ERC4626(underlying_) {
+        _exitFeeBps = exitFeeBps_;
+    }
+
+    function _exitFeeBasisPoints() internal view override returns (uint256) {
+        return _exitFeeBps;
+    }
+
+    function _exitFeeRecipient() internal view override returns (address) {
+        return address(this);
+    }
+}
+
+/// @title Bailsec #54 -- `_harvestAndReport` must net out target-vault exit fees
+/// @notice Pre-fix the yield-donating strategies valued their target-vault positions via
+///         `convertToAssets`, which overstates totalAssets by the target vault's exit fee.
+///         Post-fix they use `previewRedeem`, the EIP-4626 view required to reflect any exit-fee
+///         policy. Exercised across `ERC4626Strategy`, `YearnV3Strategy`, and
+///         `MorphoCompounderStrategy`; `SparkStrategy` inherits the fix from `ERC4626Strategy`.
+contract BailsecPreviewRedeemTest is Test {
+    ERC20Mock internal asset;
+    YieldDonatingTokenizedStrategy internal implementation;
+    ExitFeeVaultMock internal targetVault;
+
+    address internal management = address(0xA1);
+    address internal keeper = address(0xA2);
+    address internal emergencyAdmin = address(0xA3);
+    address internal donationAddress = address(0xA4);
+    address internal user = address(0xBEEF);
+
+    uint256 internal constant EXIT_FEE_BPS = 500; // 5%
+    uint256 internal constant DEPOSIT_AMOUNT = 1_000 ether;
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        targetVault = new ExitFeeVaultMock(IERC20(address(asset)), "Exit Fee Vault", "EFV", EXIT_FEE_BPS);
+        implementation = new YieldDonatingTokenizedStrategy();
+    }
+
+    function _depositThenReport(address strategyAddr) internal {
+        asset.mint(user, DEPOSIT_AMOUNT);
+        vm.startPrank(user);
+        asset.approve(strategyAddr, DEPOSIT_AMOUNT);
+        ITokenizedStrategy(strategyAddr).deposit(DEPOSIT_AMOUNT, user);
+        vm.stopPrank();
+
+        // Post-fix, _harvestAndReport returns previewRedeem which is strictly less than the deposit
+        // because of the exit fee. The default lossLimitRatio is zero, so the health check would
+        // veto any loss; disable it for this report.
+        vm.prank(management);
+        (bool ok, ) = strategyAddr.call(abi.encodeWithSignature("setDoHealthCheck(bool)", false));
+        require(ok, "setDoHealthCheck failed");
+
+        vm.prank(keeper);
+        ITokenizedStrategy(strategyAddr).report();
+    }
+
+    function _assertTotalAssetsMatchesPreviewRedeem(address strategyAddr) internal view {
+        uint256 vaultShares = targetVault.balanceOf(strategyAddr);
+        uint256 idle = asset.balanceOf(strategyAddr);
+        uint256 expected = targetVault.previewRedeem(vaultShares) + idle;
+        uint256 convertValue = targetVault.convertToAssets(vaultShares) + idle;
+
+        assertLt(expected, convertValue, "mock invariant: previewRedeem < convertToAssets");
+        assertEq(
+            ITokenizedStrategy(strategyAddr).totalAssets(),
+            expected,
+            "totalAssets must equal previewRedeem-based valuation (net of exit fee)"
+        );
+    }
+
+    function test_bailsec_54_ERC4626Strategy_harvestUsesPreviewRedeem() public {
+        ERC4626Strategy strategy = new ERC4626Strategy(
+            address(targetVault),
+            address(asset),
+            "Octant ERC4626 Bailsec",
+            "osBailsecE",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
+        );
+        _depositThenReport(address(strategy));
+        _assertTotalAssetsMatchesPreviewRedeem(address(strategy));
+    }
+
+    function test_bailsec_54_YearnV3Strategy_harvestUsesPreviewRedeem() public {
+        YearnV3Strategy strategy = new YearnV3Strategy(
+            address(targetVault),
+            address(asset),
+            "Octant Yearn Bailsec",
+            "osBailsecY",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
+        );
+        _depositThenReport(address(strategy));
+        _assertTotalAssetsMatchesPreviewRedeem(address(strategy));
+    }
+
+    function test_bailsec_54_MorphoCompounderStrategy_harvestUsesPreviewRedeem() public {
+        MorphoCompounderStrategy strategy = new MorphoCompounderStrategy(
+            address(targetVault),
+            address(asset),
+            "Octant Morpho Bailsec",
+            "osBailsecM",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
+        );
+        _depositThenReport(address(strategy));
+        _assertTotalAssetsMatchesPreviewRedeem(address(strategy));
+    }
+}

--- a/test/unit/strategies/yieldDonating/BailsecZeroSharesDeployFunds.t.sol
+++ b/test/unit/strategies/yieldDonating/BailsecZeroSharesDeployFunds.t.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { ERC4626Strategy } from "src/strategies/yieldDonating/ERC4626Strategy.sol";
+import { YearnV3Strategy } from "src/strategies/yieldDonating/YearnV3Strategy.sol";
+import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
+
+/// @notice Minimal 4626-shaped vault that always credits zero shares on deposit.
+/// @dev Simulates the "downstream vault rounds minted shares to zero" regime
+///      (high PPS + tiny deposit) without having to stage the inflation manually.
+contract ZeroSharesVaultMock {
+    address public immutable asset;
+
+    constructor(address underlying) {
+        asset = underlying;
+    }
+
+    function deposit(uint256 assets, address /*receiver*/) external returns (uint256) {
+        IERC20(asset).transferFrom(msg.sender, address(this), assets);
+        return 0;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function maxDeposit(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function maxWithdraw(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewRedeem(uint256) external pure returns (uint256) {
+        return 0;
+    }
+
+    function convertToAssets(uint256) external pure returns (uint256) {
+        return 0;
+    }
+}
+
+/// @title Bailsec #55 / deposit leg of #57 -- `_deployFunds` must revert on zero shares minted
+/// @notice Pre-fix the yield-donating strategies discarded the share return from their target
+///         vault's deposit, so a vault that credits zero shares silently consumed the strategy's
+///         assets. Post-fix, `require(shares > 0, ...)` converts that silent loss into an explicit
+///         revert. Exercised across `ERC4626Strategy`, `YearnV3Strategy`, and
+///         `MorphoCompounderStrategy`; `SparkStrategy` inherits the fix from `ERC4626Strategy`.
+///         For #57's withdraw leg, `_freeFunds` relies on `TokenizedStrategy._withdraw` balance-diff
+///         accounting because target `withdraw` returns shares burned rather than assets received.
+contract BailsecZeroSharesDeployFundsTest is Test {
+    ERC20Mock internal asset;
+    YieldDonatingTokenizedStrategy internal implementation;
+    ZeroSharesVaultMock internal targetVault;
+
+    address internal management = address(0xA1);
+    address internal keeper = address(0xA2);
+    address internal emergencyAdmin = address(0xA3);
+    address internal donationAddress = address(0xA4);
+    address internal user = address(0xBEEF);
+
+    uint256 internal constant DEPOSIT_AMOUNT = 1_000 ether;
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        targetVault = new ZeroSharesVaultMock(address(asset));
+        implementation = new YieldDonatingTokenizedStrategy();
+    }
+
+    function _expectDepositReverts(address strategyAddr, string memory reason) internal {
+        asset.mint(user, DEPOSIT_AMOUNT);
+        vm.startPrank(user);
+        asset.approve(strategyAddr, DEPOSIT_AMOUNT);
+        vm.expectRevert(bytes(reason));
+        ITokenizedStrategy(strategyAddr).deposit(DEPOSIT_AMOUNT, user);
+        vm.stopPrank();
+    }
+
+    function test_bailsec_55_YearnV3Strategy_deployFundsRevertsOnZeroShares() public {
+        YearnV3Strategy strategy = new YearnV3Strategy(
+            address(targetVault),
+            address(asset),
+            "Octant Yearn Bailsec",
+            "osBailsecY",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
+        );
+        _expectDepositReverts(address(strategy), "YearnV3Strategy: zero shares minted");
+    }
+
+    function test_bailsec_55_ERC4626Strategy_deployFundsRevertsOnZeroShares() public {
+        ERC4626Strategy strategy = new ERC4626Strategy(
+            address(targetVault),
+            address(asset),
+            "Octant ERC4626 Bailsec",
+            "osBailsecE",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
+        );
+        _expectDepositReverts(address(strategy), "ERC4626Strategy: zero shares minted");
+    }
+
+    function test_bailsec_55_MorphoCompounderStrategy_deployFundsRevertsOnZeroShares() public {
+        MorphoCompounderStrategy strategy = new MorphoCompounderStrategy(
+            address(targetVault),
+            address(asset),
+            "Octant Morpho Bailsec",
+            "osBailsecM",
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            false,
+            address(implementation)
+        );
+        _expectDepositReverts(address(strategy), "MorphoCompounderStrategy: zero shares minted");
+    }
+}

--- a/test/unit/strategies/yieldDonating/ERC4626BranchCoverage.t.sol
+++ b/test/unit/strategies/yieldDonating/ERC4626BranchCoverage.t.sol
@@ -1,0 +1,186 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { ERC4626Strategy } from "src/strategies/yieldDonating/ERC4626Strategy.sol";
+import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
+
+/// @notice 4626-shaped vault used by the branch-coverage tests below.
+/// @dev    Implements only the surface exercised by `_deployFunds` and
+///         `availableDepositLimit`. Advertises `type(uint256).max` capacity
+///         for `maxDeposit` and credits 1:1 shares on deposit so a single
+///         instance can drive both the exact-approval lifecycle and the
+///         unbounded-sentinel branches.
+contract UnboundedVaultMock {
+    address public immutable asset;
+    mapping(address => uint256) public balanceOf;
+    uint256 public totalSupply;
+    uint256 public pullBps = 10_000;
+
+    constructor(address underlying) {
+        asset = underlying;
+    }
+
+    function setPullBps(uint256 _pullBps) external {
+        pullBps = _pullBps;
+    }
+
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
+        uint256 pulled = (assets * pullBps) / 10_000;
+        IERC20(asset).transferFrom(msg.sender, address(this), pulled);
+        shares = pulled;
+        balanceOf[receiver] += shares;
+        totalSupply += shares;
+    }
+
+    function maxDeposit(address) external pure returns (uint256) {
+        return type(uint256).max;
+    }
+
+    function maxWithdraw(address) external pure returns (uint256) {
+        return 0;
+    }
+
+    function previewRedeem(uint256 shares) external pure returns (uint256) {
+        return shares;
+    }
+
+    function convertToAssets(uint256 shares) external pure returns (uint256) {
+        return shares;
+    }
+}
+
+/// @title  Branch coverage for ERC4626Strategy and MorphoCompounderStrategy
+/// @notice Exercises shared ERC-4626-lineage branches not reached by the
+///         generic yield-donating unit suite (which uses MockStrategy):
+///
+///         1. `_deployFunds` issues a per-deposit `forceApprove(_amount)` and
+///            clears the allowance after the target call. No standing max allowance
+///            or residual under-pull allowance against the external (upgradeable)
+///            target vault is left over from construction.
+contract ERC4626BranchCoverageTest is Test {
+    ERC20Mock internal asset;
+    YieldDonatingTokenizedStrategy internal implementation;
+    UnboundedVaultMock internal targetVault;
+
+    address internal management = address(0xA1);
+    address internal keeper = address(0xA2);
+    address internal emergencyAdmin = address(0xA3);
+    address internal donationAddress = address(0xA4);
+    address internal user = address(0xBEEF);
+
+    uint256 internal constant DEPOSIT_AMOUNT = 1_000 ether;
+
+    function setUp() public {
+        asset = new ERC20Mock();
+        targetVault = new UnboundedVaultMock(address(asset));
+        implementation = new YieldDonatingTokenizedStrategy();
+    }
+
+    // ─── Deployment helpers ───────────────────────────────────────────
+
+    function _deployERC4626Strategy() internal returns (ERC4626Strategy) {
+        return
+            new ERC4626Strategy(
+                address(targetVault),
+                address(asset),
+                "Octant ERC4626 Test",
+                "osERC4626Test",
+                management,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false,
+                address(implementation)
+            );
+    }
+
+    function _deployMorphoStrategy() internal returns (MorphoCompounderStrategy) {
+        return
+            new MorphoCompounderStrategy(
+                address(targetVault),
+                address(asset),
+                "Octant Morpho Test",
+                "osMorphoTest",
+                management,
+                keeper,
+                emergencyAdmin,
+                donationAddress,
+                false,
+                address(implementation)
+            );
+    }
+
+    // ─── Behavioural assertions (shared across strategies) ────────────
+
+    function _assertExactApprovalLifecycle(address strategyAddr) internal {
+        // Constructor must NOT leave a standing max-approval against the external vault.
+        assertEq(
+            asset.allowance(strategyAddr, address(targetVault)),
+            0,
+            "constructor leaked a standing allowance against the target vault"
+        );
+
+        // Deposit routes through `_deployFunds`, which approves exactly the
+        // deposit amount and clears allowance after the vault call.
+        asset.mint(user, DEPOSIT_AMOUNT);
+        vm.startPrank(user);
+        asset.approve(strategyAddr, DEPOSIT_AMOUNT);
+        ITokenizedStrategy(strategyAddr).deposit(DEPOSIT_AMOUNT, user);
+        vm.stopPrank();
+
+        assertEq(
+            asset.allowance(strategyAddr, address(targetVault)),
+            0,
+            "_deployFunds left a non-zero allowance after deposit"
+        );
+    }
+
+    function _assertResidualApprovalClearedOnUnderPull(address strategyAddr) internal {
+        targetVault.setPullBps(5_000);
+
+        asset.mint(user, DEPOSIT_AMOUNT);
+        vm.startPrank(user);
+        asset.approve(strategyAddr, DEPOSIT_AMOUNT);
+        ITokenizedStrategy(strategyAddr).deposit(DEPOSIT_AMOUNT, user);
+        vm.stopPrank();
+
+        assertEq(
+            asset.allowance(strategyAddr, address(targetVault)),
+            0,
+            "_deployFunds left residual allowance when target under-pulled"
+        );
+        assertEq(
+            asset.balanceOf(strategyAddr),
+            DEPOSIT_AMOUNT / 2,
+            "mock invariant: unpulled assets remain idle on the strategy"
+        );
+    }
+
+    // ─── Exact-amount approval in `_deployFunds` ──────────────────────
+
+    /// @notice ERC4626Strategy._deployFunds approves exactly `_amount`; no standing allowance.
+    function test_erc4626_deployFunds_usesExactApproval() public {
+        _assertExactApprovalLifecycle(address(_deployERC4626Strategy()));
+    }
+
+    /// @notice MorphoCompounderStrategy._deployFunds approves exactly `_amount`; no standing allowance.
+    function test_morphoCompounder_deployFunds_usesExactApproval() public {
+        _assertExactApprovalLifecycle(address(_deployMorphoStrategy()));
+    }
+
+    /// @notice ERC4626Strategy._deployFunds clears residual allowance if the target under-pulls.
+    function test_erc4626_deployFunds_clearsResidualApprovalOnUnderPull() public {
+        _assertResidualApprovalClearedOnUnderPull(address(_deployERC4626Strategy()));
+    }
+
+    /// @notice MorphoCompounderStrategy._deployFunds clears residual allowance if the target under-pulls.
+    function test_morphoCompounder_deployFunds_clearsResidualApprovalOnUnderPull() public {
+        _assertResidualApprovalClearedOnUnderPull(address(_deployMorphoStrategy()));
+    }
+}

--- a/test/unit/strategies/yieldDonating/ERC4626BranchCoverage.t.sol
+++ b/test/unit/strategies/yieldDonating/ERC4626BranchCoverage.t.sol
@@ -63,6 +63,12 @@ contract UnboundedVaultMock {
 ///            clears the allowance after the target call. No standing max allowance
 ///            or residual under-pull allowance against the external (upgradeable)
 ///            target vault is left over from construction.
+///         2. `availableDepositLimit` short-circuits when the target vault
+///            advertises `type(uint256).max`, preserving the ERC-4626
+///            "infinite capacity" sentinel that `TokenizedStrategy._maxMint`
+///            keys off (the pre-fix subtraction clobbered the sentinel into
+///            `uint256.max - idle`, routing through `_convertToShares` and
+///            risking a mulDiv overflow once PPS drifts off 1:1).
 contract ERC4626BranchCoverageTest is Test {
     ERC20Mock internal asset;
     YieldDonatingTokenizedStrategy internal implementation;
@@ -75,6 +81,7 @@ contract ERC4626BranchCoverageTest is Test {
     address internal user = address(0xBEEF);
 
     uint256 internal constant DEPOSIT_AMOUNT = 1_000 ether;
+    uint256 internal constant IDLE_SEED = 1 ether;
 
     function setUp() public {
         asset = new ERC20Mock();
@@ -162,6 +169,24 @@ contract ERC4626BranchCoverageTest is Test {
         );
     }
 
+    function _assertMaxMintSentinel(address strategyAddr) internal {
+        // Seed a non-zero idle balance so we exercise the subtraction branch;
+        // without this the pre-fix code path would coincidentally return the
+        // sentinel because `max - 0 == max`.
+        asset.mint(strategyAddr, IDLE_SEED);
+
+        assertEq(
+            ITokenizedStrategy(strategyAddr).maxMint(user),
+            type(uint256).max,
+            "maxMint sentinel clobbered by idle-balance subtraction on unbounded vault"
+        );
+        assertEq(
+            ITokenizedStrategy(strategyAddr).maxDeposit(user),
+            type(uint256).max,
+            "maxDeposit sentinel clobbered by idle-balance subtraction on unbounded vault"
+        );
+    }
+
     // ─── Exact-amount approval in `_deployFunds` ──────────────────────
 
     /// @notice ERC4626Strategy._deployFunds approves exactly `_amount`; no standing allowance.
@@ -182,5 +207,17 @@ contract ERC4626BranchCoverageTest is Test {
     /// @notice MorphoCompounderStrategy._deployFunds clears residual allowance if the target under-pulls.
     function test_morphoCompounder_deployFunds_clearsResidualApprovalOnUnderPull() public {
         _assertResidualApprovalClearedOnUnderPull(address(_deployMorphoStrategy()));
+    }
+
+    // ─── Unbounded-capacity sentinel in `availableDepositLimit` ───────
+
+    /// @notice ERC4626Strategy.availableDepositLimit preserves the unbounded-capacity sentinel.
+    function test_erc4626_availableDepositLimit_preservesUnboundedSentinel() public {
+        _assertMaxMintSentinel(address(_deployERC4626Strategy()));
+    }
+
+    /// @notice MorphoCompounderStrategy.availableDepositLimit preserves the unbounded-capacity sentinel.
+    function test_morphoCompounder_availableDepositLimit_preservesUnboundedSentinel() public {
+        _assertMaxMintSentinel(address(_deployMorphoStrategy()));
     }
 }


### PR DESCRIPTION
## Summary

Bailsec audit fixes for the ERC-4626-family yield-donating strategies: `YearnV3Strategy`, `ERC4626Strategy`, and `MorphoCompounderStrategy`. `SparkStrategy` inherits from `ERC4626Strategy` and picks up the ERC-4626 fixes for free.

The Bailsec remediation remains one finding/bundle per commit. Two isolated support commits are also included so this PR stays green against the current `develop` merge ref.

| Bailsec | Severity | Action | Commit |
|---|---|---|---|
| 52 | Low | FIX — preserve `uint256.max` sentinel in `availableDepositLimit` on overflow | `f15e6ddf` |
| 54 | Low | FIX — `_harvestAndReport` uses `previewRedeem` to net out exit fees (EIP-4626) | `7943f26d` |
| 55 | Low | FIX — revert on zero shares minted by target vault | `e4ccd7e9` |
| 57 | Info | FIX/ACK — deposit-side zero-share guard; withdraw side relies on `TokenizedStrategy._withdraw` balance-diff/max-loss accounting because target `withdraw` returns shares burned, not assets received | `e4ccd7e9` |
| 59 | Low | ACK/DOC — keep `emergencyWithdraw(uint256)` ABI unchanged; document Yearn `maxLoss = 10_000` and off-chain emergency-admin responsibility | `a54273be` |
| 60 | Low | FIX — ERC-4626-family approval hygiene: exact approval in `_deployFunds`, then explicit post-call allowance clear | `2335365b` |

### Split Scope

- Bailsec `#60` is split intentionally: this PR handles the ERC-4626-family leg; PR #414 handles the AaveV3Strategy leg. Both commits should be listed in the remediation report for the approval-hygiene finding.
- Bailsec `#59` is intentionally docs-only. We are not adding `emergencyWithdraw(uint256,uint256)` or changing the shared emergency ABI.
- Bailsec `#57` is intentionally deposit-side runtime fix plus withdraw-side acknowledgement. For `_freeFunds`, the target `withdraw` return value is shares burned; asset receipt is validated by `TokenizedStrategy._withdraw` through post-call balance-diff accounting and the caller's max-loss limit.

### Support Commits

| Scope | Why | Commit |
|---|---|---|
| Forwarder compatibility | Reuse inherited `YieldForwarder.forwardToken` so the current `develop` merge ref compiles | `3f146728` |
| CI semver compatibility | Retry old-ref semver build with unversioned changed-source overlays when `develop` has an unrelated unversioned compile regression | `db713815` |

### Source Impact

- `src/strategies/yieldDonating/YearnV3Strategy.sol` — ERC-4626-family fixes, #57 withdraw-side acknowledgement, and #59 emergency-withdraw documentation.
- `src/strategies/yieldDonating/ERC4626Strategy.sol` — exact approval with explicit post-call allowance clear, sentinel preservation, `previewRedeem`, zero-shares guard, #57 withdraw-side acknowledgement.
- `src/strategies/yieldDonating/MorphoCompounderStrategy.sol` — same ERC-4626-family fixes and #57 withdraw-side acknowledgement.
- `src/strategies/yieldDonating/SparkStrategy.sol` — inherits the ERC4626Strategy fixes and has NatSpec updated to reflect the inherited approval flow.
- `AaveV3Strategy` approval hygiene is handled in PR #414; this PR handles the ERC-4626-family side of Bailsec #60.
- `AaveV3Strategy` is not affected by the ERC-4626-specific valuation fixes.

### Test Coverage

| Test file | Covers |
|---|---|
| `test/unit/strategies/yieldDonating/BailsecAvailableDepositLimitSentinel.t.sol` | 52 (YearnV3 branches) |
| `test/unit/strategies/yieldDonating/ERC4626BranchCoverage.t.sol` | 52 + 60 (ERC4626Strategy + MorphoCompounderStrategy branches, including under-pulling target-vault residual allowance) |
| `test/unit/strategies/yieldDonating/BailsecExactApprovalYearnV3.t.sol` | 60 (YearnV3 branches, including under-pulling target-vault residual allowance) |
| `test/unit/strategies/yieldDonating/BailsecPreviewRedeem.t.sol` | 54 — ERC4626Fees-based target with 5% exit fee; asserts `totalAssets == previewRedeem + idle` across all three strategies |
| `test/unit/strategies/yieldDonating/BailsecZeroSharesDeployFunds.t.sol` | 55 + deposit leg of 57 — zero-shares-minting target causes `deposit` to revert with scoped message across all three strategies |
| `test/unit/core/*Forwarder*.t.sol` | Support forwarder compatibility commit |

Integration tests updated in the Bailsec 54 commit: migrated `vm.mockCall(..., IERC4626.convertToAssets.selector, ...)` to `IERC4626.previewRedeem.selector` across the Yearn, Morpho, Spark, Kpk, and base integration files so the existing profit / loss / overflow simulations intercept the post-fix code path.

## Test plan

- [x] `npx -y @yarnpkg/cli-dist@4.9.2 format:check` → clean
- [x] `bash script/check-natspec.sh` → clean
- [x] `./node_modules/.bin/commitlint --from origin/develop --to HEAD` → clean
- [x] `npx -y @yarnpkg/cli-dist@4.9.2 build` → clean
- [x] `forge test --match-path "test/unit/strategies/yieldDonating/Bailsec*.t.sol"` → 11/11 PASS
- [x] `forge test --match-path "test/unit/strategies/yieldDonating/ERC4626BranchCoverage.t.sol"` → 6/6 PASS
- [x] `forge test --match-path "test/unit/core/*Forwarder*.t.sol"` → 81/81 PASS
- [x] `node scripts/sol-semver.mjs check --old-ref origin/develop --new-ref HEAD` → clean
- [x] `npx -y @yarnpkg/cli-dist@4.9.2 lint` → exits 0 with existing repo warnings
- [x] GitHub PR Standards checks on head `db713815` → all jobs green