### PR TITLE
[codex] fix yield-donating virtual offset accounting

### DIFF
--- a/kontrol.toml
+++ b/kontrol.toml
@@ -41,7 +41,7 @@ auto_abstract              = true
 run-constructor            = false
 match-test                 = [
         # ============================================
-        # YieldDonating strategy proofs (7 inherited + 4 unique = 11)
+        # YieldDonating strategy proofs (7 inherited + 5 unique = 12)
         # ============================================
         # Inherited from StrategyBaseTest
         "YDStrategyTest.testTend()",
@@ -56,6 +56,7 @@ match-test                 = [
         "YDStrategyTest.testReportLossInsufficientDragon()",
         "YDStrategyTest.testSharesRedeemableAfterDepositYD(uint256,address)",
         "YDStrategyTest.testConversionConsistencyYD(uint256)",
+        "YDStrategyTest.testDustLossRecoveryFlowMintsDragonAndBlocksFinalDustBurn(uint256)",
         # ============================================
         # YieldSkimming strategy proofs (4 inherited + 11 unique = 15)
         # ============================================

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -474,6 +474,14 @@ abstract contract TokenizedStrategy {
     ///      10,000 basis points = 100%
     uint256 internal constant MAX_BPS = 10_000;
 
+    /// @notice Virtual assets used in ERC4626 conversions to avoid empty-vault inflation cliffs.
+    /// @dev Uses an OpenZeppelin/YieldBox-style virtual offset with 0 extra share decimals.
+    uint256 internal constant VIRTUAL_ASSETS = 1;
+
+    /// @notice Virtual shares used in ERC4626 conversions to avoid empty-vault inflation cliffs.
+    /// @dev Kept at 1 so existing share decimals and normal 1:1 healthy-path accounting remain unchanged.
+    uint256 internal constant VIRTUAL_SHARES = 1;
+
     /// @notice Mandatory cooldown period for dragon router changes
     /// @dev 14 days in seconds. Prevents rapid changes that could enable attacks
     ///      OCTANT-SPECIFIC security feature to protect yield distribution
@@ -817,7 +825,7 @@ abstract contract TokenizedStrategy {
     /**
      * @notice Converts asset amount to equivalent shares
      * @dev Uses Floor rounding (conservative for conversions)
-     *      Formula: (assets * totalSupply) / totalAssets
+     *      Formula: (assets * (totalSupply + virtualShares)) / (totalAssets + virtualAssets)
      * @param assets Amount of assets to convert
      * @return shares_ Equivalent amount of shares
      */
@@ -828,7 +836,7 @@ abstract contract TokenizedStrategy {
     /**
      * @notice Converts share amount to equivalent assets
      * @dev Uses Floor rounding (conservative for conversions)
-     *      Formula: (shares * totalAssets) / totalSupply
+     *      Formula: (shares * (totalAssets + virtualAssets)) / (totalSupply + virtualShares)
      * @param shares Amount of shares to convert
      * @return assets_ Equivalent amount of assets
      */
@@ -968,16 +976,7 @@ abstract contract TokenizedStrategy {
         uint256 assets,
         Math.Rounding _rounding
     ) internal view virtual returns (uint256) {
-        // Saves an extra SLOAD if values are non-zero.
-        uint256 totalSupply_ = _totalSupply(S);
-        // If supply is 0, PPS = 1.
-        if (totalSupply_ == 0) return assets;
-
-        uint256 totalAssets_ = _totalAssets(S);
-        // If assets are 0 but supply is not PPS = 0.
-        if (totalAssets_ == 0) return 0;
-
-        return assets.mulDiv(totalSupply_, totalAssets_, _rounding);
+        return assets.mulDiv(_totalSupply(S) + VIRTUAL_SHARES, _totalAssets(S) + VIRTUAL_ASSETS, _rounding);
     }
 
     /// @dev Internal implementation of {convertToAssets}.
@@ -989,10 +988,7 @@ abstract contract TokenizedStrategy {
         uint256 shares,
         Math.Rounding _rounding
     ) internal view virtual returns (uint256) {
-        // Saves an extra SLOAD if totalSupply() is non-zero.
-        uint256 supply = _totalSupply(S);
-
-        return supply == 0 ? shares : shares.mulDiv(_totalAssets(S), supply, _rounding);
+        return shares.mulDiv(_totalAssets(S) + VIRTUAL_ASSETS, _totalSupply(S) + VIRTUAL_SHARES, _rounding);
     }
 
     /// @dev Internal implementation of {maxDeposit}.

--- a/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
+++ b/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
@@ -711,7 +711,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
         lossImpl.redeem(5e18, user, user, 10000);
     }
 
-    // --- Mint zero assets => ZERO_ASSETS (line 685, branch 0) ---
+    // --- Mint zero shares => ZERO_ASSETS (line 685, branch 0) ---
 
     function test_mint_zeroAssets_reverts() public {
         MockTokenizedStrategyWithLoss lossImpl = _freshLossImpl();
@@ -726,17 +726,14 @@ contract TokenizedStrategyBranchCoverageTest is Test {
             false
         );
 
-        // totalSupply > 0 but totalAssets == 0 => _convertToAssets returns 0
-        lossImpl.mintShares(user, 10e18);
-
         vm.prank(user);
         vm.expectRevert("ZERO_ASSETS");
-        lossImpl.mint(1e18, user);
+        lossImpl.mint(0, user);
     }
 
-    // --- _convertToShares when totalAssets == 0 (line 961, branch 0) ---
+    // --- _convertToShares when totalAssets == 0 uses the virtual offset ---
 
-    function test_convertToShares_totalAssetsZero_returnsZero() public {
+    function test_convertToShares_totalAssetsZero_usesVirtualOffset() public {
         MockTokenizedStrategyWithLoss lossImpl = _freshLossImpl();
         lossImpl.initialize(
             address(asset),
@@ -752,7 +749,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
         lossImpl.mintShares(user, 10e18);
 
         uint256 shares = lossImpl.convertToShares(1e18);
-        assertEq(shares, 0, "convertToShares should return 0 when totalAssets == 0");
+        assertEq(shares, 1e18 * (10e18 + 1), "convertToShares should use virtual assets and shares");
     }
 
     // --- maxMint with limited deposit (line 995, branch 0) ---

--- a/test/unit/strategies/yieldDonating/VirtualOffset.t.sol
+++ b/test/unit/strategies/yieldDonating/VirtualOffset.t.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.18;
+
+import { Setup } from "./utils/Setup.sol";
+
+contract VirtualOffsetTest is Setup {
+    uint256 internal constant TS_BASE =
+        uint256(0x4df8983d84042631e7325fb5ba31b73b056fa9890e796c4c95fbf1e6d76eba00);
+    uint256 internal constant TS_TOTAL_SUPPLY_SLOT = TS_BASE + 8;
+    uint256 internal constant TS_TOTAL_ASSETS_SLOT = TS_BASE + 9;
+
+    address internal dustHolder = address(0xA11CE);
+    address internal depositor = address(0xB0B);
+
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function test_virtualOffset_preservesHealthyFirstDepositOneToOne() public {
+        uint256 assets = 100e18;
+
+        asset.mint(depositor, assets);
+        vm.startPrank(depositor);
+        asset.approve(address(strategy), assets);
+        uint256 shares = strategy.deposit(assets, depositor);
+        vm.stopPrank();
+
+        assertEq(shares, assets, "empty healthy vault should still mint 1:1");
+        assertEq(strategy.totalAssets(), assets, "total assets");
+        assertEq(strategy.totalSupply(), assets, "total supply");
+        assertEq(strategy.balanceOf(depositor), assets, "depositor shares");
+    }
+
+    function test_virtualOffset_allowsDepositWhenTrackedAssetsZeroAndSupplyDust() public {
+        _createZeroAssetDustShareState();
+
+        asset.mint(depositor, 1);
+        vm.startPrank(depositor);
+        asset.approve(address(strategy), 1);
+        uint256 shares = strategy.deposit(1, depositor);
+        vm.stopPrank();
+
+        assertEq(shares, 2, "virtual offset should avoid ZERO_SHARES DoS");
+        assertEq(strategy.totalAssets(), 1, "total assets after deposit");
+        assertEq(strategy.totalSupply(), 3, "dust plus depositor shares");
+        assertEq(strategy.maxRedeem(depositor), 2, "depositor shares redeemable");
+        assertEq(strategy.convertToAssets(2), 1, "depositor can recover the deposited wei");
+    }
+
+    function test_virtualOffset_recoveryReportMintsDragonAndBlocksFinalDustBurn() public {
+        _createZeroAssetDustShareState();
+
+        uint256 recoveredAssets = 100e18;
+        asset.mint(address(yieldSource), recoveredAssets);
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = strategy.report();
+
+        assertEq(profit, recoveredAssets, "recovery should be reported as profit");
+        assertEq(loss, 0, "no loss on recovery");
+        assertEq(strategy.totalAssets(), recoveredAssets, "tracked assets restored");
+        assertEq(strategy.balanceOf(donationAddress), recoveredAssets * 2, "dragon gets recovery shares");
+        assertEq(strategy.totalSupply(), recoveredAssets * 2 + 1, "dust remains but no longer dominates");
+
+        assertEq(strategy.maxWithdraw(dustHolder), 0, "dust holder cannot withdraw even 1 wei");
+        vm.expectRevert("ERC4626: withdraw more than max");
+        vm.prank(dustHolder);
+        strategy.withdraw(1, dustHolder, dustHolder, MAX_BPS);
+
+        assertGt(strategy.totalSupply(), 0, "supply must not reset to zero");
+        assertEq(strategy.totalAssets(), recoveredAssets, "assets remain assigned against dragon supply");
+    }
+
+    function test_virtualOffset_bailsecChainCannotReachSupplyZeroAssetsPositive() public {
+        _createZeroAssetDustShareState();
+
+        uint256 recoveredAssets = 100e18;
+        asset.mint(address(yieldSource), recoveredAssets);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        vm.expectRevert("ERC4626: withdraw more than max");
+        vm.prank(dustHolder);
+        strategy.withdraw(1, dustHolder, dustHolder, MAX_BPS);
+
+        assertGt(strategy.totalSupply(), 0, "final dust burn should be impossible");
+        assertEq(strategy.totalAssets(), recoveredAssets, "ghost-collateral state should not form");
+    }
+
+    function test_virtualOffset_forcedGhostStateRejectsDustFirstDepositor() public {
+        _forceTotals({ totalSupply_: 0, totalAssets_: 100e18 });
+
+        assertEq(strategy.previewDeposit(1), 0, "dust deposit should preview zero shares");
+
+        asset.mint(dustHolder, 1);
+        vm.startPrank(dustHolder);
+        asset.approve(address(strategy), 1);
+        vm.expectRevert("ZERO_SHARES");
+        strategy.deposit(1, dustHolder);
+        vm.stopPrank();
+
+        assertEq(strategy.totalSupply(), 0, "supply unchanged");
+        assertEq(strategy.totalAssets(), 100e18, "tracked assets unchanged");
+    }
+
+    function test_virtualOffset_reportAssignsRecoveredAssetsToDragonWhenSupplyIsZero() public {
+        uint256 recoveredAssets = 100e18;
+        asset.mint(address(yieldSource), recoveredAssets);
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = strategy.report();
+
+        assertEq(profit, recoveredAssets, "recovery should be reported as profit");
+        assertEq(loss, 0, "no loss");
+        assertEq(strategy.balanceOf(donationAddress), recoveredAssets, "dragon receives first recovery shares");
+        assertEq(strategy.totalSupply(), recoveredAssets, "recovery creates dragon supply");
+        assertEq(strategy.totalAssets(), recoveredAssets, "assets tracked");
+    }
+
+    function _createZeroAssetDustShareState() internal {
+        uint256 initialDeposit = 100e18;
+
+        asset.mint(dustHolder, initialDeposit);
+        vm.startPrank(dustHolder);
+        asset.approve(address(strategy), initialDeposit);
+        strategy.deposit(initialDeposit, dustHolder);
+        vm.stopPrank();
+
+        yieldSource.simulateLoss(initialDeposit - 1);
+
+        vm.prank(dustHolder);
+        strategy.withdraw(initialDeposit - 1, dustHolder, dustHolder, MAX_BPS);
+
+        assertEq(strategy.totalAssets(), 1, "setup: tracked dust asset");
+        assertEq(strategy.totalSupply(), 1, "setup: dust share");
+        assertEq(strategy.balanceOf(dustHolder), 1, "setup: holder has one dust share");
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = strategy.report();
+
+        assertEq(profit, 0, "setup: no profit");
+        assertEq(loss, 1, "setup: final loss realized");
+        assertEq(strategy.totalAssets(), 0, "setup: zero tracked assets");
+        assertEq(strategy.totalSupply(), 1, "setup: positive supply");
+        assertEq(strategy.balanceOf(donationAddress), 0, "setup: no dragon shares");
+    }
+
+    function _forceTotals(uint256 totalSupply_, uint256 totalAssets_) internal {
+        vm.store(address(strategy), bytes32(TS_TOTAL_SUPPLY_SLOT), bytes32(totalSupply_));
+        vm.store(address(strategy), bytes32(TS_TOTAL_ASSETS_SLOT), bytes32(totalAssets_));
+    }
+}

--- a/verification/kontrol/YDStrategyTest.k.sol
+++ b/verification/kontrol/YDStrategyTest.k.sol
@@ -17,11 +17,13 @@ struct YDProofState {
 /**
  * @title YDStrategyTest
  * @notice Kontrol formal verification proofs for YieldDonatingTokenizedStrategy
- * @dev Inherits 7 common proofs from StrategyBaseTest and adds 4 YD-specific proofs:
- *      - testReportProfit: shares minted to dragon, PPS non-decreasing
+ * @dev Inherits 7 common proofs from StrategyBaseTest and adds 5 YD-specific proofs:
+ *      - testReportProfit: virtual-offset shares minted to dragon, virtual PPS non-decreasing
  *      - testReportLossInsufficientDragon: partial burn, PPS impact bounded
  *      - testSharesRedeemableAfterDepositYD: deposit produces redeemable shares
  *      - testConversionConsistencyYD: round-trip does not create value
+ *      - testDustLossRecoveryFlowMintsDragonAndBlocksFinalDustBurn:
+ *          recovery from totalAssets=0,totalSupply=1 mints dragon shares and traps dust
  */
 contract YDStrategyTest is StrategyBaseTest, YDSetup {
     YDProofState private preState;
@@ -100,9 +102,15 @@ contract YDStrategyTest is StrategyBaseTest, YDSetup {
                     INVARIANTS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice PPS does not decrease: totalAssets_new * totalSupply_old >= totalAssets_old * totalSupply_new
+    /// @notice Virtual PPS does not decrease:
+    ///         (totalAssets_new + 1) * (totalSupply_old + 1)
+    ///         >= (totalAssets_old + 1) * (totalSupply_new + 1)
     function ppsNonDecreasingInvariant(Mode mode) internal view {
-        _establish(mode, postState.totalAssets * preState.totalSupply >= preState.totalAssets * postState.totalSupply);
+        _establish(
+            mode,
+            (postState.totalAssets + 1) * (preState.totalSupply + 1) >=
+                (preState.totalAssets + 1) * (postState.totalSupply + 1)
+        );
     }
 
     /// @notice totalAssets updated to the expected value
@@ -120,7 +128,7 @@ contract YDStrategyTest is StrategyBaseTest, YDSetup {
     //////////////////////////////////////////////////////////////*/
 
     /// @notice When report harvests a profit, shares are minted to dragon router
-    ///         and PPS is preserved (non-decreasing) for regular holders
+    ///         and virtual PPS is preserved (non-decreasing) for regular holders
     function testReportProfit() public {
         _assumeNonReentrant();
 
@@ -139,12 +147,14 @@ contract YDStrategyTest is StrategyBaseTest, YDSetup {
         vm.assume(newTotalAssets > preState.totalAssets);
         _storeUInt256(address(strategy), MOCK_NEXT_TOTAL_ASSETS_SLOT, newTotalAssets);
 
-        // Avoid overflow in sharesToMint = profit * totalSupply / totalAssets
+        // Avoid overflow in sharesToMint = profit * (totalSupply + 1) / (totalAssets + 1)
         uint256 profit = newTotalAssets - preState.totalAssets;
-        _assumeNoOverflow(profit, preState.totalSupply);
+        uint256 virtualSupply = preState.totalSupply + 1;
+        uint256 virtualAssets = preState.totalAssets + 1;
+        _assumeNoOverflow(profit, virtualSupply);
 
         // Avoid overflow in totalSupply + sharesToMint
-        uint256 sharesToMint = (profit * preState.totalSupply) / preState.totalAssets;
+        uint256 sharesToMint = (profit * virtualSupply) / virtualAssets;
         _assumeNoOverflow(preState.totalSupply, sharesToMint);
 
         // Avoid overflow in dragonBalance + sharesToMint
@@ -197,8 +207,10 @@ contract YDStrategyTest is StrategyBaseTest, YDSetup {
         _storeUInt256(address(strategy), MOCK_NEXT_TOTAL_ASSETS_SLOT, newTotalAssets);
 
         uint256 loss = preState.totalAssets - newTotalAssets;
-        _assumeNoOverflow(loss, preState.totalSupply);
-        uint256 sharesToBurn = Math.ceilDiv(loss * preState.totalSupply, preState.totalAssets);
+        uint256 virtualSupply = preState.totalSupply + 1;
+        uint256 virtualAssets = preState.totalAssets + 1;
+        _assumeNoOverflow(loss, virtualSupply);
+        uint256 sharesToBurn = Math.mulDiv(loss, virtualSupply, virtualAssets, Math.Rounding.Floor);
         vm.assume(sharesToBurn > preState.dragonBalance);
 
         vm.startPrank(_keeper);
@@ -234,8 +246,10 @@ contract YDStrategyTest is StrategyBaseTest, YDSetup {
         vm.assume(totalAssets > 0);
         vm.assume(totalSupply > 0);
 
-        _assumeNoOverflow(assets, totalSupply);
-        uint256 expectedShares = (assets * totalSupply) / totalAssets;
+        uint256 virtualSupply = totalSupply + 1;
+        uint256 virtualAssets = totalAssets + 1;
+        _assumeNoOverflow(assets, virtualSupply);
+        uint256 expectedShares = (assets * virtualSupply) / virtualAssets;
         vm.assume(expectedShares > 0);
         _assumeNoOverflow(totalSupply, expectedShares);
         _assumeNoOverflow(totalAssets, assets);
@@ -288,5 +302,43 @@ contract YDStrategyTest is StrategyBaseTest, YDSetup {
         _assumeNoOverflow(amount, totalAssets);
 
         _assertConversionConsistency(amount);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    YD-SPECIFIC: DUST LOSS RECOVERY FLOW
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Regression for the Bailsec dust-loss-recovery chain.
+    ///         From totalAssets=0,totalSupply=1, any positive recovery report
+    ///         mints dragon shares through the virtual-offset converter, and
+    ///         the original dust share cannot withdraw 1 wei afterward.
+    function testDustLossRecoveryFlowMintsDragonAndBlocksFinalDustBurn(uint256 recoveredAssets) public {
+        _assumeNonReentrant();
+
+        address stratAddr = getStrategyAddr();
+        address dustHolder = makeAddr("DUST_HOLDER");
+
+        _storeData(stratAddr, HC_SLOT, HC_DO_HEALTH_CHECK_OFFSET, HC_DO_HEALTH_CHECK_WIDTH, 0);
+        _storeData(stratAddr, TS_FLAGS_SLOT, TS_SHUTDOWN_OFFSET, TS_SHUTDOWN_WIDTH, 0);
+        _storeData(stratAddr, TS_FLAGS_SLOT, TS_ENABLE_BURNING_OFFSET, TS_ENABLE_BURNING_WIDTH, 0);
+
+        vm.assume(recoveredAssets > 0);
+        vm.assume(recoveredAssets < ETH_UPPER_BOUND / 2);
+
+        _storeUInt256(stratAddr, TS_TOTAL_ASSETS_SLOT, 0);
+        _storeUInt256(stratAddr, TS_TOTAL_SUPPLY_SLOT, 1);
+        _storeMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(dustHolder)), 0, 1);
+        _storeMappingUInt256(stratAddr, TS_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0, 0);
+        _storeUInt256(stratAddr, MOCK_NEXT_TOTAL_ASSETS_SLOT, recoveredAssets);
+
+        vm.startPrank(_keeper);
+        iStrategy.report();
+        vm.stopPrank();
+
+        uint256 expectedDragonShares = recoveredAssets * 2;
+        assertEq(iStrategy.totalAssets(), recoveredAssets);
+        assertEq(iStrategy.balanceOf(_dragonRouter), expectedDragonShares);
+        assertEq(iStrategy.totalSupply(), expectedDragonShares + 1);
+        assertEq(iStrategy.maxWithdraw(dustHolder), 0);
     }
 }


### PR DESCRIPTION
## Summary

Implements Option A from the Bailsec discussion: add an OpenZeppelin/YieldBox-style virtual assets/shares offset to the core `TokenizedStrategy` ERC4626 conversion helpers.

The conversion helpers now use:

- `assets * (totalSupply + 1) / (totalAssets + 1)` for shares
- `shares * (totalAssets + 1) / (totalSupply + 1)` for assets

This keeps healthy first-deposit behavior effectively 1:1 while removing the dangerous zero-assets / nonzero-supply conversion cliff.

## Root Cause

The yield-donating vault could be pushed into a degenerate accounting state after a stale-accounting withdrawal and later loss report:

1. A holder withdraws almost all recoverable assets while leaving dust shares.
2. A loss report moves tracked `totalAssets` to zero while `totalSupply` remains nonzero.
3. A later recovery report sees profit while old tracked assets are zero, but profit-to-share conversion returned zero, so recovered value was not assigned to dragon.
4. The dust holder could then dominate recovered value and potentially produce a ghost state where `totalSupply == 0 && totalAssets > 0`, making the first post-reset deposit a mempool race.

## Fix

- Adds `VIRTUAL_ASSETS = 1` and `VIRTUAL_SHARES = 1` in `TokenizedStrategy`.
- Updates `_convertToShares` and `_convertToAssets` to always use the virtual-offset denominator/numerator instead of special-casing zero supply/assets.
- Updates stale branch-coverage expectations that encoded the old vulnerable zero-assets conversion behavior.
- Adds a focused `VirtualOffset.t.sol` regression suite covering the Bailsec path and adversarial ghost-state checks.
- Extends the Kontrol YD proof suite with a dust-loss-recovery proof and updates existing proof formulas to the virtual PPS model.

## Security Notes

In the concrete Bailsec recovery state `totalAssets == 0 && totalSupply == 1`, a positive recovery report now mints `recoveredAssets * 2` shares to dragon before updating tracked assets. That prevents the dust holder from becoming the sole claimant on recovered value and makes `maxWithdraw(dustHolder) == 0`, blocking the final dust-burn step.

A forced `totalSupply == 0 && totalAssets > 0` state is also tested: a 1 wei dust first deposit previews/mints zero shares and reverts with `ZERO_SHARES`, so the sandwichable first-depositor reset path is not available.

## Validation

Run on branch `feature/bailsec-17-virtual-offset-accounting` based on `origin/develop`:

- `forge test --match-path test/unit/strategies/yieldDonating/VirtualOffset.t.sol -vvv` - 6 passed
- `forge test --match-path 'test/unit/**' -vv` - 2032 passed
- `yarn build` - successful
- `FOUNDRY_PROFILE=kprove kontrol build` - successful
- `FOUNDRY_PROFILE=kprove kontrol prove --match-test 'YDStrategyTest.testDustLossRecoveryFlowMintsDragonAndBlocksFinalDustBurn(uint256)'` - proof passed

Earlier while hardening the proof suite, the old raw PPS invariant failed under virtual accounting, so the YD profit proof was updated to assert virtual PPS instead. That matches the new conversion model.
