### PR TITLE
fix(tokenized-strategy): bailsec #8 emit emergency withdraw event

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,9 +31,10 @@ jobs:
           HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
           BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
           HEAD_BRANCH: ${{ github.head_ref }}
+          BASE_BRANCH: ${{ github.base_ref }}
         run: |
           private_ci_supported=true
-          expected_branches="feature/*, fix/*, bugfix/*, hotfix/*, release/*, chore/*, ci/*, docs/*, test/*, refactor/*, perf/*"
+          expected_branches="feature/*, fix/*, bugfix/*, hotfix/*, release/*, chore/*, ci/*, docs/*, test/*, refactor/*, perf/*, or master -> develop release sync"
 
           if [ "$HEAD_REPOSITORY" != "$BASE_REPOSITORY" ]; then
             private_ci_supported=false
@@ -42,6 +43,12 @@ jobs:
 
           case "$HEAD_BRANCH" in
             feature/*|fix/*|bugfix/*|hotfix/*|release/*|chore/*|ci/*|docs/*|test/*|refactor/*|perf/*)
+              ;;
+            master)
+              if [ "$BASE_BRANCH" != "develop" ]; then
+                private_ci_supported=false
+                echo "::error title=Unsupported branch name::Branch '$HEAD_BRANCH' is allowed only for release sync PRs targeting develop."
+              fi
               ;;
             *)
               private_ci_supported=false
@@ -60,6 +67,7 @@ jobs:
               echo "| Head repository | $HEAD_REPOSITORY |"
               echo "| Base repository | $BASE_REPOSITORY |"
               echo "| Head branch | $HEAD_BRANCH |"
+              echo "| Base branch | $BASE_BRANCH |"
               echo "| Expected branch names | $expected_branches |"
               echo ""
               echo "Private-container CI can run only for branches in the base repository because fork PRs do not receive the required secrets."

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,9 +17,60 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr_preflight:
+    name: PR Preflight
+    if: github.head_ref != 'main'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    outputs:
+      private_ci_supported: ${{ steps.check.outputs.private_ci_supported }}
+    steps:
+      - name: Check PR source and branch
+        id: check
+        env:
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_BRANCH: ${{ github.head_ref }}
+        run: |
+          private_ci_supported=true
+          expected_branches="feature/*, fix/*, bugfix/*, hotfix/*, release/*, chore/*, ci/*, docs/*, test/*, refactor/*, perf/*"
+
+          if [ "$HEAD_REPOSITORY" != "$BASE_REPOSITORY" ]; then
+            private_ci_supported=false
+            echo "::error title=Unsupported PR source::PR Standards Check uses private container images. GitHub does not expose the required secrets to fork PRs. Push this branch to $BASE_REPOSITORY and open the PR from there."
+          fi
+
+          case "$HEAD_BRANCH" in
+            feature/*|fix/*|bugfix/*|hotfix/*|release/*|chore/*|ci/*|docs/*|test/*|refactor/*|perf/*)
+              ;;
+            *)
+              private_ci_supported=false
+              echo "::error title=Unsupported branch name::Branch '$HEAD_BRANCH' does not match the expected naming convention: $expected_branches."
+              ;;
+          esac
+
+          echo "private_ci_supported=$private_ci_supported" >> "$GITHUB_OUTPUT"
+
+          if [ "$private_ci_supported" != true ]; then
+            {
+              echo "## PR preflight failed"
+              echo ""
+              echo "| Check | Value |"
+              echo "|-------|-------|"
+              echo "| Head repository | $HEAD_REPOSITORY |"
+              echo "| Base repository | $BASE_REPOSITORY |"
+              echo "| Head branch | $HEAD_BRANCH |"
+              echo "| Expected branch names | $expected_branches |"
+              echo ""
+              echo "Private-container CI can run only for branches in the base repository because fork PRs do not receive the required secrets."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
   check-formatting:
     name: Check Code Formatting
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -39,7 +90,8 @@ jobs:
 
   lint:
     name: Lint Code
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -59,7 +111,8 @@ jobs:
 
   conventional-commits:
     name: Conventional Commits
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -79,7 +132,8 @@ jobs:
 
   build:
     name: Build
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -101,7 +155,8 @@ jobs:
 
   test:
     name: Test suite
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: general
     container:
@@ -151,7 +206,8 @@ jobs:
 
   coverage:
     name: Code Coverage
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 30
     runs-on: general
     container:
@@ -279,7 +335,8 @@ jobs:
 
   kontrol-proofs:
     name: Kontrol Formal Verification
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     runs-on: general
     continue-on-error: true
     container:
@@ -326,7 +383,8 @@ jobs:
 
   analyze:
     name: Analyze with Slither
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -355,7 +413,8 @@ jobs:
 
   trivy:
     name: Vulnerability Scan
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -367,7 +426,8 @@ jobs:
 
   natspec:
     name: NatSpec Documentation Check
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -398,7 +458,8 @@ jobs:
 
   semver-check:
     name: Contract Semver Check
-    if: github.head_ref != 'main'
+    needs: pr_preflight
+    if: github.head_ref != 'main' && needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -84,6 +84,13 @@ abstract contract TokenizedStrategy {
     event StrategyShutdown();
 
     /**
+     * @notice Emitted when an emergency withdrawal is processed after shutdown.
+     * @param caller Address that initiated the emergency withdrawal
+     * @param requestedAssets Amount of assets requested to be withdrawn
+     */
+    event EmergencyWithdraw(address indexed caller, uint256 requestedAssets);
+
+    /**
      * @notice Emitted on the initialization of any new `strategy` that uses `asset`
      * with this specific `apiVersion`.
      */
