### PR TITLE
fix(strategies): enforce bailsec #31 pending-burn reporting

### DIFF
--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -1496,7 +1496,7 @@ abstract contract TokenizedStrategy {
      * @param _enableBurning Whether to enable the burning mechanism.
      * @custom:security Only callable by the current `management`
      */
-    function setEnableBurning(bool _enableBurning) external onlyManagement {
+    function setEnableBurning(bool _enableBurning) external virtual onlyManagement {
         _strategyStorage().enableBurning = _enableBurning;
         emit UpdateBurningMechanism(_enableBurning);
     }

--- a/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
@@ -119,6 +119,39 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
     }
 
     /**
+     * @notice Sets whether dragon-share burning is enabled for loss protection.
+     * @dev Yield-donating strategies learn their authoritative current asset value
+     *      through `report()`. When dragon shares exist, disabling burning without
+     *      reporting first could retroactively preserve dragon shares through an
+     *      unreported loss. Use `reportAndDisableBurning()` in that case.
+     * @param _enableBurning Whether to enable the burning mechanism
+     */
+    function setEnableBurning(bool _enableBurning) external override onlyManagement {
+        StrategyData storage S = _strategyStorage();
+
+        if (S.enableBurning && !_enableBurning) {
+            require(S.balances[S.dragonRouter] == 0, "report before disabling burning");
+        }
+
+        S.enableBurning = _enableBurning;
+        emit UpdateBurningMechanism(_enableBurning);
+    }
+
+    /**
+     * @notice Reports current accounting, then disables dragon burn loss protection.
+     * @dev This explicit helper gives operators an atomic path for disabling burning
+     *      without leaving a between-transaction window for unreported losses.
+     * @return profit Profit reported by the accounting sync
+     * @return loss Loss reported by the accounting sync
+     */
+    function reportAndDisableBurning() external onlyManagement returns (uint256 profit, uint256 loss) {
+        (profit, loss) = report();
+
+        _strategyStorage().enableBurning = false;
+        emit UpdateBurningMechanism(false);
+    }
+
+    /**
      * @dev Internal function to handle loss protection for dragon principal
      * @param S Storage struct pointer to access strategy's storage variables
      * @param loss Amount of loss to protect against in asset base units

--- a/src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol
+++ b/src/strategies/yieldSkimming/IYieldSkimmingStrategy.sol
@@ -65,4 +65,12 @@ interface IYieldSkimmingStrategy {
      * @return isInsolvent True if vault cannot cover user value debt
      */
     function isVaultInsolvent() external view returns (bool isInsolvent);
+
+    /**
+     * @notice Reports current accounting, then disables dragon burn loss protection.
+     * @dev Use this when disabling burning may otherwise race with unreported loss.
+     * @return profit Profit reported by the accounting sync
+     * @return loss Loss reported by the accounting sync
+     */
+    function reportAndDisableBurning() external returns (uint256 profit, uint256 loss);
 }

