### PR TITLE
ci: restore Kontrol PR check

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,4 +1,4 @@
-name: '⚙️ PR Standards Check'
+name: "⚙️ PR Standards Check"
 on:
   pull_request:
     branches:
@@ -276,6 +276,47 @@ jobs:
             exit 1
           fi
           echo "All coverage metrics meet the ${THRESHOLD}% threshold."
+
+  kontrol-proofs:
+    name: Kontrol Formal Verification
+    if: github.head_ref != 'main'
+    runs-on: general
+    continue-on-error: true
+    container:
+      image: runtimeverificationinc/kontrol:ubuntu-jammy-1.0.231
+      options: --user root
+    env:
+      PYTHONPATH: /home/user/.local/lib/python3.10/site-packages
+      XDG_CACHE_HOME: /home/user/.cache
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Fix Python environment
+        run: rm -f /home/user/.local/lib/python3.10/site-packages/typing.py
+
+      - name: Install Forge dependencies
+        run: |
+          for attempt in 1 2 3; do
+            if forge soldeer install; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt 3 ]; then
+              echo "forge soldeer install failed on attempt ${attempt}/3; retrying..."
+              sleep $((attempt * 10))
+            fi
+          done
+
+          echo "forge soldeer install failed after 3 attempts"
+          exit 1
+
+      - name: Kontrol Build
+        run: kontrol build
+
+      - name: Kontrol Prove
+        run: kontrol prove --workers 4
+        timeout-minutes: 240
 
   analyze:
     name: Analyze with Slither


### PR DESCRIPTION
## Summary
- Restore the non-blocking Kontrol formal verification job to the current PR workflow.
- Keep the last known working Kontrol container and environment settings.
- Run `forge soldeer install`, `kontrol build`, and `kontrol prove --workers 4` for PRs.

## Blame / regression timeline
- Kontrol CI was added in `ac4d6e6f` on 2026-02-09 by Ferit: `ci: add Kontrol formal verification as non-blocking PR check`.
- The job was then fixed/hardened across several follow-up CI commits on 2026-02-09 and 2026-02-10:
  - `edb0a74c`: use the correct Docker Hub image
  - `6e3d708c`: run the Kontrol container as root for workspace permissions
  - `e1d351d9`: set `PYTHONPATH` when running as root
  - `0bb2fb8c`: remove the conflicting `typing.py` backport
  - `e6101209` / `43bdc231`: set K/Kontrol cache/data paths
  - `b9ca02f6`: increase `kontrol prove` workers to 4 and timeout to 240 minutes
- The job was still present immediately before the CI revamp in `.github/workflows/pull-request.yml` as `kontrol-proofs`, running `kontrol build` and `kontrol prove --workers 4`.
- The regression was introduced by `e51f4225` on 2026-04-03, authored and committed by Michał Kluczek: `ci: CICD workflows revamp [skip ci]`.
- That commit deleted `.github/workflows/pull-request.yml` and introduced `.github/workflows/pr-checks.yml`, but did not carry over the `kontrol-proofs` job.
- Result: since `e51f4225`, PR CI has continued running the standard Forge test job, but it no longer schedules Kontrol at all. The normal `yarn test:ci` path does not cover this because the default Foundry profile excludes the Kontrol tests.
