### PR TITLE
fix(strategies): enforce bailsec #17 dust-share invariants

### DIFF
--- a/kontrol.toml
+++ b/kontrol.toml
@@ -41,7 +41,7 @@ auto_abstract              = true
 run-constructor            = false
 match-test                 = [
         # ============================================
-        # YieldDonating strategy proofs (7 inherited + 4 unique = 11)
+        # YieldDonating strategy proofs
         # ============================================
         # Inherited from StrategyBaseTest
         "YDStrategyTest.testTend()",
@@ -53,11 +53,16 @@ match-test                 = [
         "YDStrategyTest.testReportLossNoBurning()",
         # YD-unique
         "YDStrategyTest.testReportProfit()",
+        "YDStrategyTest.testReportZeroAssetRecoveryMintsOnlySurplusDragonShares()",
+        "YDStrategyTest.testReportZeroAssetRecoverySurplusRedeemableOneToOne()",
+        "YDStrategyTest.testReportZeroAssetRecoveryPreservesPrincipalWhenRecoveryAtOrBelowSupply()",
+        "YDStrategyTest.testWithdrawFinalShareCannotLeaveTrackedAssets()",
+        "YDStrategyTest.testDepositBlockedWhenSupplyZeroAssetsPositive()",
         "YDStrategyTest.testReportLossInsufficientDragon()",
         "YDStrategyTest.testSharesRedeemableAfterDepositYD(uint256,address)",
         "YDStrategyTest.testConversionConsistencyYD(uint256)",
         # ============================================
-        # YieldSkimming strategy proofs (4 inherited + 11 unique = 15)
+        # YieldSkimming strategy proofs
         # ============================================
         # Inherited from StrategyBaseTest (overridden for debt assertions)
         "YSStrategyTest.testTend()",
@@ -71,13 +76,18 @@ match-test                 = [
         "YSStrategyTest.testDepositBlockedDuringInsolvency()",
         "YSStrategyTest.testDragonBlockedDuringInsolvency()",
         "YSStrategyTest.testDepositBlockedForDragon()",
+        "YSStrategyTest.testStrandedAssetPreviewsReturnZeroYS()",
+        "YSStrategyTest.testStrandedAssetDepositRevertsYS()",
+        "YSStrategyTest.testStrandedAssetMintRevertsYS()",
         "YSStrategyTest.testDepositValueDebtYS(uint256,address)",
         "YSStrategyTest.testTransferDragonToUser(address,uint256)",
         "YSStrategyTest.testTransferUserToDragon(address,uint256)",
+        "YSStrategyTest.testFinalWithdrawZeroValueSurplusFreesAndTransfersDragonDustYS()",
+        "YSStrategyTest.testFinalWithdrawPositiveValueSurplusMintsDragonSharesYS()",
         "YSStrategyTest.testConversionSolventYS(uint256)",
         "YSStrategyTest.testConversionFallbackInsolventYS(uint256)",
         # ============================================
-        # YieldForwarder proofs (5)
+        # YieldForwarder proofs
         # ============================================
         "YFTest.testReportAndForwardOnlyKeeper()",
         "YFTest.testReportAndForwardReceiverGuarantee()",
@@ -85,7 +95,7 @@ match-test                 = [
         "YFTest.testReportAndForwardZeroSharesPassthrough()",
         "YFTest.testReportAndForwardReturnsRedeemAssets()",
         # ============================================
-        # SwappingYieldForwarder proofs (7)
+        # SwappingYieldForwarder proofs
         # ============================================
         "SYFTest.testReportSwapAndForwardOnlyKeeper()",
         "SYFTest.testReportSwapAndForwardReceiverGuarantee()",

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -459,7 +459,7 @@ abstract contract TokenizedStrategy {
 
     /// @notice API version identifier for this TokenizedStrategy implementation
     /// @dev Used for tracking strategy versions and compatibility
-    string internal constant API_VERSION = "1.0.0";
+    string internal constant API_VERSION = "1.1.0";
 
     /// @notice Reentrancy guard flag value during function execution
     /// @dev Set to 2 when a protected function is executing

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -5,7 +5,7 @@ import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ECDSA } from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-import { TokenizedStrategy__InvalidSigner } from "src/errors.sol";
+import { TokenizedStrategy__FinalWithdrawLeavesAssets, TokenizedStrategy__InvalidSigner } from "src/errors.sol";
 
 import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
 
@@ -970,8 +970,8 @@ abstract contract TokenizedStrategy {
     ) internal view virtual returns (uint256) {
         // Saves an extra SLOAD if values are non-zero.
         uint256 totalSupply_ = _totalSupply(S);
-        // If supply is 0, PPS = 1.
-        if (totalSupply_ == 0) return assets;
+        // If supply is 0, PPS = 1 unless assets are stranded without shares.
+        if (totalSupply_ == 0) return _totalAssets(S) == 0 ? assets : 0;
 
         uint256 totalAssets_ = _totalAssets(S);
         // If assets are 0 but supply is not PPS = 0.
@@ -992,13 +992,16 @@ abstract contract TokenizedStrategy {
         // Saves an extra SLOAD if totalSupply() is non-zero.
         uint256 supply = _totalSupply(S);
 
-        return supply == 0 ? shares : shares.mulDiv(_totalAssets(S), supply, _rounding);
+        if (supply == 0) return _totalAssets(S) == 0 ? shares : 0;
+
+        return shares.mulDiv(_totalAssets(S), supply, _rounding);
     }
 
     /// @dev Internal implementation of {maxDeposit}.
     function _maxDeposit(StrategyData storage S, address receiver) internal view returns (uint256) {
         // Cannot deposit when shutdown or to the strategy.
         if (S.shutdown || receiver == address(this)) return 0;
+        if (_totalSupply(S) == 0 && _totalAssets(S) != 0) return 0;
 
         return IBaseStrategy(address(this)).availableDepositLimit(receiver);
     }
@@ -1007,6 +1010,7 @@ abstract contract TokenizedStrategy {
     function _maxMint(StrategyData storage S, address receiver) internal view returns (uint256 maxMint_) {
         // Cannot mint when shutdown or to the strategy.
         if (S.shutdown || receiver == address(this)) return 0;
+        if (_totalSupply(S) == 0 && _totalAssets(S) != 0) return 0;
 
         maxMint_ = IBaseStrategy(address(this)).availableDepositLimit(receiver);
         if (maxMint_ != type(uint256).max) {
@@ -1079,6 +1083,24 @@ abstract contract TokenizedStrategy {
     }
 
     /**
+     * @dev Allows specialized strategies to allocate surplus assets that would
+     *      otherwise remain after the last pre-existing share is burned.
+     *
+     * The default implementation leaves accounting unchanged, so `_withdraw`
+     * will still revert unless an override either accounts for all assets or
+     * mints replacement shares before the burn. `assets` is the receiver
+     * payout that `_withdraw` will transfer after this hook returns.
+     */
+    function _handleFinalWithdrawSurplus(
+        StrategyData storage,
+        uint256 assetsToRemove,
+        uint256,
+        uint256
+    ) internal virtual returns (uint256) {
+        return assetsToRemove;
+    }
+
+    /**
      * @dev To be called during {redeem} and {withdraw}.
      *
      * This will handle all logic, transfers and accounting
@@ -1134,8 +1156,23 @@ abstract contract TokenizedStrategy {
             }
         }
 
+        uint256 assetsToRemove = assets + loss;
+        uint256 totalAssets_ = _totalAssets(S);
+
+        // Do not let rounding burn the last share while leaving tracked assets
+        // behind. A zero-supply/positive-assets state prices the next deposit as
+        // a first deposit even though the strategy still has assets.
+        if (shares == _totalSupply(S) && assetsToRemove != totalAssets_) {
+            if (assetsToRemove < totalAssets_) {
+                assetsToRemove = _handleFinalWithdrawSurplus(S, assetsToRemove, totalAssets_, assets);
+            }
+            if (assetsToRemove > totalAssets_ || (assetsToRemove != totalAssets_ && shares == _totalSupply(S))) {
+                revert TokenizedStrategy__FinalWithdrawLeavesAssets();
+            }
+        }
+
         // Update assets based on how much we took.
-        S.totalAssets -= (assets + loss);
+        S.totalAssets = totalAssets_ - assetsToRemove;
 
         _burn(S, owner, shares);
 

--- a/src/errors.sol
+++ b/src/errors.sol
@@ -41,5 +41,6 @@ error TokenizedStrategy__RedeemMoreThanMax();
 error TokenizedStrategy__NotPendingManagement();
 error TokenizedStrategy__StrategyNotInShutdown();
 error TokenizedStrategy__TooMuchLoss();
+error TokenizedStrategy__FinalWithdrawLeavesAssets();
 
 error BaseStrategy__NotSelf();

--- a/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
@@ -19,22 +19,14 @@ import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
  *      - Losses first attempt dragon share burning when enabled; residual losses decrease PPS
  *      - Dragon router change follows TokenizedStrategy cooldown and two-step finalization
  *
- * Terminal-state recovery (operator-managed):
+ * Terminal-state recovery:
  *      - After a catastrophic loss that reduces `totalAssets` to 0 while `totalSupply`
- *        remains positive (all dragon shares burned and residual loss socialized), the
- *        strategy enters a terminal state: `_convertToShares` returns 0 at the new PPS,
- *        so deposit() and mint() revert until accounting is restored by a future report
- *        and conversions no longer round to zero.
- *      - External donations of the underlying asset are not a dedicated recovery
- *        mechanism. A donated balance can raise `totalAssets` when report() records it,
- *        but the value flows proportionally to existing shareholders. At the terminal
- *        ratio the dragon-mint floors to 0, so no new profit shares accrue to the dragon
- *        router or donation receiver.
- *      - This contract does not implement an automatic recovery flow for that state.
- *        Recovery is operator-managed: call `shutdownStrategy` to stop new deposits while
- *        operators assess the position and migrate users to a fresh deployment if needed.
- *        Avoiding a donation-based rescue path prevents reintroducing first-depositor
- *        dust-extraction style issues.
+ *        remains positive, deposit() and mint() stay blocked while `totalAssets` is 0.
+ *      - If value later re-enters the strategy and report() records positive assets,
+ *        existing shares receive first claim up to 1 asset per share. Only recovered
+ *        value above the outstanding supply is minted to the dragon router as surplus.
+ *        This keeps full-loss recovery with remaining non-dust supply from being donated
+ *        while preventing stale dust shares from capturing recovered surplus.
  */
 
 contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
@@ -90,7 +82,17 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
             unchecked {
                 profit = newTotalAssets - oldTotalAssets;
             }
-            uint256 sharesToMint = _convertToShares(S, profit, Math.Rounding.Floor);
+            uint256 totalSupply_ = _totalSupply(S);
+            uint256 sharesToMint;
+            if (oldTotalAssets == 0 && totalSupply_ != 0) {
+                if (profit > totalSupply_) {
+                    unchecked {
+                        sharesToMint = profit - totalSupply_;
+                    }
+                }
+            } else {
+                sharesToMint = _convertToShares(S, profit, Math.Rounding.Floor);
+            }
 
             // Floor rounding can map dust profit to zero shares; skip the no-op mint and
             // DonationMinted emission so off-chain indexers do not see a donation event

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -622,6 +622,8 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         uint256 assets,
         Math.Rounding rounding
     ) internal view virtual override returns (uint256) {
+        if (_totalSupply(S) == 0 && _totalAssets(S) != 0) return 0;
+
         if (_isVaultInsolvent()) {
             // Vault insolvent - use parent TokenizedStrategy logic
             return super._convertToShares(S, assets, rounding);
@@ -649,6 +651,8 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         uint256 shares,
         Math.Rounding rounding
     ) internal view virtual override returns (uint256) {
+        if (_totalSupply(S) == 0 && _totalAssets(S) != 0) return 0;
+
         if (_isVaultInsolvent()) {
             // Vault insolvent - use parent TokenizedStrategy logic
             return super._convertToAssets(S, shares, rounding);
@@ -662,6 +666,43 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
                 return super._convertToAssets(S, shares, rounding);
             }
         }
+    }
+
+    /**
+     * @dev When the last user exit leaves surplus value because the exchange
+     *      rate moved up after the latest report, materialize that surplus as
+     *      dragon shares before the user shares are burned.
+     */
+    function _handleFinalWithdrawSurplus(
+        StrategyData storage S,
+        uint256 assetsToRemove,
+        uint256 totalAssets_,
+        uint256 assets
+    ) internal override returns (uint256) {
+        uint256 surplus = totalAssets_ - assetsToRemove;
+        uint256 currentRate = _currentRateRay();
+        uint256 surplusValue = surplus.mulDiv(currentRate, WadRayMath.RAY);
+
+        if (surplusValue == 0) {
+            uint256 requiredIdle = assets + surplus;
+            uint256 idle = S.asset.balanceOf(address(this));
+            if (idle < requiredIdle) {
+                IBaseStrategy(address(this)).freeFunds(requiredIdle - idle);
+                idle = S.asset.balanceOf(address(this));
+            }
+
+            if (idle < requiredIdle) return assetsToRemove;
+
+            S.asset.safeTransfer(S.dragonRouter, surplus);
+            return totalAssets_;
+        }
+
+        _mint(S, S.dragonRouter, surplusValue);
+        _strategyYieldSkimmingStorage().dragonRouterDebtInAssetValue += surplusValue;
+
+        emit DonationMinted(S.dragonRouter, surplusValue, currentRate.rayToWad());
+
+        return assetsToRemove;
     }
 
     /**

--- a/test/integration/factories/YieldDonatingTokenizedStrategy.t.sol
+++ b/test/integration/factories/YieldDonatingTokenizedStrategy.t.sol
@@ -88,7 +88,7 @@ contract YieldDonatingTokenizedStrategyTest is Test {
     function testInheritedFunctions() public view {
         // Test accessing the API version
         string memory apiVersion = strategy.apiVersion();
-        assertEq(apiVersion, "1.0.0", "API version should match parent contract");
+        assertEq(apiVersion, "1.1.0", "API version should match parent contract");
     }
 
     /**

--- a/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
+++ b/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
@@ -70,7 +70,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
         bytes32 PERMIT_TYPEHASH = keccak256(
             "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
         );
-        bytes32 VERSION_HASH = keccak256(bytes("1.0.0"));
+        bytes32 VERSION_HASH = keccak256(bytes("1.1.0"));
         bytes32 nameHash = keccak256(bytes(ITokenizedStrategy(address(strategy)).name()));
         bytes32 domainSeparator = keccak256(
             abi.encode(EIP712DOMAIN_TYPEHASH, nameHash, VERSION_HASH, block.chainid, address(strategy))
@@ -591,7 +591,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
 
     function test_apiVersion_returns100() public view {
         string memory version = ITokenizedStrategy(address(strategy)).apiVersion();
-        assertEq(keccak256(bytes(version)), keccak256(bytes("1.0.0")));
+        assertEq(keccak256(bytes(version)), keccak256(bytes("1.1.0")));
     }
 
     // --- getter functions ---

--- a/test/unit/core/tokenizedStrategy/Permit.t.sol
+++ b/test/unit/core/tokenizedStrategy/Permit.t.sol
@@ -22,7 +22,7 @@ contract TokenizedStrategyPermitTest is Test {
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     bytes32 constant PERMIT_TYPEHASH =
         keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
-    bytes32 constant VERSION_HASH = keccak256(bytes("1.0.0"));
+    bytes32 constant VERSION_HASH = keccak256(bytes("1.1.0"));
 
     function setUp() public {
         ownerPk = uint256(keccak256(abi.encodePacked("TokenizedStrategyPermitTest owner")));

--- a/test/unit/strategies/yieldDonating/ReportLifecycle.t.sol
+++ b/test/unit/strategies/yieldDonating/ReportLifecycle.t.sol
@@ -4,10 +4,27 @@ pragma solidity >=0.8.18;
 import { Setup, IMockStrategy } from "./utils/Setup.sol";
 import { TokenizedStrategy } from "src/core/TokenizedStrategy.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { TokenizedStrategy__FinalWithdrawLeavesAssets } from "src/errors.sol";
 
 contract ReportLifecycleTest is Setup {
+    bytes32 internal constant OCTANT_STRATEGY_STORAGE =
+        keccak256(abi.encode(uint256(keccak256("octant.tokenized.strategy.storage")) - 1)) & ~bytes32(uint256(0xff));
+
+    bytes32 internal constant BALANCES_SLOT = bytes32(uint256(OCTANT_STRATEGY_STORAGE) + 1);
+    bytes32 internal constant TOTAL_SUPPLY_SLOT = bytes32(uint256(OCTANT_STRATEGY_STORAGE) + 8);
+    bytes32 internal constant TOTAL_ASSETS_SLOT = bytes32(uint256(OCTANT_STRATEGY_STORAGE) + 9);
+
     function setUp() public override {
         super.setUp();
+    }
+
+    function _writeStrategyState(uint256 totalSupply_, uint256 totalAssets_) internal {
+        vm.store(address(strategy), TOTAL_SUPPLY_SLOT, bytes32(totalSupply_));
+        vm.store(address(strategy), TOTAL_ASSETS_SLOT, bytes32(totalAssets_));
+    }
+
+    function _writeBalance(address account, uint256 amount) internal {
+        vm.store(address(strategy), keccak256(abi.encode(account, BALANCES_SLOT)), bytes32(amount));
     }
 
     // ==================== Report with Profit ====================
@@ -81,6 +98,100 @@ contract ReportLifecycleTest is Setup {
 
         vm.prank(keeper);
         strategy.report();
+    }
+
+    function test_reportRecovery_zeroAssetsDustSupplyDonatesOnlySurplus() public {
+        address dustHolder = address(0xA11CE);
+        uint256 recoveredValue = 100 ether;
+        uint256 dustSupply = 1;
+
+        _writeStrategyState({ totalSupply_: dustSupply, totalAssets_: 0 });
+        _writeBalance(dustHolder, dustSupply);
+        asset.mint(address(strategy), recoveredValue);
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 recoveryLoss) = strategy.report();
+
+        assertEq(profit, recoveredValue, "recovered value should be reported as profit");
+        assertEq(recoveryLoss, 0, "recovery report should not report loss");
+        assertEq(
+            strategy.balanceOf(donationAddress),
+            recoveredValue - dustSupply,
+            "dragon should receive recovered surplus shares"
+        );
+        assertEq(strategy.balanceOf(dustHolder), dustSupply, "dust holder balance should remain");
+        assertEq(strategy.totalSupply(), recoveredValue, "recovery surplus shares should refill supply to assets");
+        assertEq(strategy.totalAssets(), recoveredValue, "recovered assets should be tracked");
+        assertEq(strategy.previewRedeem(dustSupply), dustSupply, "dust holder should recover only dust principal");
+    }
+
+    function test_reportRecovery_zeroAssetsNonDustSupplyPreservesRecoveredPrincipal() public {
+        address lossHolder = address(0xA11CE);
+        uint256 oldSupply = 100 ether;
+        uint256 recoveredValue = 100 ether;
+
+        _writeStrategyState({ totalSupply_: oldSupply, totalAssets_: 0 });
+        _writeBalance(lossHolder, oldSupply);
+        asset.mint(address(strategy), recoveredValue);
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 recoveryLoss) = strategy.report();
+
+        assertEq(profit, recoveredValue, "recovered value should be reported as profit");
+        assertEq(recoveryLoss, 0, "recovery report should not report loss");
+        assertEq(strategy.balanceOf(donationAddress), 0, "dragon should not receive principal recovery shares");
+        assertEq(strategy.balanceOf(lossHolder), oldSupply, "loss holder balance should remain");
+        assertEq(strategy.totalSupply(), oldSupply, "no recovery shares should be minted");
+        assertEq(strategy.totalAssets(), recoveredValue, "recovered assets should be tracked");
+        assertEq(strategy.previewRedeem(oldSupply), recoveredValue, "loss holder should recover principal first");
+    }
+
+    function test_reportRecovery_zeroAssetsNonDustSupplyDonatesSurplusOnly() public {
+        address lossHolder = address(0xA11CE);
+        uint256 oldSupply = 100 ether;
+        uint256 recoveredValue = 150 ether;
+        uint256 expectedSurplus = recoveredValue - oldSupply;
+
+        _writeStrategyState({ totalSupply_: oldSupply, totalAssets_: 0 });
+        _writeBalance(lossHolder, oldSupply);
+        asset.mint(address(strategy), recoveredValue);
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 recoveryLoss) = strategy.report();
+
+        assertEq(profit, recoveredValue, "recovered value should be reported as profit");
+        assertEq(recoveryLoss, 0, "recovery report should not report loss");
+        assertEq(strategy.balanceOf(donationAddress), expectedSurplus, "dragon should receive surplus shares only");
+        assertEq(strategy.balanceOf(lossHolder), oldSupply, "loss holder balance should remain");
+        assertEq(strategy.totalSupply(), recoveredValue, "surplus shares should refill supply to recovered assets");
+        assertEq(strategy.totalAssets(), recoveredValue, "recovered assets should be tracked");
+        assertEq(strategy.previewRedeem(oldSupply), oldSupply, "loss holder should recover principal first");
+        assertEq(strategy.previewRedeem(expectedSurplus), expectedSurplus, "dragon should receive recovered surplus");
+    }
+
+    function test_withdrawCannotBurnFinalShareUnlessAllAssetsAreRemoved() public {
+        _writeStrategyState({ totalSupply_: 1, totalAssets_: 100 ether });
+        _writeBalance(user, 1);
+        asset.mint(address(strategy), 100 ether);
+
+        vm.prank(user);
+        vm.expectRevert(TokenizedStrategy__FinalWithdrawLeavesAssets.selector);
+        strategy.withdraw(1, user, user, 0);
+    }
+
+    function test_depositBlockedWhenSupplyZeroAssetsPositive() public {
+        address firstDepositor = address(0xBEEF);
+        _writeStrategyState({ totalSupply_: 0, totalAssets_: 100 ether });
+
+        assertEq(strategy.previewDeposit(1), 0, "stranded assets should not price deposits at 1:1");
+        assertEq(strategy.maxDeposit(firstDepositor), 0, "deposits should be blocked while assets are stranded");
+
+        asset.mint(firstDepositor, 1);
+        vm.startPrank(firstDepositor);
+        asset.approve(address(strategy), 1);
+        vm.expectRevert("ERC4626: deposit more than max");
+        strategy.deposit(1, firstDepositor);
+        vm.stopPrank();
     }
 
     // ==================== Report with Loss + Burning Enabled ====================

--- a/test/unit/strategies/yieldSkimming/Accounting.t.sol
+++ b/test/unit/strategies/yieldSkimming/Accounting.t.sol
@@ -1525,14 +1525,23 @@ contract AccountingTest is Setup {
         vm.prank(user2);
         strategy.redeem(user2Balance, user2, user2);
 
+        uint256 finalDragonShares = strategy.balanceOf(donationAddress);
+        assertGt(finalDragonShares, 0, "Final surplus should be allocated to dragon shares");
+
         // w3: No User3 to withdraw (deposit was blocked by insolvency)
         console2.log("Step 12: w3 - No User3 withdrawal (no deposit occurred)");
 
         console2.log("\n=== FINAL STATE ===");
-        console2.log("Final dragon shares:", strategy.balanceOf(donationAddress));
+        console2.log("Final dragon shares:", finalDragonShares);
         console2.log("Final total assets:", strategy.totalAssets());
         console2.log("Final total supply:", strategy.totalSupply());
         console2.log("Final total value debt:", strategy.totalSupply() - strategy.balanceOf(strategy.dragonRouter()));
+
+        vm.prank(donationAddress);
+        strategy.redeem(finalDragonShares, donationAddress, donationAddress);
+
+        assertEq(strategy.totalAssets(), 0, "Dragon surplus redemption should empty assets");
+        assertEq(strategy.totalSupply(), 0, "Dragon surplus redemption should empty supply");
 
         // Verify that without the rate check, losses are properly handled
         assertEq(profit2, 0, "Should report no profit in second report");

--- a/test/unit/strategies/yieldSkimming/FinalWithdrawSurplus.t.sol
+++ b/test/unit/strategies/yieldSkimming/FinalWithdrawSurplus.t.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.18;
+
+import { BaseStrategy, ERC20 } from "src/core/BaseStrategy.sol";
+import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
+import { MockYieldSourceSkimming } from "test/mocks/core/tokenized-strategies/MockYieldSourceSkimming.sol";
+import { Setup } from "./utils/Setup.sol";
+
+contract YieldSkimmingFinalWithdrawSurplusTest is Setup {
+    bytes32 internal constant TOKENIZED_STRATEGY_STORAGE =
+        keccak256(abi.encode(uint256(keccak256("octant.tokenized.strategy.storage")) - 1)) & ~bytes32(uint256(0xff));
+    bytes32 internal constant TOTAL_ASSETS_SLOT = bytes32(uint256(TOKENIZED_STRATEGY_STORAGE) + 9);
+
+    function test_finalWithdrawZeroValueSurplusFreesBeforeDragonTransfer() public {
+        MockDeployedSkimmingStrategy deployedStrategy = new MockDeployedSkimmingStrategy(
+            address(yieldSource),
+            management,
+            keeper,
+            emergencyAdmin,
+            donationAddress,
+            address(implementation)
+        );
+
+        address alice = makeAddr("alice");
+        uint256 initialAssets = 100e18;
+        uint256 withdrawalAssets = 200e18;
+        uint256 trackedAssets = withdrawalAssets + 1;
+
+        yieldSource.mint(alice, initialAssets);
+
+        vm.prank(alice);
+        yieldSource.approve(address(deployedStrategy), initialAssets);
+
+        vm.prank(alice);
+        ITokenizedStrategy(address(deployedStrategy)).deposit(initialAssets, alice);
+
+        deployedStrategy.updateExchangeRate(5e17);
+        deployedStrategy.setDeployedAssets(trackedAssets);
+        vm.store(address(deployedStrategy), TOTAL_ASSETS_SLOT, bytes32(trackedAssets));
+
+        uint256 dragonBalanceBefore = yieldSource.balanceOf(donationAddress);
+
+        vm.prank(alice);
+        uint256 withdrawn = ITokenizedStrategy(address(deployedStrategy)).redeem(initialAssets, alice, alice, MAX_BPS);
+
+        assertEq(withdrawn, withdrawalAssets, "withdrawn assets");
+        assertEq(yieldSource.balanceOf(alice), withdrawalAssets, "receiver assets");
+        assertEq(yieldSource.balanceOf(donationAddress) - dragonBalanceBefore, 1, "dragon surplus");
+        assertEq(ITokenizedStrategy(address(deployedStrategy)).totalAssets(), 0, "tracked assets");
+        assertEq(ITokenizedStrategy(address(deployedStrategy)).totalSupply(), 0, "total supply");
+        assertEq(yieldSource.balanceOf(address(deployedStrategy)), 0, "idle assets");
+        assertEq(deployedStrategy.deployedAssets(), 0, "deployed assets");
+    }
+}
+
+contract MockDeployedSkimmingStrategy is BaseStrategy {
+    address public yieldSource;
+    uint256 public deployedAssets;
+    uint256 private exchangeRate = 1e18;
+
+    constructor(
+        address _yieldSource,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        address _tokenizedStrategyAddress
+    )
+        BaseStrategy(
+            _yieldSource,
+            "Deployed Test Strategy",
+            "dtsSYMBOL",
+            _management,
+            _keeper,
+            _emergencyAdmin,
+            _donationAddress,
+            false,
+            _tokenizedStrategyAddress
+        )
+    {
+        yieldSource = _yieldSource;
+        ERC20(_yieldSource).approve(_yieldSource, type(uint256).max);
+    }
+
+    function getCurrentExchangeRate() public view returns (uint256) {
+        return exchangeRate;
+    }
+
+    function updateExchangeRate(uint256 newExchangeRate) external {
+        exchangeRate = newExchangeRate;
+    }
+
+    function decimalsOfExchangeRate() public pure returns (uint256) {
+        return 18;
+    }
+
+    function setDeployedAssets(uint256 newDeployedAssets) external {
+        deployedAssets = newDeployedAssets;
+    }
+
+    function _deployFunds(uint256 amount) internal override {
+        if (amount == 0) return;
+
+        deployedAssets += amount;
+        ERC20(yieldSource).transfer(address(0xdead), amount);
+    }
+
+    function _freeFunds(uint256 amount) internal override {
+        uint256 freed = amount < deployedAssets ? amount : deployedAssets;
+        if (freed == 0) return;
+
+        deployedAssets -= freed;
+        MockYieldSourceSkimming(yieldSource).mint(address(this), freed);
+    }
+
+    function _harvestAndReport() internal view override returns (uint256) {
+        return ITokenizedStrategy(address(this)).totalAssets();
+    }
+}

--- a/test/unit/strategies/yieldSkimming/YieldSkimmingPreview.t.sol
+++ b/test/unit/strategies/yieldSkimming/YieldSkimmingPreview.t.sol
@@ -14,9 +14,18 @@ import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/Yie
 contract YieldSkimmingPreviewTest is Setup {
     uint256 internal constant INITIAL_RATE = 1e18;
     uint256 internal constant DEPOSIT_AMOUNT = 100e18;
+    bytes32 internal constant TOKENIZED_STRATEGY_STORAGE =
+        keccak256(abi.encode(uint256(keccak256("octant.tokenized.strategy.storage")) - 1)) & ~bytes32(uint256(0xff));
+    bytes32 internal constant TOTAL_SUPPLY_SLOT = bytes32(uint256(TOKENIZED_STRATEGY_STORAGE) + 8);
+    bytes32 internal constant TOTAL_ASSETS_SLOT = bytes32(uint256(TOKENIZED_STRATEGY_STORAGE) + 9);
 
     function setUp() public override {
         super.setUp();
+    }
+
+    function _writeStrategyState(uint256 totalSupply_, uint256 totalAssets_) internal {
+        vm.store(address(strategy), TOTAL_SUPPLY_SLOT, bytes32(totalSupply_));
+        vm.store(address(strategy), TOTAL_ASSETS_SLOT, bytes32(totalAssets_));
     }
 
     /// @dev Drops the exchange rate to force `_isVaultInsolvent` -> true. After a deposit
@@ -88,6 +97,17 @@ contract YieldSkimmingPreviewTest is Setup {
         _makeInsolventAfterDeposit(INITIAL_RATE / 2);
 
         assertEq(strategy.previewMint(1e18), 0, "previewMint must return 0 while the real mint would revert");
+    }
+
+    function test_previewsReturnZeroWhenSupplyZeroAssetsPositive() public {
+        _writeStrategyState({ totalSupply_: 0, totalAssets_: DEPOSIT_AMOUNT });
+
+        assertEq(strategy.maxDeposit(user), 0, "stranded assets should block deposits");
+        assertEq(strategy.maxMint(user), 0, "stranded assets should block mints");
+        assertEq(strategy.previewDeposit(1e18), 0, "previewDeposit should mirror stranded-assets guard");
+        assertEq(strategy.previewMint(1e18), 0, "previewMint should mirror stranded-assets guard");
+        assertEq(strategy.convertToShares(1e18), 0, "convertToShares should mirror stranded-assets guard");
+        assertEq(strategy.convertToAssets(1e18), 0, "convertToAssets should mirror stranded-assets guard");
     }
 
     // -------------------------------------------------------------------------

--- a/verification/kontrol/MockDeployedYieldSkimmingStrategy.k.sol
+++ b/verification/kontrol/MockDeployedYieldSkimmingStrategy.k.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import { BaseYieldSkimmingHealthCheck } from "src/strategies/periphery/BaseYieldSkimmingHealthCheck.sol";
+import { TestERC20 } from "test/kontrol/TestERC20.k.sol";
+
+/**
+ * @title MockDeployedYieldSkimmingStrategy
+ * @notice YieldSkimming Kontrol mock with deployed-assets accounting.
+ * @dev Used for final-withdraw surplus proofs where TokenizedStrategy must call
+ *      freeFunds() before the last share can burn.
+ */
+contract MockDeployedYieldSkimmingStrategy is BaseYieldSkimmingHealthCheck {
+    uint256 public nextTotalAssets;
+    uint256 public mockExchangeRate;
+    uint256 public mockExchangeRateDecimals;
+    uint256 public deployedAssets;
+
+    constructor(
+        address _asset,
+        string memory _name,
+        string memory _symbol,
+        address _management,
+        address _keeper,
+        address _emergencyAdmin,
+        address _donationAddress,
+        bool _enableBurning,
+        address _tokenizedStrategyAddress
+    )
+        BaseYieldSkimmingHealthCheck(
+            _asset,
+            _name,
+            _symbol,
+            _management,
+            _keeper,
+            _emergencyAdmin,
+            _donationAddress,
+            _enableBurning,
+            _tokenizedStrategyAddress
+        )
+    {}
+
+    function setNextTotalAssets(uint256 _amount) external {
+        nextTotalAssets = _amount;
+    }
+
+    function setMockExchangeRate(uint256 _rate) external {
+        mockExchangeRate = _rate;
+    }
+
+    function setMockExchangeRateDecimals(uint256 _decimals) external {
+        mockExchangeRateDecimals = _decimals;
+    }
+
+    function setDeployedAssets(uint256 _amount) external {
+        deployedAssets = _amount;
+    }
+
+    function getCurrentExchangeRate() external view returns (uint256) {
+        return mockExchangeRate;
+    }
+
+    function decimalsOfExchangeRate() external view returns (uint256) {
+        return mockExchangeRateDecimals;
+    }
+
+    function _harvestAndReport() internal view override returns (uint256) {
+        return nextTotalAssets;
+    }
+
+    function _deployFunds(uint256 amount) internal override {
+        deployedAssets += amount;
+    }
+
+    function _freeFunds(uint256 amount) internal override {
+        uint256 freed = amount < deployedAssets ? amount : deployedAssets;
+        if (freed == 0) return;
+
+        deployedAssets -= freed;
+        TestERC20(address(asset)).mint(address(this), freed);
+    }
+
+    function _emergencyWithdraw(uint256) internal override {}
+}

--- a/verification/kontrol/SharedStateSlots.k.sol
+++ b/verification/kontrol/SharedStateSlots.k.sol
@@ -72,10 +72,10 @@ uint256 constant TS_ENABLE_BURNING_WIDTH = 1;
 // ============================================
 // YieldSkimming-specific (YS_) constants
 // ============================================
-// Storage at keccak256("octant.yieldSkimming.exchangeRate") - 1
-// = 0x07fb4a10feb8168b5b4e83e7b226bebb72233fd2b17be5642e2b2896eed0348a
+// Storage at keccak256(abi.encode(uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1)) & ~bytes32(uint256(0xff))
+// = 0x66b3d9d1383d5ce25503fdc2e0f4d387777e50a9b5be65141986eec7395fef00
 
-uint256 constant YS_BASE = uint256(0x07fb4a10feb8168b5b4e83e7b226bebb72233fd2b17be5642e2b2896eed0348a);
+uint256 constant YS_BASE = uint256(0x66b3d9d1383d5ce25503fdc2e0f4d387777e50a9b5be65141986eec7395fef00);
 
 uint256 constant YS_TOTAL_DEBT_OWED_TO_USER_SLOT = YS_BASE + 0;
 uint256 constant YS_LAST_REPORTED_RATE_SLOT = YS_BASE + 1;

--- a/verification/kontrol/YDStrategyTest.k.sol
+++ b/verification/kontrol/YDStrategyTest.k.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 import { Math } from "@openzeppelin/contracts/utils/math/Math.sol";
 import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
+import { TokenizedStrategy__FinalWithdrawLeavesAssets } from "src/errors.sol";
 
 import { StrategyBaseTest } from "test/kontrol/StrategyBaseTest.k.sol";
 import { YDSetup } from "test/kontrol/YDSetup.k.sol";
@@ -17,8 +18,11 @@ struct YDProofState {
 /**
  * @title YDStrategyTest
  * @notice Kontrol formal verification proofs for YieldDonatingTokenizedStrategy
- * @dev Inherits 7 common proofs from StrategyBaseTest and adds 4 YD-specific proofs:
+ * @dev Inherits common proofs from StrategyBaseTest and adds YD-specific proofs:
  *      - testReportProfit: shares minted to dragon, PPS non-decreasing
+ *      - testReportZeroAssetRecoveryMintsOnlySurplusDragonShares: recovered surplus mints dragon shares
+ *      - testWithdrawFinalShareCannotLeaveTrackedAssets: final-share withdraw cannot strand assets
+ *      - testDepositBlockedWhenSupplyZeroAssetsPositive: stranded-asset state blocks first deposits
  *      - testReportLossInsufficientDragon: partial burn, PPS impact bounded
  *      - testSharesRedeemableAfterDepositYD: deposit produces redeemable shares
  *      - testConversionConsistencyYD: round-trip does not create value
@@ -165,6 +169,158 @@ contract YDStrategyTest is StrategyBaseTest, YDSetup {
         _establish(Mode.Assert, postState.dragonBalance >= preState.dragonBalance);
         // totalSupply increased
         _establish(Mode.Assert, postState.totalSupply >= preState.totalSupply);
+    }
+
+    /// @notice If totalAssets is zero while supply remains nonzero, later recovery
+    ///         must preserve existing share principal first and mint only recovered
+    ///         surplus to dragon.
+    function testReportZeroAssetRecoveryMintsOnlySurplusDragonShares() public {
+        _assumeNonReentrant();
+
+        address stratAddr = getStrategyAddr();
+        _storeData(stratAddr, HC_SLOT, HC_DO_HEALTH_CHECK_OFFSET, HC_DO_HEALTH_CHECK_WIDTH, 0);
+
+        uint256 oldSupply = freshUInt256Bounded();
+        vm.assume(oldSupply > 0);
+        uint256 dragonBalance = freshUInt256Bounded();
+        vm.assume(dragonBalance <= oldSupply);
+
+        _storeUInt256(stratAddr, TS_TOTAL_ASSETS_SLOT, 0);
+        _storeUInt256(stratAddr, TS_TOTAL_SUPPLY_SLOT, oldSupply);
+        _storeMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0, dragonBalance);
+
+        uint256 recoveredAssets = freshUInt256Bounded();
+        vm.assume(recoveredAssets > oldSupply);
+        _assumeNoOverflow(dragonBalance, recoveredAssets);
+        _storeUInt256(stratAddr, MOCK_NEXT_TOTAL_ASSETS_SLOT, recoveredAssets);
+
+        uint256 surplusShares = recoveredAssets - oldSupply;
+
+        vm.startPrank(_keeper);
+        iStrategy.report();
+        vm.stopPrank();
+
+        assertEq(_loadUInt256(stratAddr, TS_TOTAL_ASSETS_SLOT), recoveredAssets);
+        assertEq(_loadUInt256(stratAddr, TS_TOTAL_SUPPLY_SLOT), recoveredAssets);
+        assertEq(
+            _loadMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0),
+            dragonBalance + surplusShares
+        );
+    }
+
+    /// @notice After surplus recovery refills totalSupply to totalAssets,
+    ///         principal and surplus shares redeem 1:1.
+    function testReportZeroAssetRecoverySurplusRedeemableOneToOne() public {
+        _assumeNonReentrant();
+
+        address stratAddr = getStrategyAddr();
+        uint256 oldSupply = 100 ether;
+        uint256 recoveredAssets = 150 ether;
+        uint256 surplusShares = recoveredAssets - oldSupply;
+
+        _storeData(stratAddr, HC_SLOT, HC_DO_HEALTH_CHECK_OFFSET, HC_DO_HEALTH_CHECK_WIDTH, 0);
+        _storeUInt256(stratAddr, TS_TOTAL_ASSETS_SLOT, 0);
+        _storeUInt256(stratAddr, TS_TOTAL_SUPPLY_SLOT, oldSupply);
+        _storeMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0, 0);
+        _storeUInt256(stratAddr, MOCK_NEXT_TOTAL_ASSETS_SLOT, recoveredAssets);
+
+        vm.startPrank(_keeper);
+        iStrategy.report();
+        vm.stopPrank();
+
+        assertEq(iStrategy.convertToAssets(oldSupply), oldSupply);
+        assertEq(iStrategy.convertToAssets(surplusShares), surplusShares);
+    }
+
+    /// @notice If recovery is at or below outstanding supply, existing holders
+    ///         keep the recovered principal and dragon receives no new shares.
+    function testReportZeroAssetRecoveryPreservesPrincipalWhenRecoveryAtOrBelowSupply() public {
+        _assumeNonReentrant();
+
+        address stratAddr = getStrategyAddr();
+        address lossHolder = makeAddr("LOSS_HOLDER");
+        _storeData(stratAddr, HC_SLOT, HC_DO_HEALTH_CHECK_OFFSET, HC_DO_HEALTH_CHECK_WIDTH, 0);
+
+        uint256 oldSupply = freshUInt256Bounded();
+        vm.assume(oldSupply > 0);
+        uint256 recoveredAssets = freshUInt256Bounded();
+        vm.assume(recoveredAssets > 0);
+        vm.assume(recoveredAssets <= oldSupply);
+
+        _storeUInt256(stratAddr, TS_TOTAL_ASSETS_SLOT, 0);
+        _storeUInt256(stratAddr, TS_TOTAL_SUPPLY_SLOT, oldSupply);
+        _storeMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(lossHolder)), 0, oldSupply);
+        _storeMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0, 0);
+        _storeUInt256(stratAddr, MOCK_NEXT_TOTAL_ASSETS_SLOT, recoveredAssets);
+
+        vm.startPrank(_keeper);
+        iStrategy.report();
+        vm.stopPrank();
+
+        assertEq(_loadUInt256(stratAddr, TS_TOTAL_ASSETS_SLOT), recoveredAssets);
+        assertEq(_loadUInt256(stratAddr, TS_TOTAL_SUPPLY_SLOT), oldSupply);
+        assertEq(_loadMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(lossHolder)), 0), oldSupply);
+        assertEq(_loadMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0), 0);
+        assertEq(iStrategy.convertToAssets(oldSupply), recoveredAssets);
+    }
+
+    /// @notice A withdraw that burns the final share must remove all tracked assets.
+    ///         Otherwise the strategy would enter totalSupply == 0 && totalAssets > 0.
+    function testWithdrawFinalShareCannotLeaveTrackedAssets() public {
+        _assumeNonReentrant();
+
+        address stratAddr = getStrategyAddr();
+        address owner = makeAddr("FINAL_SHARE_OWNER");
+
+        uint256 trackedAssets = freshUInt256Bounded();
+        vm.assume(trackedAssets > 1);
+
+        _storeUInt256(stratAddr, TS_TOTAL_ASSETS_SLOT, trackedAssets);
+        _storeUInt256(stratAddr, TS_TOTAL_SUPPLY_SLOT, 1);
+        _storeMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(owner)), 0, 1);
+        _storeMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(stratAddr)), 0, trackedAssets);
+
+        vm.startPrank(owner);
+        vm.expectRevert(TokenizedStrategy__FinalWithdrawLeavesAssets.selector);
+        iStrategy.withdraw(1, owner, owner, 0);
+        vm.stopPrank();
+    }
+
+    /// @notice If a zero-supply/positive-assets state is ever present, deposits
+    ///         are blocked instead of being priced as first deposits.
+    function testDepositBlockedWhenSupplyZeroAssetsPositive() public {
+        _assumeNonReentrant();
+
+        address stratAddr = getStrategyAddr();
+        address depositor = makeAddr("STRANDED_ASSET_DEPOSITOR");
+
+        uint256 strandedAssets = freshUInt256Bounded();
+        vm.assume(strandedAssets > 0);
+
+        _storeUInt256(stratAddr, TS_TOTAL_ASSETS_SLOT, strandedAssets);
+        _storeUInt256(stratAddr, TS_TOTAL_SUPPLY_SLOT, 0);
+
+        assertEq(iStrategy.convertToShares(1), 0);
+        assertEq(iStrategy.convertToAssets(1), 0);
+        assertEq(iStrategy.maxDeposit(depositor), 0);
+        assertEq(iStrategy.maxMint(depositor), 0);
+        assertEq(iStrategy.previewDeposit(1), 0);
+        assertEq(iStrategy.previewMint(1), 0);
+
+        _storeMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(depositor)), 0, 1);
+        vm.prank(depositor);
+        (bool ok, ) = _asset.call(abi.encodeWithSignature("approve(address,uint256)", stratAddr, 1));
+        require(ok);
+
+        vm.startPrank(depositor);
+        vm.expectRevert("ERC4626: deposit more than max");
+        iStrategy.deposit(1, depositor);
+        vm.stopPrank();
+
+        vm.startPrank(depositor);
+        vm.expectRevert("ERC4626: mint more than max");
+        iStrategy.mint(1, depositor);
+        vm.stopPrank();
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/verification/kontrol/YSStrategyTest.k.sol
+++ b/verification/kontrol/YSStrategyTest.k.sol
@@ -749,8 +749,10 @@ contract YSStrategyTest is StrategyBaseTest, YSSetup {
     function testFinalWithdrawZeroValueSurplusFreesAndTransfersDragonDustYS() public {
         _assumeNonReentrant();
 
-        (MockDeployedYieldSkimmingStrategy deployedStrategy, ITokenizedStrategy tokenizedStrategy) =
-            _deployFinalExitStrategy();
+        (
+            MockDeployedYieldSkimmingStrategy deployedStrategy,
+            ITokenizedStrategy tokenizedStrategy
+        ) = _deployFinalExitStrategy();
         address owner = makeAddr("FINAL_EXIT_OWNER");
         uint256 ownerShares = 100 ether;
         uint256 withdrawalAssets = 200 ether;
@@ -779,8 +781,10 @@ contract YSStrategyTest is StrategyBaseTest, YSSetup {
     function testFinalWithdrawPositiveValueSurplusMintsDragonSharesYS() public {
         _assumeNonReentrant();
 
-        (MockDeployedYieldSkimmingStrategy deployedStrategy, ITokenizedStrategy tokenizedStrategy) =
-            _deployFinalExitStrategy();
+        (
+            MockDeployedYieldSkimmingStrategy deployedStrategy,
+            ITokenizedStrategy tokenizedStrategy
+        ) = _deployFinalExitStrategy();
         address owner = makeAddr("FINAL_EXIT_OWNER");
         uint256 ownerShares = 100 ether;
         uint256 withdrawalAssets = ownerShares;

--- a/verification/kontrol/YSStrategyTest.k.sol
+++ b/verification/kontrol/YSStrategyTest.k.sol
@@ -6,6 +6,7 @@ import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 
 import { WadRayMath } from "src/utils/libs/Maths/WadRay.sol";
 
+import { MockDeployedYieldSkimmingStrategy } from "test/kontrol/MockDeployedYieldSkimmingStrategy.k.sol";
 import { StrategyBaseTest } from "test/kontrol/StrategyBaseTest.k.sol";
 import { YSSetup } from "test/kontrol/YSSetup.k.sol";
 import "test/kontrol/SharedStateSlots.k.sol";
@@ -21,8 +22,8 @@ struct YSProofState {
 /**
  * @title YSStrategyTest
  * @notice Kontrol formal verification proofs for YieldSkimmingTokenizedStrategy
- * @dev Inherits 4 common proofs from StrategyBaseTest (testTend, testReportNoChange,
- *      testReportLossNoBurning, testReportByManagement) and adds 11 YS-specific proofs.
+ * @dev Inherits common proofs from StrategyBaseTest (testTend, testReportNoChange,
+ *      testReportLossNoBurning, testReportByManagement) and adds YS-specific proofs.
  *
  *      Strategy-agnostic proofs (testReportOnlyKeeper, testShutdownBlocks, testBalanceBounded)
  *      run only under YDStrategyTest to avoid duplication.
@@ -179,6 +180,65 @@ contract YSStrategyTest is StrategyBaseTest, YSSetup {
         );
         state.userDebt = _loadUInt256(address(ysStrategy), YS_TOTAL_DEBT_OWED_TO_USER_SLOT);
         state.dragonDebt = _loadUInt256(address(ysStrategy), YS_DRAGON_ROUTER_DEBT_SLOT);
+    }
+
+    function _deployFinalExitStrategy()
+        internal
+        returns (MockDeployedYieldSkimmingStrategy deployedStrategy, ITokenizedStrategy tokenizedStrategy)
+    {
+        deployedStrategy = new MockDeployedYieldSkimmingStrategy(
+            _asset,
+            "Deployed Test Strategy",
+            "dtsSYMBOL",
+            _management,
+            _keeper,
+            _emergencyAdmin,
+            _dragonRouter,
+            true,
+            address(ysImplementation)
+        );
+        tokenizedStrategy = ITokenizedStrategy(address(deployedStrategy));
+    }
+
+    function _setFinalExitState(
+        MockDeployedYieldSkimmingStrategy deployedStrategy,
+        address owner,
+        uint256 ownerShares,
+        uint256 trackedAssets,
+        uint256 currentRate,
+        uint256 userDebt,
+        uint256 dragonDebt
+    ) internal {
+        address stratAddr = address(deployedStrategy);
+
+        _storeUInt256(stratAddr, TS_TOTAL_SUPPLY_SLOT, ownerShares);
+        _storeUInt256(stratAddr, TS_TOTAL_ASSETS_SLOT, trackedAssets);
+        _storeMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(owner)), 0, ownerShares);
+        _storeMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0, 0);
+        _storeUInt256(stratAddr, YS_TOTAL_DEBT_OWED_TO_USER_SLOT, userDebt);
+        _storeUInt256(stratAddr, YS_DRAGON_ROUTER_DEBT_SLOT, dragonDebt);
+        _storeUInt256(stratAddr, YS_LAST_REPORTED_RATE_SLOT, currentRate);
+
+        deployedStrategy.setMockExchangeRate(currentRate);
+        deployedStrategy.setMockExchangeRateDecimals(27);
+        deployedStrategy.setDeployedAssets(trackedAssets);
+
+        _storeMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(stratAddr)), 0, 0);
+        _storeMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(owner)), 0, 0);
+        _storeMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0, 0);
+    }
+
+    function _setupStrandedAssetStateYS(uint256 strandedAssets) internal {
+        address stratAddr = getStrategyAddr();
+
+        _storeUInt256(stratAddr, TS_TOTAL_SUPPLY_SLOT, 0);
+        _storeUInt256(stratAddr, TS_TOTAL_ASSETS_SLOT, strandedAssets);
+        _storeUInt256(stratAddr, YS_TOTAL_DEBT_OWED_TO_USER_SLOT, 0);
+        _storeUInt256(stratAddr, YS_DRAGON_ROUTER_DEBT_SLOT, 0);
+        _storeUInt256(stratAddr, YS_LAST_REPORTED_RATE_SLOT, WadRayMath.RAY);
+        _storeUInt256(stratAddr, MOCK_YS_EXCHANGE_RATE_SLOT, WadRayMath.RAY);
+        _storeUInt256(stratAddr, MOCK_YS_EXCHANGE_RATE_DECIMALS_SLOT, 27);
+        _storeData(stratAddr, TS_FLAGS_SLOT, TS_SHUTDOWN_OFFSET, TS_SHUTDOWN_WIDTH, 0);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -474,6 +534,58 @@ contract YSStrategyTest is StrategyBaseTest, YSSetup {
         iYSStrategy.deposit(depositAmount, _dragonRouter);
     }
 
+    /// @notice A zero-supply strategy with tracked assets must not quote a
+    ///         positive deposit or mint path.
+    function testStrandedAssetPreviewsReturnZeroYS() public {
+        _assumeNonReentrant();
+
+        address depositor = makeAddr("STRANDED_ASSET_DEPOSITOR");
+        uint256 strandedAssets = freshUInt256Bounded();
+        vm.assume(strandedAssets > 0);
+        _setupStrandedAssetStateYS(strandedAssets);
+
+        assertEq(iYSStrategy.maxDeposit(depositor), 0);
+        assertEq(iYSStrategy.maxMint(depositor), 0);
+        assertEq(iYSStrategy.previewDeposit(1), 0);
+        assertEq(iYSStrategy.previewMint(1), 0);
+        assertEq(iYSStrategy.convertToShares(1), 0);
+        assertEq(iYSStrategy.convertToAssets(1), 0);
+    }
+
+    function testStrandedAssetDepositRevertsYS() public {
+        _assumeNonReentrant();
+
+        address stratAddr = getStrategyAddr();
+        address depositor = makeAddr("STRANDED_ASSET_DEPOSITOR");
+        uint256 strandedAssets = freshUInt256Bounded();
+        vm.assume(strandedAssets > 0);
+        _setupStrandedAssetStateYS(strandedAssets);
+
+        _storeMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(depositor)), 0, 1);
+        vm.prank(depositor);
+        (bool ok, ) = _asset.call(abi.encodeWithSignature("approve(address,uint256)", stratAddr, 1));
+        require(ok);
+
+        vm.startPrank(depositor);
+        vm.expectRevert("ERC4626: deposit more than max");
+        iYSStrategy.deposit(1, depositor);
+        vm.stopPrank();
+    }
+
+    function testStrandedAssetMintRevertsYS() public {
+        _assumeNonReentrant();
+
+        address depositor = makeAddr("STRANDED_ASSET_DEPOSITOR");
+        uint256 strandedAssets = freshUInt256Bounded();
+        vm.assume(strandedAssets > 0);
+        _setupStrandedAssetStateYS(strandedAssets);
+
+        vm.startPrank(depositor);
+        vm.expectRevert("ERC4626: mint more than max");
+        iYSStrategy.mint(1, depositor);
+        vm.stopPrank();
+    }
+
     /*//////////////////////////////////////////////////////////////
                     YS-SPECIFIC: VALUE DEBT TRACKING
     //////////////////////////////////////////////////////////////*/
@@ -630,6 +742,72 @@ contract YSStrategyTest is StrategyBaseTest, YSSetup {
         assertEq(postState.userDebt, preState.userDebt - amount);
         // Dragon debt increased
         assertEq(postState.dragonDebt, preState.dragonDebt + amount);
+    }
+
+    /// @notice A zero-value final-exit surplus is freed and transferred to
+    ///         dragon so the last user share can burn without stranding assets.
+    function testFinalWithdrawZeroValueSurplusFreesAndTransfersDragonDustYS() public {
+        _assumeNonReentrant();
+
+        (MockDeployedYieldSkimmingStrategy deployedStrategy, ITokenizedStrategy tokenizedStrategy) =
+            _deployFinalExitStrategy();
+        address owner = makeAddr("FINAL_EXIT_OWNER");
+        uint256 ownerShares = 100 ether;
+        uint256 withdrawalAssets = 200 ether;
+        uint256 surplusAssets = 1;
+        uint256 trackedAssets = withdrawalAssets + surplusAssets;
+        uint256 currentRate = WadRayMath.RAY / 2;
+
+        _setFinalExitState(deployedStrategy, owner, ownerShares, trackedAssets, currentRate, ownerShares, 0);
+
+        vm.prank(owner);
+        uint256 withdrawn = tokenizedStrategy.redeem(ownerShares, owner, owner, 10_000);
+
+        assertEq(withdrawn, withdrawalAssets);
+        assertEq(_loadUInt256(address(deployedStrategy), TS_TOTAL_ASSETS_SLOT), 0);
+        assertEq(_loadUInt256(address(deployedStrategy), TS_TOTAL_SUPPLY_SLOT), 0);
+        assertEq(_loadUInt256(address(deployedStrategy), YS_TOTAL_DEBT_OWED_TO_USER_SLOT), 0);
+        assertEq(_loadUInt256(address(deployedStrategy), YS_DRAGON_ROUTER_DEBT_SLOT), 0);
+        assertEq(_loadMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(owner)), 0), withdrawalAssets);
+        assertEq(_loadMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0), surplusAssets);
+        assertEq(_loadMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(address(deployedStrategy))), 0), 0);
+        assertEq(deployedStrategy.deployedAssets(), 0);
+    }
+
+    /// @notice A material final-exit surplus is represented as dragon shares
+    ///         and dragon value debt after the user exits.
+    function testFinalWithdrawPositiveValueSurplusMintsDragonSharesYS() public {
+        _assumeNonReentrant();
+
+        (MockDeployedYieldSkimmingStrategy deployedStrategy, ITokenizedStrategy tokenizedStrategy) =
+            _deployFinalExitStrategy();
+        address owner = makeAddr("FINAL_EXIT_OWNER");
+        uint256 ownerShares = 100 ether;
+        uint256 withdrawalAssets = ownerShares;
+        uint256 surplusAssets = 50 ether;
+        uint256 trackedAssets = withdrawalAssets + surplusAssets;
+        uint256 currentRate = WadRayMath.RAY;
+        uint256 surplusValue = surplusAssets;
+
+        _setFinalExitState(deployedStrategy, owner, ownerShares, trackedAssets, currentRate, ownerShares, 0);
+
+        vm.prank(owner);
+        uint256 withdrawn = tokenizedStrategy.redeem(ownerShares, owner, owner, 10_000);
+
+        assertEq(withdrawn, withdrawalAssets);
+        assertEq(_loadUInt256(address(deployedStrategy), TS_TOTAL_ASSETS_SLOT), surplusAssets);
+        assertEq(_loadUInt256(address(deployedStrategy), TS_TOTAL_SUPPLY_SLOT), surplusValue);
+        assertEq(_loadMappingUInt256(address(deployedStrategy), TS_BALANCES_SLOT, uint256(uint160(owner)), 0), 0);
+        assertEq(
+            _loadMappingUInt256(address(deployedStrategy), TS_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0),
+            surplusValue
+        );
+        assertEq(_loadUInt256(address(deployedStrategy), YS_TOTAL_DEBT_OWED_TO_USER_SLOT), 0);
+        assertEq(_loadUInt256(address(deployedStrategy), YS_DRAGON_ROUTER_DEBT_SLOT), surplusValue);
+        assertEq(_loadMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(owner)), 0), withdrawalAssets);
+        assertEq(_loadMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0), 0);
+        assertEq(_loadMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(address(deployedStrategy))), 0), 0);
+        assertEq(deployedStrategy.deployedAssets(), surplusAssets);
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes `Bailsec #17` at the logic level: prevents zero-supply strategies from retaining tracked assets, blocks deposits/previews into stranded-asset states, preserves yield-skimming final exits by freeing dust surplus before transfer, and makes YieldDonating zero-asset recovery fair by preserving existing holders' recovered principal before donating only surplus to the dragon.

Verified with focused Forge suites, compile-size checks, and targeted Kontrol proofs for the new/touched recovery, stranded-state, and final-exit surplus obligations.