--- a/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
+++ b/src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol
@@ -611,6 +611,38 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
     }
 
     /**
+     * @notice Sets whether dragon-share burning is enabled for loss protection.
+     * @dev Disabling burning is blocked while there is an unreported shortfall against
+     *      combined user + dragon value debt. The shortfall must be reported while
+     *      burning is still enabled so dragon shares absorb their pending first loss.
+     * @param _enableBurning Whether to enable the burning mechanism
+     */
+    function setEnableBurning(bool _enableBurning) external override onlyManagement {
+        StrategyData storage S = _strategyStorage();
+
+        if (S.enableBurning && !_enableBurning) {
+            require(!_hasPendingDragonBurn(S, _strategyYieldSkimmingStorage()), "report before disabling burning");
+        }
+
+        S.enableBurning = _enableBurning;
+        emit UpdateBurningMechanism(_enableBurning);
+    }
+
+    /**
+     * @notice Reports current accounting, then disables dragon burn loss protection.
+     * @dev This explicit helper gives operators an atomic path for disabling burning
+     *      without leaving a between-transaction window for rate changes.
+     * @return profit Profit reported by the accounting sync
+     * @return loss Loss reported by the accounting sync
+     */
+    function reportAndDisableBurning() external onlyManagement returns (uint256 profit, uint256 loss) {
+        (profit, loss) = report();
+
+        _strategyStorage().enableBurning = false;
+        emit UpdateBurningMechanism(false);
+    }
+
+    /**
      * @dev Converts assets to shares using value debt approach with solvency awareness
      * @param S Strategy storage
      * @param assets Amount of assets to convert
@@ -677,6 +709,24 @@ contract YieldSkimmingTokenizedStrategy is TokenizedStrategy {
         // Vault is only insolvent if it cannot cover user debt
         // Dragon debt is excluded as dragon shares are designed to absorb losses
         return YS.totalDebtOwedToUserInAssetValue > 0 && currentVaultValue < YS.totalDebtOwedToUserInAssetValue;
+    }
+
+    /**
+     * @dev Returns true when dragon shares still have a pending first-loss burn.
+     *      This intentionally checks combined debt, not `_isVaultInsolvent()`, because
+     *      users can still be fully covered while the dragon tranche is impaired.
+     */
+    function _hasPendingDragonBurn(
+        StrategyData storage S,
+        YieldSkimmingStorage storage YS
+    ) internal view returns (bool) {
+        if (_balanceOf(S, S.dragonRouter) == 0) return false;
+
+        uint256 currentRate = _currentRateRay();
+        uint256 currentVaultValue = S.asset.balanceOf(address(this)).mulDiv(currentRate, WadRayMath.RAY);
+        uint256 totalDebt = YS.totalDebtOwedToUserInAssetValue + YS.dragonRouterDebtInAssetValue;
+
+        return currentVaultValue < totalDebt;
     }
 
     /**

--- a/test/unit/strategies/yieldDonating/BurningToggle.t.sol
+++ b/test/unit/strategies/yieldDonating/BurningToggle.t.sol
@@ -98,9 +98,9 @@ contract BurningToggleTest is Setup {
         vm.prank(user);
         strategy.transfer(donationAddress, 20e18);
 
-        // Disable burning mid-lifecycle
+        // Sync and disable burning mid-lifecycle
         vm.prank(management);
-        YieldDonatingTokenizedStrategy(address(strategy)).setEnableBurning(false);
+        YieldDonatingTokenizedStrategy(address(strategy)).reportAndDisableBurning();
 
         // Simulate a loss
         uint256 loss = 10e18;
@@ -174,7 +174,7 @@ contract BurningToggleTest is Setup {
         vm.startPrank(management);
         YieldDonatingTokenizedStrategy(address(strategy)).setEnableBurning(false);
         YieldDonatingTokenizedStrategy(address(strategy)).setEnableBurning(true);
-        YieldDonatingTokenizedStrategy(address(strategy)).setEnableBurning(false);
+        YieldDonatingTokenizedStrategy(address(strategy)).reportAndDisableBurning();
         vm.stopPrank();
 
         // Simulate loss while burning is disabled (final state)
@@ -241,5 +241,42 @@ contract BurningToggleTest is Setup {
             // No burning: dragon shares unchanged
             assertEq(strategy.balanceOf(donationAddress), dragonBalBefore, "dragon shares should not change");
         }
+    }
+
+    function test_bailsec31_disableBurningWithDragonSharesRevertsUntilReported() public {
+        vm.prank(management);
+        YieldDonatingTokenizedStrategy(address(strategy)).setEnableBurning(true);
+
+        uint256 amount = 100e18;
+        mintAndDepositIntoStrategy(strategy, user, amount);
+
+        asset.mint(address(yieldSource), 20e18);
+        vm.prank(keeper);
+        strategy.report();
+
+        uint256 dragonBalBefore = strategy.balanceOf(donationAddress);
+        assertGt(dragonBalBefore, 0, "dragon should have profit shares");
+
+        yieldSource.simulateLoss(10e18);
+
+        vm.prank(management);
+        vm.expectRevert("report before disabling burning");
+        YieldDonatingTokenizedStrategy(address(strategy)).setEnableBurning(false);
+
+        vm.prank(management);
+        (uint256 profit, uint256 loss) = YieldDonatingTokenizedStrategy(address(strategy)).reportAndDisableBurning();
+
+        assertEq(profit, 0, "no profit");
+        assertEq(loss, 10e18, "loss should be reported");
+        assertLt(strategy.balanceOf(donationAddress), dragonBalBefore, "dragon shares should be burned");
+        assertFalse(strategy.enableBurning(), "burning disabled atomically");
+    }
+
+    function test_reportAndDisableBurning_byNonManagement_reverts(address _caller) public {
+        vm.assume(_caller != management);
+
+        vm.prank(_caller);
+        vm.expectRevert("!management");
+        YieldDonatingTokenizedStrategy(address(strategy)).reportAndDisableBurning();
     }
 }

--- a/test/unit/strategies/yieldSkimming/AccessControl.t.sol
+++ b/test/unit/strategies/yieldSkimming/AccessControl.t.sol
@@ -8,8 +8,24 @@ import { IYieldSkimmingStrategy } from "src/strategies/yieldSkimming/IYieldSkimm
 import { MockStrategySkimming } from "test/mocks/core/tokenized-strategies/MockStrategySkimming.sol";
 
 contract AccessControlTest is Setup {
+    uint256 internal constant BAILSEC31_DEPOSIT_AMOUNT = 100e18;
+
     function setUp() public override {
         super.setUp();
+    }
+
+    function _seedBailsec31DragonProfit() internal {
+        vm.prank(management);
+        strategy.setEnableBurning(true);
+
+        mintAndDepositIntoStrategy(strategy, user, BAILSEC31_DEPOSIT_AMOUNT);
+
+        MockStrategySkimming(address(strategy)).updateExchangeRate(15e17);
+        vm.prank(keeper);
+        strategy.report();
+
+        assertEq(strategy.balanceOf(donationAddress), 50e18, "dragon profit shares");
+        assertTrue(strategy.enableBurning(), "burning enabled");
     }
 
     function test_setManagement(address _address) public {
@@ -190,6 +206,99 @@ contract AccessControlTest is Setup {
         strategy.setName(newName);
 
         assertEq(strategy.name(), newName);
+    }
+
+    // ================== Burning Toggle Tests ==================
+
+    function test_bailsec31_disableBurningRevertsWithPendingDragonBurn() public {
+        _seedBailsec31DragonProfit();
+
+        MockStrategySkimming(address(strategy)).updateExchangeRate(9e17);
+        assertTrue(IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(), "user debt should be undercovered");
+
+        vm.prank(management);
+        vm.expectRevert("report before disabling burning");
+        strategy.setEnableBurning(false);
+
+        assertTrue(strategy.enableBurning(), "burning should remain enabled");
+    }
+
+    function test_bailsec31_disableBurningChecksCombinedDebtNotOnlyUserInsolvency() public {
+        _seedBailsec31DragonProfit();
+
+        MockStrategySkimming(address(strategy)).updateExchangeRate(12e17);
+        assertFalse(
+            IYieldSkimmingStrategy(address(strategy)).isVaultInsolvent(),
+            "users should still be fully covered"
+        );
+
+        vm.prank(management);
+        vm.expectRevert("report before disabling burning");
+        strategy.setEnableBurning(false);
+    }
+
+    function test_bailsec31_disableBurningUsesLiveAssetBalance() public {
+        _seedBailsec31DragonProfit();
+
+        vm.prank(address(strategy));
+        yieldSource.transfer(address(0xdead), 1e18);
+
+        assertEq(strategy.totalAssets(), BAILSEC31_DEPOSIT_AMOUNT, "stored totalAssets should be stale");
+        assertEq(
+            yieldSource.balanceOf(address(strategy)),
+            BAILSEC31_DEPOSIT_AMOUNT - 1e18,
+            "live balance should be lower"
+        );
+
+        vm.prank(management);
+        vm.expectRevert("report before disabling burning");
+        strategy.setEnableBurning(false);
+    }
+
+    function test_bailsec31_reportThenDisableBurningSucceeds() public {
+        _seedBailsec31DragonProfit();
+
+        MockStrategySkimming(address(strategy)).updateExchangeRate(9e17);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        assertEq(strategy.balanceOf(donationAddress), 0, "dragon shares should be burned");
+
+        vm.prank(management);
+        strategy.setEnableBurning(false);
+
+        assertFalse(strategy.enableBurning(), "burning disabled after report");
+    }
+
+    function test_bailsec31_reportAndDisableBurningIsAtomic() public {
+        _seedBailsec31DragonProfit();
+
+        MockStrategySkimming(address(strategy)).updateExchangeRate(9e17);
+
+        vm.prank(management);
+        (uint256 profit, uint256 loss) = IYieldSkimmingStrategy(address(strategy)).reportAndDisableBurning();
+
+        assertEq(profit, 0, "no profit");
+        assertGt(loss, 0, "loss should be reported");
+        assertEq(strategy.balanceOf(donationAddress), 0, "dragon shares should be burned");
+        assertFalse(strategy.enableBurning(), "burning disabled atomically");
+    }
+
+    function test_bailsec31_disableBurningSucceedsWhenNoPendingDragonBurn() public {
+        _seedBailsec31DragonProfit();
+
+        vm.prank(management);
+        strategy.setEnableBurning(false);
+
+        assertFalse(strategy.enableBurning(), "burning disabled");
+        assertEq(strategy.balanceOf(donationAddress), 50e18, "dragon shares unchanged");
+    }
+
+    function test_bailsec31_reportAndDisableBurningOnlyManagement() public {
+        vm.prank(user);
+        vm.expectRevert("!management");
+        IYieldSkimmingStrategy(address(strategy)).reportAndDisableBurning();
     }
 
     // ================== Dragon Router Cooldown Tests ==================


### PR DESCRIPTION
Fixes `Bailsec #31` at the logic level: prevents disabling `enableBurning` before pending dragon burns are synchronized in yield-skimming and yield-donating strategies, adds atomic `reportAndDisableBurning()` flows, and keeps direct disabling safe through strategy-specific accounting checks.\n\nVerified with focused Forge suites for yield-skimming and yield-donating burning behavior, plus build and formatting checks.