@@ -1242,6 +1249,8 @@ abstract contract TokenizedStrategy {
 
         // Withdraw from the yield source.
         IBaseStrategy(address(this)).shutdownWithdraw(amount);
+
+        emit EmergencyWithdraw(msg.sender, amount);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/core/interfaces/ITokenizedStrategy.sol
+++ b/src/core/interfaces/ITokenizedStrategy.sol
@@ -22,6 +22,13 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
     event StrategyShutdown();
 
     /**
+     * @notice Emitted when an emergency withdrawal is processed after shutdown.
+     * @param caller Address that initiated the emergency withdrawal
+     * @param requestedAssets Amount of assets requested to be withdrawn
+     */
+    event EmergencyWithdraw(address indexed caller, uint256 requestedAssets);
+
+    /**
      * @notice Emitted on the initialization of any new `strategy` that uses `asset`
      * with this specific `apiVersion`.
      */

--- a/src/interfaces/IEvents.sol
+++ b/src/interfaces/IEvents.sol
@@ -18,6 +18,13 @@ interface IEvents {
     event StrategyShutdown();
 
     /**
+     * @notice Emitted when an emergency withdrawal is processed after shutdown
+     * @param caller Address that initiated the emergency withdrawal
+     * @param requestedAssets Amount of assets requested to be withdrawn
+     */
+    event EmergencyWithdraw(address indexed caller, uint256 requestedAssets);
+
+    /**
      * @notice Emitted on the initialization of any new strategy
      * @param strategy Address of the newly initialized strategy
      * @param asset Address of the underlying asset

--- a/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
+++ b/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
@@ -7,6 +7,7 @@ import { MockYieldSource } from "test/mocks/core/MockYieldSource.sol";
 import { MockStrategy as MockBaseStrategy } from "test/mocks/core/MockBaseStrategy.sol";
 import { MockIlliquidStrategy } from "test/mocks/core/tokenized-strategies/MockIlliquidStrategy.sol";
 import { MockTokenizedStrategyWithLoss } from "test/mocks/core/MockTokenizedStrategyWithLoss.sol";
+import { TokenizedStrategy } from "src/core/TokenizedStrategy.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { TokenizedStrategy__InvalidSigner } from "src/errors.sol";
@@ -212,7 +213,10 @@ contract TokenizedStrategyBranchCoverageTest is Test {
 
     function test_emergencyWithdraw_afterShutdown_succeeds() public {
         ITokenizedStrategy(address(strategy)).shutdownStrategy();
-        // Should not revert
+
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit TokenizedStrategy.EmergencyWithdraw(address(this), 0);
+
         ITokenizedStrategy(address(strategy)).emergencyWithdraw(0);
     }
 
@@ -1167,10 +1171,15 @@ contract TokenizedStrategyBranchCoverageTest is Test {
     // --- emergencyAdmin can emergency withdraw ---
 
     function test_emergencyWithdraw_byEmergencyAdmin() public {
-        ITokenizedStrategy(address(strategy)).setEmergencyAdmin(address(0x55));
+        address newEmergencyAdmin = address(0x55);
+
+        ITokenizedStrategy(address(strategy)).setEmergencyAdmin(newEmergencyAdmin);
         ITokenizedStrategy(address(strategy)).shutdownStrategy();
 
-        vm.prank(address(0x55));
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit TokenizedStrategy.EmergencyWithdraw(newEmergencyAdmin, 0);
+
+        vm.prank(newEmergencyAdmin);
         ITokenizedStrategy(address(strategy)).emergencyWithdraw(0);
     }
 


### PR DESCRIPTION
## Summary

- add `EmergencyWithdraw(address indexed caller, uint256 requestedAssets)` to `TokenizedStrategy`, `ITokenizedStrategy`, and `IEvents`
- emit the event after `shutdownWithdraw(amount)` succeeds in `emergencyWithdraw`
- cover management and emergency-admin event emission paths in TokenizedStrategy tests
