### PR TITLE
fix(cleanup): Bailsec audit fixes (3, 9, 12, 15, 16, 19, 20, 21, 22, 43)

### DIFF
--- a/src/core/Privileged.sol
+++ b/src/core/Privileged.sol
@@ -27,13 +27,19 @@ abstract contract Privileged {
     }
 
     function _setPrivileged(address _account, bool _status) internal {
-        _privilegedStorage().privileged[_account] = _status;
+        PrivilegedData storage P = _privilegedStorage();
+        // Skip SSTORE + event when the flag is already at the requested value.
+        // Avoids spurious PrivilegedUpdated logs that would skew off-chain indexer timelines.
+        if (P.privileged[_account] == _status) return;
+        P.privileged[_account] = _status;
         emit PrivilegedUpdated(_account, _status);
     }
 
     function _setPrivilegedBatch(address[] calldata _accounts, bool _status) internal {
         PrivilegedData storage P = _privilegedStorage();
         for (uint256 i = 0; i < _accounts.length; i++) {
+            // Skip per-entry no-ops so the batch emits only on real changes.
+            if (P.privileged[_accounts[i]] == _status) continue;
             P.privileged[_accounts[i]] = _status;
             emit PrivilegedUpdated(_accounts[i], _status);
         }

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -1760,6 +1760,15 @@ abstract contract TokenizedStrategy {
      * For more information on the signature format, see the
      * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP
      * section].
+     *
+     * @dev Mempool-grief caveat: like standard ERC-2612 permit, the signature is
+     *      permissionless. Any observer of a signed payload in the mempool can
+     *      front-run the owner's own submission with the same calldata — the
+     *      allowance still lands correctly, but the owner's original transaction
+     *      reverts on a stale nonce and they pay for the revert gas plus the
+     *      cost of producing a fresh signature. This is an accepted property of
+     *      EIP-2612; integrators that must recover from a griefed permit should
+     *      catch the revert, re-read `nonces(owner)`, and resign.
      */
     function permit(
         address owner,

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -224,8 +224,15 @@ abstract contract TokenizedStrategy {
         // ============================================
         
         /// @notice The underlying ERC20 asset token
-        /// @dev Must be ERC20-compliant. Set once during initialize() and never changes
-        ///      Strategy deposits/withdraws this token to/from yield sources
+        /// @dev Must be ERC20-compliant. Set once during initialize() and never changes.
+        ///      Strategy deposits/withdraws this token to/from yield sources.
+        ///      Fee-on-transfer (FOT) and rebasing tokens are NOT supported:
+        ///      `deposit` / `mint` route the declared `assets` amount through the
+        ///      accounting math without a pre-/post-balance reconciliation, so a
+        ///      token that transfers less than it claims (transfer fee) or that
+        ///      rebases its balance between accounting events would leave the
+        ///      tracked `totalAssets` out of sync with the on-chain balance and
+        ///      corrupt every ERC-4626 conversion that depends on PPS.
         ERC20 asset;
         
         /// @notice Human-readable name of the strategy share token

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -842,37 +842,43 @@ abstract contract TokenizedStrategy {
      * @param assets Amount of assets to deposit
      * @return shares_ Expected shares to be minted
      */
-    function previewDeposit(uint256 assets) external view returns (uint256) {
+    function previewDeposit(uint256 assets) public view virtual returns (uint256) {
         return _convertToShares(_strategyStorage(), assets, Math.Rounding.Floor);
     }
 
     /**
      * @notice Previews assets required to mint exact shares
-     * @dev Uses Ceil rounding
+     * @dev Uses Ceil rounding. Marked `virtual` so strategies that gate the real
+     *      `mint` path (e.g. yield-skimming on insolvency) can mirror the gate in
+     *      the preview and stay ERC-4626-compliant.
      * @param shares Amount of shares to mint
      * @return assets_ Required assets for mint
      */
-    function previewMint(uint256 shares) external view returns (uint256) {
+    function previewMint(uint256 shares) public view virtual returns (uint256) {
         return _convertToAssets(_strategyStorage(), shares, Math.Rounding.Ceil);
     }
 
     /**
      * @notice Previews shares that would be burned for a withdrawal
-     * @dev Uses Ceil rounding
+     * @dev Uses Ceil rounding. Marked `virtual` so strategies that apply logic
+     *      before the real `withdraw` priced conversion (e.g. a lazy dragon burn
+     *      in yield-skimming) can mirror the post-gate state in the preview.
      * @param assets Amount of assets to withdraw
      * @return shares_ Expected shares to be burned
      */
-    function previewWithdraw(uint256 assets) external view returns (uint256) {
+    function previewWithdraw(uint256 assets) public view virtual returns (uint256) {
         return _convertToShares(_strategyStorage(), assets, Math.Rounding.Ceil);
     }
 
     /**
      * @notice Previews assets that would be returned for redeeming shares
-     * @dev Uses Floor rounding
+     * @dev Uses Floor rounding. Marked `virtual` so strategies that apply logic
+     *      before the real `redeem` priced conversion (e.g. a lazy dragon burn
+     *      in yield-skimming) can mirror the post-gate state in the preview.
      * @param shares Amount of shares to redeem
      * @return assets_ Expected assets to be returned
      */
-    function previewRedeem(uint256 shares) external view returns (uint256) {
+    function previewRedeem(uint256 shares) public view virtual returns (uint256) {
         return _convertToAssets(_strategyStorage(), shares, Math.Rounding.Floor);
     }
 

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -599,7 +599,7 @@ abstract contract TokenizedStrategy {
         // Set decimals based off the `asset`.
         S.decimals = ERC20(_asset).decimals();
 
-        // Set last report to this block.
+        // Set last report to the current block timestamp.
         S.lastReport = uint96(block.timestamp);
 
         // Set the default management address. Can't be 0.

--- a/src/strategies/periphery/BaseHealthCheck.sol
+++ b/src/strategies/periphery/BaseHealthCheck.sol
@@ -141,7 +141,7 @@ abstract contract BaseHealthCheck is BaseStrategy, IBaseHealthCheck {
     }
 
     /**
-     * @notice OVerrides the default {harvestAndReport} to include a healthcheck.
+     * @notice Overrides the default {harvestAndReport} to include a healthcheck.
      * @return _totalAssets New totalAssets post report.
      */
     function harvestAndReport() external override onlySelf returns (uint256 _totalAssets) {

--- a/src/strategies/yieldDonating/PrivilegedYieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/PrivilegedYieldDonatingTokenizedStrategy.sol
@@ -11,29 +11,43 @@ import { Privileged } from "src/core/Privileged.sol";
  * @notice YieldDonatingTokenizedStrategy with privileged-gated deposits and mints.
  */
 contract PrivilegedYieldDonatingTokenizedStrategy is YieldDonatingTokenizedStrategy, Privileged {
+    /// @notice Grant or revoke privileged status for a single account.
     function setPrivileged(address _account, bool _status) external onlyManagement {
         _setPrivileged(_account, _status);
     }
 
+    /// @notice Grant or revoke privileged status for a batch of accounts.
     function setPrivilegedBatch(address[] calldata _accounts, bool _status) external onlyManagement {
         _setPrivilegedBatch(_accounts, _status);
     }
 
+    /// @notice Deposit assets from a privileged caller. The receiver does not need to be privileged.
+    /// @dev Only the caller is gated. A receiver-side check would be redundant because
+    ///      ERC-20 transfers are ungated, so once shares are minted they can move to any
+    ///      address. Restricting to caller-only unblocks legitimate mint-to-contract flows
+    ///      (splitters, aggregators, integrator vaults) while preserving the real trust
+    ///      boundary: who can initiate new share issuance.
     function deposit(uint256 assets, address receiver) public override returns (uint256) {
-        require(isPrivileged(msg.sender) && isPrivileged(receiver), "!privileged");
+        require(isPrivileged(msg.sender), "!privileged");
         return super.deposit(assets, receiver);
     }
 
+    /// @notice Mint shares from a privileged caller. The receiver does not need to be privileged.
+    /// @dev Caller-only gate; see `deposit` for the rationale.
     function mint(uint256 shares, address receiver) public override returns (uint256) {
-        require(isPrivileged(msg.sender) && isPrivileged(receiver), "!privileged");
+        require(isPrivileged(msg.sender), "!privileged");
         return super.mint(shares, receiver);
     }
 
+    /// @notice Returns 0 for non-privileged receivers so front-ends steer users toward the
+    ///         privileged path; a privileged caller may still deposit on their behalf.
     function maxDeposit(address receiver) public view override returns (uint256) {
         if (!isPrivileged(receiver)) return 0;
         return super.maxDeposit(receiver);
     }
 
+    /// @notice Returns 0 for non-privileged receivers so front-ends steer users toward the
+    ///         privileged path; a privileged caller may still mint on their behalf.
     function maxMint(address receiver) public view override returns (uint256) {
         if (!isPrivileged(receiver)) return 0;
         return super.maxMint(receiver);

--- a/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
@@ -36,6 +36,23 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
      * @notice Reports strategy performance and distributes profits as donations
      * @dev Mints profit-derived shares to dragon router when newTotalAssets > oldTotalAssets; on loss, attempts
      *      dragon share burning if enabled. Residual loss reduces PPS (no tracked-loss bucket).
+     *
+     *      Keeper trust assumption: report() timing is at the keeper's discretion and directly controls
+     *      when dragon shares mint (on profit) and burn (on loss). A compromised keeper can time calls
+     *      adversarially — for example, call report() during a temporary dip to burn dragon shares at
+     *      the depressed PPS and then call again on recovery so the rebound is captured as fresh
+     *      dragon-mint profit rather than offsetting the earlier dip; or delay report() through a real
+     *      loss to let users exit at a stale, inflated PPS and socialise the loss across remaining
+     *      holders. These paths are bounded by the dragon router's share balance and degrade yield
+     *      quality rather than drain funds, but they are genuine keeper-side risks.
+     *
+     *      The keeper is a SEMI-TRUSTED role. Mitigation is operational: keeper key custody under
+     *      multisig / MPC, off-chain alerting on report() calls during volatility spikes, and the
+     *      no-cooldown `setKeeper()` rotation path if the key is compromised. `shutdownStrategy`
+     *      can be used as containment to halt new deposits/mints while rotation and assessment
+     *      happen, but it does not block tend() or report(). No on-chain cap on reporting cadence
+     *      is enforced — that would constrain legitimate operation for a threat the trust model
+     *      already accepts.
      */
     function report()
         public

--- a/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
@@ -92,9 +92,14 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
             }
             uint256 sharesToMint = _convertToShares(S, profit, Math.Rounding.Floor);
 
-            // mint the shares to the dragon router
-            _mint(S, _dragonRouter, sharesToMint);
-            emit DonationMinted(_dragonRouter, sharesToMint);
+            // Floor rounding can map dust profit to zero shares; skip the no-op mint and
+            // DonationMinted emission so off-chain indexers do not see a donation event
+            // without a corresponding supply change.
+            if (sharesToMint != 0) {
+                // mint the shares to the dragon router
+                _mint(S, _dragonRouter, sharesToMint);
+                emit DonationMinted(_dragonRouter, sharesToMint);
+            }
         } else {
             unchecked {
                 loss = oldTotalAssets - newTotalAssets;

--- a/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
@@ -18,6 +18,23 @@ import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
  *      - Profit donations are realized via share mints at the time of report
  *      - Losses first attempt dragon share burning when enabled; residual losses decrease PPS
  *      - Dragon router change follows TokenizedStrategy cooldown and two-step finalization
+ *
+ * Terminal-state recovery (operator-managed):
+ *      - After a catastrophic loss that reduces `totalAssets` to 0 while `totalSupply`
+ *        remains positive (all dragon shares burned and residual loss socialized), the
+ *        strategy enters a terminal state: `_convertToShares` returns 0 at the new PPS,
+ *        so deposit() and mint() revert until accounting is restored by a future report
+ *        and conversions no longer round to zero.
+ *      - External donations of the underlying asset are not a dedicated recovery
+ *        mechanism. A donated balance can raise `totalAssets` when report() records it,
+ *        but the value flows proportionally to existing shareholders. At the terminal
+ *        ratio the dragon-mint floors to 0, so no new profit shares accrue to the dragon
+ *        router or donation receiver.
+ *      - This contract does not implement an automatic recovery flow for that state.
+ *        Recovery is operator-managed: call `shutdownStrategy` to stop new deposits while
+ *        operators assess the position and migrate users to a fresh deployment if needed.
+ *        Avoiding a donation-based rescue path prevents reintroducing first-depositor
+ *        dust-extraction style issues.
  */
 
 contract YieldDonatingTokenizedStrategy is TokenizedStrategy {

--- a/src/strategies/yieldSkimming/PrivilegedYieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/PrivilegedYieldSkimmingTokenizedStrategy.sol
@@ -11,29 +11,43 @@ import { Privileged } from "src/core/Privileged.sol";
  * @notice YieldSkimmingTokenizedStrategy with privileged-gated deposits and mints.
  */
 contract PrivilegedYieldSkimmingTokenizedStrategy is YieldSkimmingTokenizedStrategy, Privileged {
+    /// @notice Grant or revoke privileged status for a single account.
     function setPrivileged(address _account, bool _status) external onlyManagement {
         _setPrivileged(_account, _status);
     }
 
+    /// @notice Grant or revoke privileged status for a batch of accounts.
     function setPrivilegedBatch(address[] calldata _accounts, bool _status) external onlyManagement {
         _setPrivilegedBatch(_accounts, _status);
     }
 
+    /// @notice Deposit assets from a privileged caller. The receiver does not need to be privileged.
+    /// @dev Only the caller is gated. A receiver-side check would be redundant because
+    ///      ERC-20 transfers are ungated, so once shares are minted they can move to any
+    ///      address. Restricting to caller-only unblocks legitimate mint-to-contract flows
+    ///      (splitters, aggregators, integrator vaults) while preserving the real trust
+    ///      boundary: who can initiate new share issuance.
     function deposit(uint256 assets, address receiver) public override returns (uint256) {
-        require(isPrivileged(msg.sender) && isPrivileged(receiver), "!privileged");
+        require(isPrivileged(msg.sender), "!privileged");
         return super.deposit(assets, receiver);
     }
 
+    /// @notice Mint shares from a privileged caller. The receiver does not need to be privileged.
+    /// @dev Caller-only gate; see `deposit` for the rationale.
     function mint(uint256 shares, address receiver) public override returns (uint256) {
-        require(isPrivileged(msg.sender) && isPrivileged(receiver), "!privileged");
+        require(isPrivileged(msg.sender), "!privileged");
         return super.mint(shares, receiver);
     }
 
+    /// @notice Returns 0 for non-privileged receivers so front-ends steer users toward the
+    ///         privileged path; a privileged caller may still deposit on their behalf.
     function maxDeposit(address receiver) public view override returns (uint256) {
         if (!isPrivileged(receiver)) return 0;
         return super.maxDeposit(receiver);
     }
 
+    /// @notice Returns 0 for non-privileged receivers so front-ends steer users toward the
+    ///         privileged path; a privileged caller may still mint on their behalf.
     function maxMint(address receiver) public view override returns (uint256) {
         if (!isPrivileged(receiver)) return 0;
         return super.maxMint(receiver);

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -367,6 +367,78 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
     }
 
     /**
+     * @notice Preview the shares that would be minted for a deposit of `assets`.
+     * @dev Returns 0 when the vault is insolvent or the exchange rate is 0. The real
+     *      `deposit` path reverts via `_requireVaultSolvency`, so an inherited preview
+     *      would lie to ERC-4626 integrators that expect `previewDeposit` to match the
+     *      call they are about to make. In the solvent branch the inherited
+     *      `_convertToShares` override already uses the same rate-based math as
+     *      `deposit`, so delegating to `super.previewDeposit` is accurate.
+     * @param assets Amount of assets hypothetically deposited
+     * @return shares Shares a depositor would receive (0 when a real deposit would revert)
+     */
+    function previewDeposit(uint256 assets) public view virtual override returns (uint256 shares) {
+        if (_currentRateRay() == 0 || _isVaultInsolvent()) return 0;
+        return super.previewDeposit(assets);
+    }
+
+    /**
+     * @notice Preview the assets required to mint exactly `shares`.
+     * @dev Mirror of `previewDeposit`: returns 0 when the real `mint` path would revert
+     *      (vault insolvent or exchange rate missing). Solvent branch uses the same
+     *      Ceil-rounded conversion as `mint`.
+     * @param shares Amount of shares hypothetically minted
+     * @return assets Assets a minter would deposit (0 when a real mint would revert)
+     */
+    function previewMint(uint256 shares) public view virtual override returns (uint256 assets) {
+        if (_currentRateRay() == 0 || _isVaultInsolvent()) return 0;
+        return super.previewMint(shares);
+    }
+
+    /**
+     * @notice Preview the shares burned to withdraw `assets`.
+     * @dev The real `withdraw` path applies the lazy dragon burn before pricing the
+     *      exit, so the post-burn `totalSupply` is the correct denominator in the
+     *      insolvent branch. Simulate that burn via `_simulateDragonBurnAmount` and
+     *      mirror the parent pro-rata math (Ceil rounding) against the reduced supply.
+     *      When no burn is pending, the inherited `_convertToShares` override already
+     *      matches `withdraw`, so `super.previewWithdraw` is accurate.
+     * @param assets Amount of assets hypothetically withdrawn
+     * @return shares Shares that would be burned (reflects pending dragon burn)
+     */
+    function previewWithdraw(uint256 assets) public view virtual override returns (uint256 shares) {
+        uint256 burnAmount = _simulateDragonBurnAmount();
+        if (burnAmount == 0) return super.previewWithdraw(assets);
+
+        StrategyData storage S = _strategyStorage();
+        if (S.totalAssets == 0) return 0;
+        uint256 postBurnSupply = _totalSupply(S) - burnAmount;
+        return assets.mulDiv(postBurnSupply, S.totalAssets, Math.Rounding.Ceil);
+    }
+
+    /**
+     * @notice Preview the assets returned for redeeming `shares`.
+     * @dev Mirror of `previewWithdraw`. Dragon-share burning never changes `totalAssets`
+     *      or `totalDebtOwedToUserInAssetValue`, so `_isVaultInsolvent` stays true after
+     *      the simulated burn and the parent pro-rata branch is the one that will fire
+     *      in `redeem`. Floor rounding matches `redeem`'s `_convertToAssets` call.
+     *      The preview is owner-agnostic by ERC-4626 shape; it models the non-dragon
+     *      redemption path because that is where the lazy burn applies. Dragon-owner
+     *      redemptions use `maxRedeem` for sizing, which already has its own override.
+     * @param shares Amount of shares hypothetically redeemed
+     * @return assets Assets a redeemer would receive (reflects pending dragon burn)
+     */
+    function previewRedeem(uint256 shares) public view virtual override returns (uint256 assets) {
+        uint256 burnAmount = _simulateDragonBurnAmount();
+        if (burnAmount == 0) return super.previewRedeem(shares);
+
+        StrategyData storage S = _strategyStorage();
+        uint256 postBurnSupply = _totalSupply(S) - burnAmount;
+        if (postBurnSupply == 0) return 0;
+        return shares.mulDiv(S.totalAssets, postBurnSupply, Math.Rounding.Floor);
+    }
+
+    /**
      * @notice Transfer shares with dragon solvency protection and debt rebalancing
      * @dev Special behaviors for dragon router:
      *      - Dragon cannot transfer to itself (reverts)

--- a/test/integration/strategies/PrivilegedYieldDonating/PrivilegedMorphoCompounderStrategy.t.sol
+++ b/test/integration/strategies/PrivilegedYieldDonating/PrivilegedMorphoCompounderStrategy.t.sol
@@ -128,8 +128,8 @@ contract PrivilegedMorphoCompounderStrategyTest is BasePrivilegedYieldDonatingIn
         _testDepositRevertsWhenSenderNotPrivileged();
     }
 
-    function testDepositRevertsWhenReceiverNotPrivileged() public {
-        _testDepositRevertsWhenReceiverNotPrivileged();
+    function testDepositSucceedsToNonPrivilegedReceiver() public {
+        _testDepositSucceedsToNonPrivilegedReceiver();
     }
 
     function testDepositSucceedsWhenBothPrivileged() public {
@@ -140,8 +140,8 @@ contract PrivilegedMorphoCompounderStrategyTest is BasePrivilegedYieldDonatingIn
         _testMintRevertsWhenSenderNotPrivileged();
     }
 
-    function testMintRevertsWhenReceiverNotPrivileged() public {
-        _testMintRevertsWhenReceiverNotPrivileged();
+    function testMintSucceedsToNonPrivilegedReceiver() public {
+        _testMintSucceedsToNonPrivilegedReceiver();
     }
 
     function testMintSucceedsWhenBothPrivileged() public {

--- a/test/integration/strategies/PrivilegedYieldDonating/PrivilegedSkyCompounderStrategy.t.sol
+++ b/test/integration/strategies/PrivilegedYieldDonating/PrivilegedSkyCompounderStrategy.t.sol
@@ -125,8 +125,8 @@ contract PrivilegedSkyCompounderStrategyTest is BasePrivilegedYieldDonatingInteg
         _testDepositRevertsWhenSenderNotPrivileged();
     }
 
-    function testDepositRevertsWhenReceiverNotPrivileged() public {
-        _testDepositRevertsWhenReceiverNotPrivileged();
+    function testDepositSucceedsToNonPrivilegedReceiver() public {
+        _testDepositSucceedsToNonPrivilegedReceiver();
     }
 
     function testDepositSucceedsWhenBothPrivileged() public {
@@ -137,8 +137,8 @@ contract PrivilegedSkyCompounderStrategyTest is BasePrivilegedYieldDonatingInteg
         _testMintRevertsWhenSenderNotPrivileged();
     }
 
-    function testMintRevertsWhenReceiverNotPrivileged() public {
-        _testMintRevertsWhenReceiverNotPrivileged();
+    function testMintSucceedsToNonPrivilegedReceiver() public {
+        _testMintSucceedsToNonPrivilegedReceiver();
     }
 
     function testMintSucceedsWhenBothPrivileged() public {

--- a/test/integration/strategies/PrivilegedYieldSkimming/PrivilegedLidoStrategy.t.sol
+++ b/test/integration/strategies/PrivilegedYieldSkimming/PrivilegedLidoStrategy.t.sol
@@ -125,8 +125,8 @@ contract PrivilegedLidoStrategyTest is BasePrivilegedYieldSkimmingIntegrationTes
         _testDepositRevertsWhenSenderNotPrivileged();
     }
 
-    function testDepositRevertsWhenReceiverNotPrivileged() public {
-        _testDepositRevertsWhenReceiverNotPrivileged();
+    function testDepositSucceedsToNonPrivilegedReceiver() public {
+        _testDepositSucceedsToNonPrivilegedReceiver();
     }
 
     function testDepositSucceedsWhenBothPrivileged() public {
@@ -137,8 +137,8 @@ contract PrivilegedLidoStrategyTest is BasePrivilegedYieldSkimmingIntegrationTes
         _testMintRevertsWhenSenderNotPrivileged();
     }
 
-    function testMintRevertsWhenReceiverNotPrivileged() public {
-        _testMintRevertsWhenReceiverNotPrivileged();
+    function testMintSucceedsToNonPrivilegedReceiver() public {
+        _testMintSucceedsToNonPrivilegedReceiver();
     }
 
     function testMintSucceedsWhenBothPrivileged() public {

--- a/test/integration/strategies/PrivilegedYieldSkimming/PrivilegedRocketPoolStrategy.t.sol
+++ b/test/integration/strategies/PrivilegedYieldSkimming/PrivilegedRocketPoolStrategy.t.sol
@@ -124,8 +124,8 @@ contract PrivilegedRocketPoolStrategyTest is BasePrivilegedYieldSkimmingIntegrat
         _testDepositRevertsWhenSenderNotPrivileged();
     }
 
-    function testDepositRevertsWhenReceiverNotPrivileged() public {
-        _testDepositRevertsWhenReceiverNotPrivileged();
+    function testDepositSucceedsToNonPrivilegedReceiver() public {
+        _testDepositSucceedsToNonPrivilegedReceiver();
     }
 
     function testDepositSucceedsWhenBothPrivileged() public {
@@ -136,8 +136,8 @@ contract PrivilegedRocketPoolStrategyTest is BasePrivilegedYieldSkimmingIntegrat
         _testMintRevertsWhenSenderNotPrivileged();
     }
 
-    function testMintRevertsWhenReceiverNotPrivileged() public {
-        _testMintRevertsWhenReceiverNotPrivileged();
+    function testMintSucceedsToNonPrivilegedReceiver() public {
+        _testMintSucceedsToNonPrivilegedReceiver();
     }
 
     function testMintSucceedsWhenBothPrivileged() public {

--- a/test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol
@@ -76,6 +76,15 @@ contract KpkERC4626StrategyTest is BaseYieldDonatingIntegrationTest {
 
     // ========== SETUP ==========
 
+    /// @dev Pin the mainnet fork to a block where all four KPK vaults have non-zero
+    ///      `maxDeposit`. Karpatkey periodically caps the MetaMorpho Prime vaults to 0 during
+    ///      rebalances, which would otherwise make these tests flake against mainnet `latest`.
+    ///      See `KpkTestConfig.FORK_BLOCK` for the rationale and how to refresh the pin.
+    function _setupFork() internal virtual override {
+        mainnetFork = vm.createFork("mainnet", KpkTestConfig.FORK_BLOCK);
+        vm.selectFork(mainnetFork);
+    }
+
     function _etchImplementation() internal override {
         implementation = new YieldDonatingTokenizedStrategy{ salt: keccak256("OCT_YIELD_DONATING_STRATEGY_V1") }();
         bytes memory tokenizedStrategyBytecode = address(implementation).code;

--- a/test/integration/strategies/base/BasePrivilegedIntegrationTest.sol
+++ b/test/integration/strategies/base/BasePrivilegedIntegrationTest.sol
@@ -171,8 +171,12 @@ abstract contract BasePrivilegedIntegrationTest is Test {
         vm.stopPrank();
     }
 
-    /// @notice Test that deposit reverts when receiver is not privileged
-    function _testDepositRevertsWhenReceiverNotPrivileged() internal {
+    /// @notice Test that deposit from a privileged sender succeeds even when the receiver
+    ///         is not privileged. The caller-side check is the real trust boundary; a
+    ///         receiver-side check would be redundant because ERC-20 transfers are ungated,
+    ///         so mint-to-contract flows (splitters, aggregators, integrator vaults) must
+    ///         not be blocked at the mint step.
+    function _testDepositSucceedsToNonPrivilegedReceiver() internal {
         uint256 depositAmount = _minDeposit();
         address privileged = _privilegedUser();
         address nonPrivileged = _nonPrivilegedUser();
@@ -181,9 +185,12 @@ abstract contract BasePrivilegedIntegrationTest is Test {
 
         vm.startPrank(privileged);
         ERC20(_asset()).approve(address(_vault()), depositAmount);
-        vm.expectRevert("!privileged");
-        _vault().deposit(depositAmount, nonPrivileged); // Sender is privileged, but receiver is not
+        uint256 shares = _vault().deposit(depositAmount, nonPrivileged);
         vm.stopPrank();
+
+        assertGt(shares, 0, "Should receive shares");
+        assertEq(_vault().balanceOf(nonPrivileged), shares, "Non-privileged receiver should hold the shares");
+        assertEq(_vault().balanceOf(privileged), 0, "Sender should not have any shares");
     }
 
     /// @notice Test that deposit works when both sender and receiver are privileged
@@ -219,8 +226,10 @@ abstract contract BasePrivilegedIntegrationTest is Test {
         vm.stopPrank();
     }
 
-    /// @notice Test that mint reverts when receiver is not privileged
-    function _testMintRevertsWhenReceiverNotPrivileged() internal {
+    /// @notice Test that mint from a privileged sender succeeds even when the receiver is
+    ///         not privileged. Mirror of the deposit helper so ERC-4626 `mint` matches
+    ///         `deposit` on the caller-only gate.
+    function _testMintSucceedsToNonPrivilegedReceiver() internal {
         uint256 shareAmount = _minDeposit();
         address privileged = _privilegedUser();
         address nonPrivileged = _nonPrivilegedUser();
@@ -230,9 +239,12 @@ abstract contract BasePrivilegedIntegrationTest is Test {
 
         vm.startPrank(privileged);
         ERC20(_asset()).approve(address(_vault()), type(uint256).max);
-        vm.expectRevert("!privileged");
-        _vault().mint(shareAmount, nonPrivileged);
+        uint256 assets = _vault().mint(shareAmount, nonPrivileged);
         vm.stopPrank();
+
+        assertGt(assets, 0, "Should consume assets");
+        assertEq(_vault().balanceOf(nonPrivileged), shareAmount, "Non-privileged receiver should hold the shares");
+        assertEq(_vault().balanceOf(privileged), 0, "Sender should not have any shares");
     }
 
     /// @notice Test that mint works when both sender and receiver are privileged

--- a/test/integration/strategies/config/KpkTestConfig.sol
+++ b/test/integration/strategies/config/KpkTestConfig.sol
@@ -33,6 +33,16 @@ library KpkTestConfig {
     /// @notice Tokenized strategy implementation address
     address internal constant TOKENIZED_STRATEGY_ADDRESS = 0x8cf7246a74704bBE59c9dF614ccB5e3d9717d8Ac;
 
+    /// @notice Mainnet block used for the Kpk integration fork.
+    /// @dev Karpatkey curates the KPK MetaMorpho vaults on Morpho and periodically caps their
+    ///      `maxDeposit` to 0 while rebalancing or waiting for liquidity. When the fork runs on
+    ///      mainnet `latest`, the deposit-side tests fail with `ERC4626: deposit more than max`
+    ///      during those windows even though the strategy code is correct. Pinning to a block
+    ///      where all four KPK vaults (ETH Prime, USDC Prime, Gearbox WETH, Gearbox wstETH) are
+    ///      uncapped keeps the suite deterministic against curator policy changes. Update only if
+    ///      the pinned block itself drifts out of the healthy window.
+    uint256 internal constant FORK_BLOCK = 24_800_000;
+
     // ========== USDC CONFIGURATION ==========
 
     /// @notice Minimum deposit amount for USDC fuzz tests (6 decimals)

--- a/test/unit/core/PrivilegedIdempotency.t.sol
+++ b/test/unit/core/PrivilegedIdempotency.t.sol
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.25;
+
+import { Test, Vm } from "forge-std/Test.sol";
+import { Privileged } from "src/core/Privileged.sol";
+
+/// @notice Thin harness that exposes Privileged internals for testing.
+contract PrivilegedHarness is Privileged {
+    function setPrivileged(address _account, bool _status) external {
+        _setPrivileged(_account, _status);
+    }
+
+    function setPrivilegedBatch(address[] calldata _accounts, bool _status) external {
+        _setPrivilegedBatch(_accounts, _status);
+    }
+}
+
+/// @notice Regression suite for `_setPrivileged` idempotency: neither `_setPrivileged`
+///         nor `_setPrivilegedBatch` may emit `PrivilegedUpdated` (or SSTORE) when the
+///         stored flag already matches the requested value.
+contract PrivilegedIdempotencyTest is Test {
+    PrivilegedHarness internal harness;
+
+    bytes32 internal constant PRIVILEGED_UPDATED_SIG = keccak256("PrivilegedUpdated(address,bool)");
+
+    address internal alice = makeAddr("alice");
+    address internal bob = makeAddr("bob");
+    address internal carol = makeAddr("carol");
+
+    function setUp() public {
+        harness = new PrivilegedHarness();
+    }
+
+    function _countPrivilegedUpdatedLogs(Vm.Log[] memory logs) internal pure returns (uint256 count) {
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (logs[i].topics.length > 0 && logs[i].topics[0] == PRIVILEGED_UPDATED_SIG) {
+                count++;
+            }
+        }
+    }
+
+    function test_setPrivileged_emitsOnFalseToTrue() public {
+        assertFalse(harness.isPrivileged(alice), "alice starts non-privileged");
+
+        vm.recordLogs();
+        harness.setPrivileged(alice, true);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(_countPrivilegedUpdatedLogs(logs), 1, "exactly one event on real change");
+        assertTrue(harness.isPrivileged(alice), "alice now privileged");
+    }
+
+    function test_setPrivileged_emitsOnTrueToFalse() public {
+        harness.setPrivileged(alice, true);
+
+        vm.recordLogs();
+        harness.setPrivileged(alice, false);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(_countPrivilegedUpdatedLogs(logs), 1, "exactly one event on real revocation");
+        assertFalse(harness.isPrivileged(alice), "alice revoked");
+    }
+
+    function test_setPrivileged_skipsNoOpWhenAlreadyTrue() public {
+        harness.setPrivileged(alice, true);
+
+        vm.recordLogs();
+        harness.setPrivileged(alice, true);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(_countPrivilegedUpdatedLogs(logs), 0, "no event on no-op");
+        assertTrue(harness.isPrivileged(alice), "state unchanged");
+    }
+
+    function test_setPrivileged_skipsNoOpWhenAlreadyFalse() public {
+        // alice has never been set, so the mapping default is false.
+        vm.recordLogs();
+        harness.setPrivileged(alice, false);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(_countPrivilegedUpdatedLogs(logs), 0, "no event when setting default value");
+        assertFalse(harness.isPrivileged(alice), "state unchanged");
+    }
+
+    function test_setPrivilegedBatch_emitsOnlyForRealChanges() public {
+        // Pre-set alice and bob to true; carol stays at default (false).
+        harness.setPrivileged(alice, true);
+        harness.setPrivileged(bob, true);
+
+        address[] memory batch = new address[](3);
+        batch[0] = alice; // already true, no-op
+        batch[1] = bob; // already true, no-op
+        batch[2] = carol; // false -> true, real change
+
+        vm.recordLogs();
+        harness.setPrivilegedBatch(batch, true);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(_countPrivilegedUpdatedLogs(logs), 1, "only carol emits");
+        assertTrue(harness.isPrivileged(alice), "alice still privileged");
+        assertTrue(harness.isPrivileged(bob), "bob still privileged");
+        assertTrue(harness.isPrivileged(carol), "carol now privileged");
+    }
+
+    function test_setPrivilegedBatch_allNoOpsEmitNothing() public {
+        // Default state: all three accounts are false. Setting them to false again is a no-op batch.
+        address[] memory batch = new address[](3);
+        batch[0] = alice;
+        batch[1] = bob;
+        batch[2] = carol;
+
+        vm.recordLogs();
+        harness.setPrivilegedBatch(batch, false);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(_countPrivilegedUpdatedLogs(logs), 0, "no events when every entry matches");
+    }
+
+    function test_setPrivilegedBatch_emitsOnlyOnceForRevokedSubset() public {
+        harness.setPrivileged(alice, true);
+        harness.setPrivileged(carol, true);
+        // bob stays false.
+
+        address[] memory batch = new address[](3);
+        batch[0] = alice; // true -> false, real change
+        batch[1] = bob; // false -> false, no-op
+        batch[2] = carol; // true -> false, real change
+
+        vm.recordLogs();
+        harness.setPrivilegedBatch(batch, false);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(_countPrivilegedUpdatedLogs(logs), 2, "emits for alice and carol only");
+        assertFalse(harness.isPrivileged(alice), "alice revoked");
+        assertFalse(harness.isPrivileged(bob), "bob unchanged");
+        assertFalse(harness.isPrivileged(carol), "carol revoked");
+    }
+}

--- a/test/unit/strategies/yieldDonating/YieldDonatingDustMint.t.sol
+++ b/test/unit/strategies/yieldDonating/YieldDonatingDustMint.t.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.25;
+
+import { Setup } from "./utils/Setup.sol";
+import { Vm } from "forge-std/Test.sol";
+import { TokenizedStrategy } from "src/core/TokenizedStrategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+
+/// @notice Regression suite for the dust-profit donation path: when Floor rounding maps
+///         positive profit to zero donation shares, `report()` must skip both the `_mint`
+///         and the `DonationMinted` event so the off-chain event stream never sees a
+///         donation without a corresponding supply change.
+contract YieldDonatingDustMintTest is Setup {
+    /// @dev ERC-7201 base slot derived from "octant.tokenized.strategy.storage". Matches the
+    ///      `OCTANT_STRATEGY_STORAGE` constant inside `TokenizedStrategy`.
+    bytes32 internal constant OCTANT_STRATEGY_STORAGE =
+        keccak256(abi.encode(uint256(keccak256("octant.tokenized.strategy.storage")) - 1)) & ~bytes32(uint256(0xff));
+
+    /// @dev StrategyData.totalSupply sits at offset 8 from the base (nonces, balances,
+    ///      allowances, asset, name, symbol, cachedDomainSeparator, cachedChainId).
+    bytes32 internal constant TOTAL_SUPPLY_SLOT = bytes32(uint256(OCTANT_STRATEGY_STORAGE) + 8);
+
+    /// @dev StrategyData.totalAssets sits one slot after totalSupply.
+    bytes32 internal constant TOTAL_ASSETS_SLOT = bytes32(uint256(OCTANT_STRATEGY_STORAGE) + 9);
+
+    bytes32 internal constant DONATION_MINTED_SIG = keccak256("DonationMinted(address,uint256)");
+
+    function setUp() public override {
+        super.setUp();
+    }
+
+    /// @notice Direct write to the strategy's namespaced storage. Used to construct a
+    ///         PPS > 1 state that Floor rounding can map to zero shares without having
+    ///         to drive the contract through the long path required to accumulate that
+    ///         rounding drift organically.
+    function _writeStrategyState(uint256 totalSupply_, uint256 totalAssets_) internal {
+        vm.store(address(strategy), TOTAL_SUPPLY_SLOT, bytes32(totalSupply_));
+        vm.store(address(strategy), TOTAL_ASSETS_SLOT, bytes32(totalAssets_));
+    }
+
+    function _countDonationMintedLogs(Vm.Log[] memory logs) internal view returns (uint256 count) {
+        for (uint256 i = 0; i < logs.length; i++) {
+            if (
+                logs[i].emitter == address(strategy) &&
+                logs[i].topics.length > 0 &&
+                logs[i].topics[0] == DONATION_MINTED_SIG
+            ) {
+                count++;
+            }
+        }
+    }
+
+    /// @notice Dust profit: totalSupply = 1, totalAssets = 2, yield source holds 3. Profit is
+    ///         1 wei; `_convertToShares(1, Floor) = 1 * 1 / 2 = 0`. Fix skips the zero-share
+    ///         mint and its event. Pre-fix, `_mint(dragon, 0)` executed and `DonationMinted`
+    ///         was emitted with amount 0.
+    function test_reportDustProfit_noMintNoEvent() public {
+        _writeStrategyState({ totalSupply_: 1, totalAssets_: 2 });
+        asset.mint(address(yieldSource), 3);
+
+        uint256 supplyBefore = strategy.totalSupply();
+        uint256 dragonBalBefore = strategy.balanceOf(donationAddress);
+
+        vm.recordLogs();
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = strategy.report();
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(profit, 1, "profit should be 1 wei");
+        assertEq(loss, 0, "no loss on profit path");
+        assertEq(strategy.totalSupply(), supplyBefore, "no shares minted on zero-share path");
+        assertEq(strategy.balanceOf(donationAddress), dragonBalBefore, "dragon balance unchanged");
+        assertEq(strategy.totalAssets(), 3, "totalAssets still reconciled to yield-source balance");
+        assertEq(_countDonationMintedLogs(logs), 0, "no DonationMinted event on zero-share dust");
+    }
+
+    /// @notice Sanity check: when profit rounds to a non-zero share amount the mint and the
+    ///         DonationMinted event still fire. Protects against over-guarding the dust path.
+    function test_reportProfit_emitsDonationMintedWhenSharesRoundUp() public {
+        // totalSupply = 2, totalAssets = 2 (PPS = 1). Profit of 3 -> 3 * 2 / 2 = 3 shares.
+        _writeStrategyState({ totalSupply_: 2, totalAssets_: 2 });
+        asset.mint(address(yieldSource), 5);
+
+        vm.recordLogs();
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = strategy.report();
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+
+        assertEq(profit, 3, "profit should be 3 wei");
+        assertEq(loss, 0, "no loss on profit path");
+        assertEq(_countDonationMintedLogs(logs), 1, "DonationMinted emitted on real share mint");
+        assertEq(strategy.balanceOf(donationAddress), 3, "dragon received 3 shares");
+    }
+}

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingPreview.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingPreview.t.sol
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity >=0.8.18;
+
+import { Setup, IMockStrategy } from "./utils/Setup.sol";
+import { MockStrategySkimming } from "test/mocks/core/tokenized-strategies/MockStrategySkimming.sol";
+import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
+
+/// @notice Regression suite for yield-skimming preview accuracy: ERC-4626 `previewX` must
+///         match the real `deposit` / `mint` / `withdraw` / `redeem` call including the
+///         strategy-specific gates (insolvency revert on deposit/mint, lazy dragon burn on
+///         withdraw/redeem). Without the overrides, `previewDeposit(x)` in an insolvent
+///         vault returns a positive share estimate even though the real `deposit` reverts
+///         with "Cannot operate when vault is insolvent".
+contract YieldSkimmingPreviewTest is Setup {
+    uint256 internal constant INITIAL_RATE = 1e18;
+    uint256 internal constant DEPOSIT_AMOUNT = 100e18;
+
+    function setUp() public override {
+        super.setUp();
+    }
+
+    /// @dev Drops the exchange rate to force `_isVaultInsolvent` -> true. After a deposit
+    ///      at the initial rate, halving the rate leaves `currentVaultValue` below
+    ///      `totalDebtOwedToUserInAssetValue` (which was locked in at the higher rate).
+    function _makeInsolventAfterDeposit(uint256 newRate) internal {
+        MockStrategySkimming(address(strategy)).updateExchangeRate(newRate);
+        assertTrue(
+            YieldSkimmingTokenizedStrategy(address(strategy)).isVaultInsolvent(),
+            "setup: vault should be insolvent after rate drop"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Deposit / mint: preview mirrors the solvency gate that `deposit` / `mint`
+    // enforce via `_requireVaultSolvency`.
+    // -------------------------------------------------------------------------
+
+    function test_previewDeposit_matchesDepositWhenSolvent(uint256 _amount) public {
+        _amount = bound(_amount, 1e6, 1e24);
+
+        // Seed the vault so totalSupply > 0 (otherwise previewDeposit takes the
+        // 1:1 fallback in _convertToShares and we aren't exercising the rate path).
+        mintAndDepositIntoStrategy(strategy, user, DEPOSIT_AMOUNT);
+
+        uint256 predicted = strategy.previewDeposit(_amount);
+
+        // Fund a fresh user and deposit to measure the real return.
+        address alice = makeAddr("alice");
+        yieldSource.mint(alice, _amount);
+        vm.prank(alice);
+        yieldSource.approve(address(strategy), _amount);
+
+        vm.prank(alice);
+        uint256 actual = strategy.deposit(_amount, alice);
+
+        assertEq(predicted, actual, "previewDeposit must equal actual deposit shares");
+    }
+
+    function test_previewDeposit_returnsZeroWhenInsolvent() public {
+        mintAndDepositIntoStrategy(strategy, user, DEPOSIT_AMOUNT);
+
+        _makeInsolventAfterDeposit(INITIAL_RATE / 2);
+
+        assertEq(strategy.previewDeposit(1e18), 0, "previewDeposit must return 0 while the real deposit would revert");
+    }
+
+    function test_previewMint_matchesMintWhenSolvent(uint256 _shares) public {
+        _shares = bound(_shares, 1e6, 1e24);
+
+        mintAndDepositIntoStrategy(strategy, user, DEPOSIT_AMOUNT);
+
+        uint256 predicted = strategy.previewMint(_shares);
+
+        address bob = makeAddr("bob");
+        yieldSource.mint(bob, predicted + 1e18); // a little slack for rounding
+        vm.prank(bob);
+        yieldSource.approve(address(strategy), type(uint256).max);
+
+        vm.prank(bob);
+        uint256 actual = strategy.mint(_shares, bob);
+
+        assertEq(predicted, actual, "previewMint must equal actual mint assets");
+    }
+
+    function test_previewMint_returnsZeroWhenInsolvent() public {
+        mintAndDepositIntoStrategy(strategy, user, DEPOSIT_AMOUNT);
+
+        _makeInsolventAfterDeposit(INITIAL_RATE / 2);
+
+        assertEq(strategy.previewMint(1e18), 0, "previewMint must return 0 while the real mint would revert");
+    }
+
+    // -------------------------------------------------------------------------
+    // Withdraw / redeem: with no pending dragon burn the inherited preview math
+    // is correct; exercise it to lock in the happy path.
+    // -------------------------------------------------------------------------
+
+    function test_previewRedeem_matchesRedeemWhenSolvent(uint256 _shares) public {
+        mintAndDepositIntoStrategy(strategy, user, DEPOSIT_AMOUNT);
+
+        uint256 userShares = strategy.balanceOf(user);
+        _shares = bound(_shares, 1, userShares);
+
+        uint256 predicted = strategy.previewRedeem(_shares);
+
+        vm.prank(user);
+        uint256 actual = strategy.redeem(_shares, user, user);
+
+        assertEq(predicted, actual, "previewRedeem must equal actual redeem assets");
+    }
+
+    function test_previewWithdraw_matchesWithdrawWhenSolvent(uint256 _assets) public {
+        mintAndDepositIntoStrategy(strategy, user, DEPOSIT_AMOUNT);
+
+        uint256 maxAssets = strategy.maxWithdraw(user);
+        _assets = bound(_assets, 1, maxAssets);
+
+        uint256 predicted = strategy.previewWithdraw(_assets);
+
+        uint256 sharesBefore = strategy.balanceOf(user);
+        vm.prank(user);
+        strategy.withdraw(_assets, user, user);
+        uint256 sharesAfter = strategy.balanceOf(user);
+        uint256 actual = sharesBefore - sharesAfter;
+
+        assertEq(predicted, actual, "previewWithdraw must equal actual shares burned");
+    }
+
+    // -------------------------------------------------------------------------
+    // Redeem with a pending lazy dragon burn: preview must price against the
+    // POST-burn supply, otherwise it underestimates the assets a user receives.
+    // -------------------------------------------------------------------------
+
+    function test_previewRedeem_reflectsPendingDragonBurn() public {
+        // Enable burning so `_applyDragonLossProtectionIfNeeded` actually fires
+        // on the redeem path we are testing.
+        vm.prank(management);
+        YieldSkimmingTokenizedStrategy(address(strategy)).setEnableBurning(true);
+
+        // User deposits and locks in a value debt of DEPOSIT_AMOUNT at the initial rate.
+        mintAndDepositIntoStrategy(strategy, user, DEPOSIT_AMOUNT);
+
+        // Report a profit so the dragon router receives shares that can be burned.
+        // Bump the yield-source balance of the strategy to simulate appreciation,
+        // then call report() to mint dragon shares at the higher rate.
+        MockStrategySkimming(address(strategy)).updateExchangeRate((INITIAL_RATE * 12) / 10); // +20%
+        vm.prank(keeper);
+        strategy.report();
+        assertGt(strategy.balanceOf(donationAddress), 0, "dragon must hold shares for burn simulation");
+
+        // Drop the rate back below the user's locked-in debt to cause insolvency.
+        // The lazy burn logic will then be eligible during `redeem`.
+        MockStrategySkimming(address(strategy)).updateExchangeRate(INITIAL_RATE / 2);
+        assertTrue(
+            YieldSkimmingTokenizedStrategy(address(strategy)).isVaultInsolvent(),
+            "vault must be insolvent for the lazy burn to fire"
+        );
+
+        // Preview the user's redeem with the burn pending, then execute redeem and
+        // confirm the real output matches the preview (post-burn pricing).
+        uint256 userShares = strategy.balanceOf(user);
+        uint256 predicted = strategy.previewRedeem(userShares);
+
+        vm.prank(user);
+        uint256 actual = strategy.redeem(userShares, user, user);
+
+        assertEq(predicted, actual, "previewRedeem must mirror post-burn redeem math");
+    }
+}


### PR DESCRIPTION
## Summary

Cleanup sweep covering ten small-surface Bailsec findings that did not fit into the focused per-component PRs (#413 yield-skim, #414 aave, #415 yield-forwarder, #417 swappers, #419 yield-donating). Each audit finding now ships as exactly one conventional commit so reviewers can inspect each issue independently. A final `test(kpk)` commit pins the Kpk integration fork to a block where the MetaMorpho vaults accept deposits, unblocking the suite from the karpatkey curator capacity-cap behaviour.

Note: Cantina C-4 / OSU-1204 (MultiStrategyVault deposit DoS during yield-skimming insolvency) was already fixed before this PR in PR #263 / `96ebf6d9`; this PR does not claim closure for it.

| # | Severity | Action | Subject | Commit |
|---|---|---|---|---|
| 3 | Low | ACK + DOC | Permit frontrun grief — NatSpec on `permit()` | `3bdd8d66` |
| 9 | Info | FIX | `lastReport` inline comment: block → timestamp | `520ff43f` |
| 12 | Info | ACK + DOC | Fee-on-transfer / rebasing tokens unsupported (NatSpec on `asset`) | `2176b205` |
| 15 | Info | FIX | `_setPrivileged` idempotency — skip no-op writes and events | `59fd35a3` |
| 16 | Governance | ACK + DOC | Keeper timing trust assumption on `report()` | `3c1123b9` |
| 19 | Low | ACK + DOC | Terminal-state recovery is operator-managed; no dedicated donation recovery path | `5fef432e` |
| 20 | Low | FIX | Override preview functions to mirror deposit/redeem gates (yield-skim) | `cd5009e8` |
| 21 | Info | FIX | Skip zero-share donation mint and event on dust profit | `3e847c42` |
| 22 | Info | FIX | Drop receiver-side gate on privileged `deposit` / `mint` | `4c0e83d5` |
| 43 | Info | FIX | NatSpec typo `OVerrides` on `harvestAndReport` | `12716f7d` |

Plus one test-infra commit (not a finding):

| Commit | Subject |
|---|---|
| `a2ebb4a3` | `test(kpk)` — pin mainnet fork to block 24 800 000 where all four KPK vaults accept deposits |

## Source impact

- `src/core/Privileged.sol` — idempotency guard (#15)
- `src/core/TokenizedStrategy.sol` — preview funcs promoted from `external` to `public virtual` (#20); asset NatSpec extended for FOT (#12); permit grief `@dev` note (#3); `lastReport` inline comment (#9)
- `src/strategies/periphery/BaseHealthCheck.sol` — NatSpec typo (#43)
- `src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol` — dust-mint guard (#21); terminal-state NatSpec (#19); keeper-trust NatSpec (#16)
- `src/strategies/yieldDonating/PrivilegedYieldDonatingTokenizedStrategy.sol` — drop receiver gate (#22)
- `src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol` — 4 preview overrides (#20)
- `src/strategies/yieldSkimming/PrivilegedYieldSkimmingTokenizedStrategy.sol` — drop receiver gate (#22 mirror)
- `test/integration/strategies/config/KpkTestConfig.sol` — `FORK_BLOCK = 24_800_000` constant
- `test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol` — override `_setupFork()` to pin
- Tests: `PrivilegedIdempotency.t.sol`, `YieldDonatingDustMint.t.sol`, `YieldSkimmingPreview.t.sol` + integration test renames (4 files) + Base helper inversion for #22

## Test plan

- [x] `forge test --match-path "test/unit/core/PrivilegedIdempotency.t.sol"` — 7/7 pass
- [x] `forge test --match-path "test/unit/strategies/yieldDonating/YieldDonatingDustMint.t.sol"` — 2/2 pass
- [x] `forge test --match-path "test/unit/strategies/yieldSkimming/YieldSkimmingPreview.t.sol"` — 7/7 pass (including pending-burn redeem scenario)
- [x] `forge test --match-path "test/unit/strategies/yieldDonating/ReportLifecycle.t.sol"` — 14/14 pass (no regression on dust-mint skip)
- [x] `bash script/check-natspec.sh` — clean
- [x] Prettier check over Solidity sources — clean
- [x] Commitlint over `develop..HEAD` — clean
- [x] Solhint on changed Solidity files — 0 errors (repo warnings only)
- [x] Final rewritten tree matches the pre-rewrite PR head exactly
- [x] `git merge-tree --write-tree` against every other open PR (#413 / #414 / #415 / #417 / #419) — CLEAN on all five at rewritten PR head
- [x] CI green

## Merge-conflict guarantee

Every file this PR modifies is disjoint from every other open audit-fix PR's file list. The `test(kpk)` commit does add an override to `KpkERC4626Strategy.t.sol`, which PR #419 also touches for the Kpk fork integration-test migration — verified CLEAN via `git merge-tree` because the two PRs' hunks are in different regions (PR #419 migrates `vm.mockCall` selectors, this PR adds a new `_setupFork` override).


