### PR TITLE
ci: add PR preflight for unsupported sources

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -47,12 +47,12 @@ jobs:
             develop)
               if [ "$BASE_BRANCH" != "master" ]; then
                 private_ci_supported=false
-                echo "::error title=Unsupported branch name::Branch '$HEAD_BRANCH' is allowed only for production release PRs targeting master."
+                echo "::error title=Unsupported branch name::The 'develop' head branch is allowed only for production release PRs targeting master."
               fi
               ;;
             *)
               private_ci_supported=false
-              echo "::error title=Unsupported branch name::Branch '$HEAD_BRANCH' does not match the expected naming convention: $expected_branches."
+              echo "::error title=Unsupported branch name::The PR head branch does not match the expected naming convention: $expected_branches."
               ;;
           esac
 

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -17,12 +17,66 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  pr_preflight:
+    name: PR Preflight
+    if: github.head_ref != 'master'
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    outputs:
+      private_ci_supported: ${{ steps.check.outputs.private_ci_supported }}
+    steps:
+      - name: Check PR source and branch
+        id: check
+        env:
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPOSITORY: ${{ github.event.pull_request.base.repo.full_name }}
+          HEAD_BRANCH: ${{ github.head_ref }}
+          BASE_BRANCH: ${{ github.base_ref }}
+        run: |
+          private_ci_supported=true
+          expected_branches="feature/*, fix/*, bugfix/*, hotfix/*, release/*, chore/*, ci/*, docs/*, test/*, refactor/*, perf/*, or develop -> master production release"
+
+          if [ "$HEAD_REPOSITORY" != "$BASE_REPOSITORY" ]; then
+            private_ci_supported=false
+            echo "::error title=Unsupported PR source::PR Standards Check uses private container images. GitHub does not expose the required secrets to fork PRs. Push this branch to $BASE_REPOSITORY and open the PR from there."
+          fi
+
+          case "$HEAD_BRANCH" in
+            feature/*|fix/*|bugfix/*|hotfix/*|release/*|chore/*|ci/*|docs/*|test/*|refactor/*|perf/*)
+              ;;
+            develop)
+              if [ "$BASE_BRANCH" != "master" ]; then
+                private_ci_supported=false
+                echo "::error title=Unsupported branch name::Branch '$HEAD_BRANCH' is allowed only for production release PRs targeting master."
+              fi
+              ;;
+            *)
+              private_ci_supported=false
+              echo "::error title=Unsupported branch name::Branch '$HEAD_BRANCH' does not match the expected naming convention: $expected_branches."
+              ;;
+          esac
+
+          echo "private_ci_supported=$private_ci_supported" >> "$GITHUB_OUTPUT"
+
+          if [ "$private_ci_supported" != true ]; then
+            {
+              echo "## PR preflight failed"
+              echo ""
+              echo "- Head repository: \`$HEAD_REPOSITORY\`"
+              echo "- Base repository: \`$BASE_REPOSITORY\`"
+              echo "- Head branch: \`$HEAD_BRANCH\`"
+              echo "- Base branch: \`$BASE_BRANCH\`"
+              echo "- Expected branch names: \`$expected_branches\`"
+              echo ""
+              echo "Private-container CI can run only for branches in the base repository because fork PRs do not receive the required secrets."
+            } >> "$GITHUB_STEP_SUMMARY"
+            exit 1
+          fi
+
   check-formatting:
     name: Check Code Formatting
-    if: >-
-      github.base_ref != 'develop' ||
-      github.head_ref != 'master' ||
-      github.event.pull_request.head.repo.full_name != github.repository
+    needs: pr_preflight
+    if: needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -42,10 +96,8 @@ jobs:
 
   lint:
     name: Lint Code
-    if: >-
-      github.base_ref != 'develop' ||
-      github.head_ref != 'master' ||
-      github.event.pull_request.head.repo.full_name != github.repository
+    needs: pr_preflight
+    if: needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -65,10 +117,8 @@ jobs:
 
   conventional-commits:
     name: Conventional Commits
-    if: >-
-      github.base_ref != 'develop' ||
-      github.head_ref != 'master' ||
-      github.event.pull_request.head.repo.full_name != github.repository
+    needs: pr_preflight
+    if: needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -88,10 +138,8 @@ jobs:
 
   build:
     name: Build
-    if: >-
-      github.base_ref != 'develop' ||
-      github.head_ref != 'master' ||
-      github.event.pull_request.head.repo.full_name != github.repository
+    needs: pr_preflight
+    if: needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -113,10 +161,8 @@ jobs:
 
   test:
     name: Test suite
-    if: >-
-      github.base_ref != 'develop' ||
-      github.head_ref != 'master' ||
-      github.event.pull_request.head.repo.full_name != github.repository
+    needs: pr_preflight
+    if: needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: general
     container:
@@ -166,10 +212,8 @@ jobs:
 
   coverage:
     name: Code Coverage
-    if: >-
-      github.base_ref != 'develop' ||
-      github.head_ref != 'master' ||
-      github.event.pull_request.head.repo.full_name != github.repository
+    needs: pr_preflight
+    if: needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 30
     runs-on: general
     container:
@@ -297,8 +341,10 @@ jobs:
 
   kontrol-proofs:
     name: Kontrol Formal Verification
+    needs: pr_preflight
     # Run the expensive proofs only on the canonical develop -> master release PR path.
     if: >-
+      needs.pr_preflight.outputs.private_ci_supported == 'true' &&
       github.base_ref == 'master' &&
       github.head_ref == 'develop' &&
       github.event.pull_request.head.repo.full_name == github.repository
@@ -347,10 +393,8 @@ jobs:
 
   analyze:
     name: Analyze with Slither
-    if: >-
-      github.base_ref != 'develop' ||
-      github.head_ref != 'master' ||
-      github.event.pull_request.head.repo.full_name != github.repository
+    needs: pr_preflight
+    if: needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -379,10 +423,8 @@ jobs:
 
   trivy:
     name: Vulnerability Scan
-    if: >-
-      github.base_ref != 'develop' ||
-      github.head_ref != 'master' ||
-      github.event.pull_request.head.repo.full_name != github.repository
+    needs: pr_preflight
+    if: needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
@@ -394,10 +436,8 @@ jobs:
 
   natspec:
     name: NatSpec Documentation Check
-    if: >-
-      github.base_ref != 'develop' ||
-      github.head_ref != 'master' ||
-      github.event.pull_request.head.repo.full_name != github.repository
+    needs: pr_preflight
+    if: needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:
@@ -428,12 +468,10 @@ jobs:
 
   semver-check:
     name: Contract Semver Check
-    needs: kontrol-proofs
+    needs: [pr_preflight, kontrol-proofs]
     if: >-
       always() &&
-      (github.base_ref != 'develop' ||
-      github.head_ref != 'master' ||
-      github.event.pull_request.head.repo.full_name != github.repository)
+      needs.pr_preflight.outputs.private_ci_supported == 'true'
     timeout-minutes: 15
     runs-on: ubuntu-latest
     container:


### PR DESCRIPTION
## Summary

Adds a lightweight `pr_preflight` job to `.github/workflows/pr-checks.yml` that fails fast with project-owned `::error` annotations and a step summary when private-container CI cannot run on a PR. Downstream jobs depend on its `private_ci_supported` output, so unsupported PRs surface a clear message instead of GitHub's opaque `Unexpected value ''` template error.

## Behavior

| PR shape | Result |
|---|---|
| Same-repo conventional branches (`feature/*`, `fix/*`, `chore/*`, `ci/*`, etc.) | Preflight passes; all checks run |
| Same-repo `develop -> master` (production release) | All checks run; `kontrol-proofs` runs and `semver-check` requires it to succeed |
| `master -> develop` (release sync) | Preflight skipped via `if: github.head_ref != 'master'`; all jobs cascade-skip |
| Any fork PR | Preflight emits `Unsupported PR source` error, fails; downstream cascade-skip |
| Any other branch name | Preflight emits `Unsupported branch name` error, fails; downstream cascade-skip |

## Changes

- New `pr_preflight` job validates head repo (must equal base for private registry secrets) and head branch (expected naming list, plus `develop` only for production release into `master`).
- Every downstream job: `needs: pr_preflight` + `if: needs.pr_preflight.outputs.private_ci_supported == 'true'`.
- Workflow trigger uses `master` (Gitflow production branch), not `main`.
- `kontrol-proofs` runs only on `develop -> master`; `semver-check` integrates the preflight gate while keeping the prior kontrol requirement.
- `::error` annotations no longer interpolate attacker-controlled head branch name (avoids `%0A`/`%0D`/`%25` log injection); branch name remains in the step summary which does not use the workflow-command parser.

## Commits

- `b49a2ed5` ci(preflight): add fail-fast preflight for unsupported PR sources
- `c4c1cd41` ci(preflight): drop attacker-controlled head_ref from ::error lines