### PR TITLE
fix(yield-donating): lock minimum liquidity

### DIFF
--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -970,8 +970,12 @@ abstract contract TokenizedStrategy {
     ) internal view virtual returns (uint256) {
         // Saves an extra SLOAD if values are non-zero.
         uint256 totalSupply_ = _totalSupply(S);
-        // If supply is 0, PPS = 1.
-        if (totalSupply_ == 0) return assets;
+        if (totalSupply_ == 0) {
+            // A tracked positive-asset balance with zero shares is a corrupted
+            // ghost-collateral state. Do not price a first depositor at 1:1.
+            if (_totalAssets(S) != 0) return 0;
+            return assets;
+        }
 
         uint256 totalAssets_ = _totalAssets(S);
         // If assets are 0 but supply is not PPS = 0.
@@ -992,13 +996,21 @@ abstract contract TokenizedStrategy {
         // Saves an extra SLOAD if totalSupply() is non-zero.
         uint256 supply = _totalSupply(S);
 
-        return supply == 0 ? shares : shares.mulDiv(_totalAssets(S), supply, _rounding);
+        if (supply == 0) {
+            if (_totalAssets(S) != 0) return 0;
+            return shares;
+        }
+
+        return shares.mulDiv(_totalAssets(S), supply, _rounding);
     }
 
     /// @dev Internal implementation of {maxDeposit}.
     function _maxDeposit(StrategyData storage S, address receiver) internal view returns (uint256) {
         // Cannot deposit when shutdown or to the strategy.
         if (S.shutdown || receiver == address(this)) return 0;
+        uint256 totalSupply_ = _totalSupply(S);
+        uint256 totalAssets_ = _totalAssets(S);
+        if ((totalSupply_ == 0 && totalAssets_ != 0) || (totalSupply_ != 0 && totalAssets_ == 0)) return 0;
 
         return IBaseStrategy(address(this)).availableDepositLimit(receiver);
     }
@@ -1007,6 +1019,9 @@ abstract contract TokenizedStrategy {
     function _maxMint(StrategyData storage S, address receiver) internal view returns (uint256 maxMint_) {
         // Cannot mint when shutdown or to the strategy.
         if (S.shutdown || receiver == address(this)) return 0;
+        uint256 totalSupply_ = _totalSupply(S);
+        uint256 totalAssets_ = _totalAssets(S);
+        if ((totalSupply_ == 0 && totalAssets_ != 0) || (totalSupply_ != 0 && totalAssets_ == 0)) return 0;
 
         maxMint_ = IBaseStrategy(address(this)).availableDepositLimit(receiver);
         if (maxMint_ != type(uint256).max) {
@@ -1030,17 +1045,20 @@ abstract contract TokenizedStrategy {
 
     /// @dev Internal implementation of {maxRedeem}.
     function _maxRedeem(StrategyData storage S, address owner) internal view returns (uint256 maxRedeem_) {
+        uint256 balance = _balanceOf(S, owner);
+        if (balance == 0 || _convertToAssets(S, balance, Math.Rounding.Floor) == 0) return 0;
+
         // Get the max the owner could withdraw currently.
         maxRedeem_ = IBaseStrategy(address(this)).availableWithdrawLimit(owner);
 
         // Conversion would overflow and saves a min check if there is no withdrawal limit.
         if (maxRedeem_ == type(uint256).max) {
-            maxRedeem_ = _balanceOf(S, owner);
+            maxRedeem_ = balance;
         } else {
             maxRedeem_ = Math.min(
                 // Can't redeem more than the balance.
                 _convertToShares(S, maxRedeem_, Math.Rounding.Floor),
-                _balanceOf(S, owner)
+                balance
             );
         }
     }

--- a/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
@@ -22,26 +22,25 @@ import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
  * Terminal-state recovery (operator-managed):
  *      - After a catastrophic loss that reduces `totalAssets` to 0 while `totalSupply`
  *        remains positive (all dragon shares burned and residual loss socialized), the
- *        strategy enters a terminal state: `_convertToShares` returns 0 at the new PPS,
- *        so deposit() and mint() revert until accounting is restored by a future report
- *        and conversions no longer round to zero.
- *      - External donations of the underlying asset are not a dedicated recovery
- *        mechanism. A donated balance can raise `totalAssets` when report() records it,
- *        but the value flows proportionally to existing shareholders. At the terminal
- *        ratio the dragon-mint floors to 0, so no new profit shares accrue to the dragon
- *        router or donation receiver.
- *      - This contract does not implement an automatic recovery flow for that state.
- *        Recovery is operator-managed: call `shutdownStrategy` to stop new deposits while
- *        operators assess the position and migrate users to a fresh deployment if needed.
- *        Avoiding a donation-based rescue path prevents reintroducing first-depositor
- *        dust-extraction style issues.
+ *        strategy enters a terminal state: `_convertToShares` returns 0 while tracked
+ *        assets are 0, so deposit() and mint() revert until accounting is restored.
+ *      - A direct donation followed by report() can heal that state. When report()
+ *        observes recovered assets from a zero-asset state, surplus recovery shares
+ *        are minted to the dragon router as donation yield. This restores a usable
+ *        PPS without assigning the recovered surplus to stale dust holders.
  */
 
 contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
     using Math for uint256;
 
-    /// @notice Emitted when profit shares are minted to dragon router
-    /// @param dragonRouter Address receiving minted donation shares
+    /// @notice Permanently locked first shares, following the Uniswap V2 minimum-liquidity pattern
+    uint256 internal constant MINIMUM_LIQUIDITY = 1_000;
+
+    /// @notice Receiver for permanently locked minimum-liquidity shares
+    address internal constant MINIMUM_LIQUIDITY_RECEIVER = address(0xdead);
+
+    /// @notice Emitted when profit or recovery shares are minted
+    /// @param dragonRouter Address receiving minted donation or recovery shares
     /// @param amount Amount of shares minted in share base units
     event DonationMinted(address indexed dragonRouter, uint256 amount);
 
@@ -49,6 +48,118 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
     /// @param dragonRouter Address whose shares are burned
     /// @param amount Amount of shares burned in share base units
     event DonationBurned(address indexed dragonRouter, uint256 amount);
+
+    /// @inheritdoc TokenizedStrategy
+    function deposit(uint256 assets, address receiver) public virtual override nonReentrant returns (uint256 shares) {
+        StrategyData storage S = _strategyStorage();
+
+        if (assets == type(uint256).max) {
+            assets = S.asset.balanceOf(msg.sender);
+        }
+
+        require(assets <= _maxDepositWithMinimumLiquidity(S, receiver), "ERC4626: deposit more than max");
+        require((shares = _convertToShares(S, assets, Math.Rounding.Floor)) != 0, "ZERO_SHARES");
+
+        _deposit(S, receiver, assets, shares);
+    }
+
+    /// @dev Yield-donating first deposits fund permanently locked shares.
+    function _convertToShares(
+        StrategyData storage S,
+        uint256 assets,
+        Math.Rounding _rounding
+    ) internal view virtual override returns (uint256) {
+        if (_totalSupply(S) == 0) {
+            if (_totalAssets(S) != 0) return 0;
+            return assets > MINIMUM_LIQUIDITY ? assets - MINIMUM_LIQUIDITY : 0;
+        }
+
+        return super._convertToShares(S, assets, _rounding);
+    }
+
+    /// @inheritdoc TokenizedStrategy
+    function previewMint(uint256 shares) public view virtual override returns (uint256 assets) {
+        StrategyData storage S = _strategyStorage();
+        if (_totalSupply(S) == 0 && _totalAssets(S) == 0) return _addMinimumLiquidity(shares);
+
+        return super.previewMint(shares);
+    }
+
+    /// @inheritdoc TokenizedStrategy
+    function mint(uint256 shares, address receiver) public virtual override nonReentrant returns (uint256 assets) {
+        StrategyData storage S = _strategyStorage();
+
+        require(shares <= _maxMint(S, receiver), "ERC4626: mint more than max");
+
+        if (_totalSupply(S) == 0 && _totalAssets(S) == 0) {
+            assets = _addMinimumLiquidity(shares);
+        } else {
+            assets = _convertToAssets(S, shares, Math.Rounding.Ceil);
+        }
+
+        require(assets != 0, "ZERO_ASSETS");
+
+        _deposit(S, receiver, assets, shares);
+    }
+
+    /// @inheritdoc TokenizedStrategy
+    function maxDeposit(address receiver) public view virtual override returns (uint256) {
+        StrategyData storage S = _strategyStorage();
+
+        return _maxDepositWithMinimumLiquidity(S, receiver);
+    }
+
+    /// @inheritdoc TokenizedStrategy
+    function maxMint(address receiver) public view virtual override returns (uint256) {
+        StrategyData storage S = _strategyStorage();
+        if (_isZeroAssetTerminalState(S)) return 0;
+
+        return super.maxMint(receiver);
+    }
+
+    /// @inheritdoc TokenizedStrategy
+    function maxRedeem(address owner) public view virtual override returns (uint256) {
+        StrategyData storage S = _strategyStorage();
+        if (_isZeroAssetTerminalState(S)) return 0;
+
+        return super.maxRedeem(owner);
+    }
+
+    /// @dev Seeds permanently locked shares on the first successful yield-donating deposit/mint.
+    function _deposit(
+        StrategyData storage S,
+        address receiver,
+        uint256 assets,
+        uint256 shares
+    ) internal virtual override {
+        bool seedMinimumLiquidity = _totalSupply(S) == 0;
+
+        super._deposit(S, receiver, assets, shares);
+
+        if (seedMinimumLiquidity) {
+            _mint(S, MINIMUM_LIQUIDITY_RECEIVER, MINIMUM_LIQUIDITY);
+        }
+    }
+
+    function _addMinimumLiquidity(uint256 shares) internal pure returns (uint256) {
+        if (shares == 0) return 0;
+        if (shares > type(uint256).max - MINIMUM_LIQUIDITY) return type(uint256).max;
+        return shares + MINIMUM_LIQUIDITY;
+    }
+
+    function _maxDepositWithMinimumLiquidity(
+        StrategyData storage S,
+        address receiver
+    ) internal view returns (uint256 maxAssets) {
+        maxAssets = _maxDeposit(S, receiver);
+        // Empty yield-donating vaults need enough headroom to fund the dead-share lock.
+        if (_totalSupply(S) == 0 && _totalAssets(S) == 0 && maxAssets <= MINIMUM_LIQUIDITY) return 0;
+    }
+
+    function _isZeroAssetTerminalState(StrategyData storage S) internal view returns (bool) {
+        return _totalSupply(S) != 0 && _totalAssets(S) == 0;
+    }
+
     /**
      * @notice Reports strategy performance and distributes profits as donations
      * @dev Mints profit-derived shares to dragon router when newTotalAssets > oldTotalAssets; on loss, attempts
@@ -90,15 +201,35 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
             unchecked {
                 profit = newTotalAssets - oldTotalAssets;
             }
-            uint256 sharesToMint = _convertToShares(S, profit, Math.Rounding.Floor);
+            uint256 totalSupply_ = _totalSupply(S);
+            address sharesReceiver = _dragonRouter;
+            uint256 sharesToMint = 0;
+
+            if (totalSupply_ == 0) {
+                // Ghost collateral has assets but no share owner. Lock matching
+                // shares to the strategy so later deposits do not get first-
+                // depositor pricing against pre-existing assets.
+                sharesReceiver = address(this);
+                sharesToMint = newTotalAssets;
+            } else if (oldTotalAssets == 0) {
+                // Recovery from a zero-asset state should not let stale dust
+                // capture the surplus; normal conversion cannot price from zero.
+                // Existing supply receives up to 1 asset/share, surplus goes to dragon.
+                if (newTotalAssets > totalSupply_) {
+                    unchecked {
+                        sharesToMint = newTotalAssets - totalSupply_;
+                    }
+                }
+            } else {
+                sharesToMint = _convertToShares(S, profit, Math.Rounding.Floor);
+            }
 
             // Floor rounding can map dust profit to zero shares; skip the no-op mint and
             // DonationMinted emission so off-chain indexers do not see a donation event
             // without a corresponding supply change.
             if (sharesToMint != 0) {
-                // mint the shares to the dragon router
-                _mint(S, _dragonRouter, sharesToMint);
-                emit DonationMinted(_dragonRouter, sharesToMint);
+                _mint(S, sharesReceiver, sharesToMint);
+                emit DonationMinted(sharesReceiver, sharesToMint);
             }
         } else {
             unchecked {
@@ -109,6 +240,11 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
                 // Handle loss protection
                 _handleDragonLossProtection(S, loss);
             }
+        }
+
+        if (_totalSupply(S) == 0 && newTotalAssets != 0) {
+            _mint(S, address(this), newTotalAssets);
+            emit DonationMinted(address(this), newTotalAssets);
         }
 
         // Update the new total assets value

--- a/test/integration/strategies/YieldDonating/AaveV3Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/AaveV3Strategy.t.sol
@@ -470,10 +470,10 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         }
 
         if (shouldUser1Withdraw && shouldUser2Withdraw) {
-            assertLt(
+            assertLe(
                 IERC4626(address(strategy)).totalAssets(),
-                10,
-                "Strategy should be nearly empty after all withdrawals"
+                MINIMUM_LIQUIDITY + 10,
+                "Strategy should only retain minimum liquidity after all withdrawals"
             );
         }
     }

--- a/test/integration/strategies/YieldDonating/MorphoCompounderStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/MorphoCompounderStrategy.t.sol
@@ -454,10 +454,10 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
         }
 
         if (shouldUser1Withdraw && shouldUser2Withdraw) {
-            assertLt(
+            assertLe(
                 IERC4626(address(strategy)).totalAssets(),
-                10,
-                "Strategy should be nearly empty after all withdrawals"
+                MINIMUM_LIQUIDITY + 10,
+                "Strategy should only retain minimum liquidity after all withdrawals"
             );
         }
     }

--- a/test/integration/strategies/YieldDonating/SkyCompounder.t.sol
+++ b/test/integration/strategies/YieldDonating/SkyCompounder.t.sol
@@ -177,7 +177,11 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
         uint256 assetsReceived = vault.redeem(sharesToRedeem, user, user);
         vm.stopPrank();
 
-        assertEq(assetsReceived, depositAmount, "User should only receive original deposit");
+        assertEq(
+            assetsReceived,
+            depositAmount - MINIMUM_LIQUIDITY,
+            "User should receive original deposit less locked liquidity"
+        );
         assertEq(vault.balanceOf(donationAddress), profitAmount, "Donation address should receive profit in shares");
     }
 

--- a/test/integration/strategies/YieldDonating/SparkSUsdsStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/SparkSUsdsStrategy.t.sol
@@ -345,7 +345,12 @@ contract SparkSUsdsDonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 received = vault.redeem(redeemable, user, user);
         vm.stopPrank();
 
-        assertApproxEqAbs(received, amount, 2, "User should recover the deposited amount within rounding");
+        assertApproxEqAbs(
+            received,
+            amount - MINIMUM_LIQUIDITY,
+            2,
+            "User should recover deposited amount less locked liquidity"
+        );
         assertLe(vault.balanceOf(user), 2, "User should hold at most dust shares after full redeem");
     }
 

--- a/test/integration/strategies/YieldDonating/YearnV3Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/YearnV3Strategy.t.sol
@@ -456,10 +456,11 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         }
 
         if (shouldUser1Withdraw && shouldUser2Withdraw) {
-            assertLt(
+            uint256 expectedRemaining = profit <= totalDeposits ? profit + MINIMUM_LIQUIDITY : MINIMUM_LIQUIDITY;
+            assertLe(
                 IERC4626(address(strategy)).totalAssets(),
-                1000e6,
-                "Strategy should be nearly empty after all withdrawals"
+                expectedRemaining + 10,
+                "Strategy should only retain donation profit and minimum liquidity"
             );
         }
     }

--- a/test/integration/strategies/YieldDonating/base/BaseYieldDonatingIntegrationTest.sol
+++ b/test/integration/strategies/YieldDonating/base/BaseYieldDonatingIntegrationTest.sol
@@ -22,6 +22,9 @@ abstract contract BaseYieldDonatingIntegrationTest is BaseIntegrationTest {
     /// @notice Implementation of YieldDonatingTokenizedStrategy
     YieldDonatingTokenizedStrategy public implementation;
 
+    /// @notice Permanent first-deposit share lock used by yield-donating strategies.
+    uint256 internal constant MINIMUM_LIQUIDITY = 1_000;
+
     // ========== ABSTRACT METHODS ==========
 
     /// @notice Returns the compounder/staking vault address for mocking
@@ -257,12 +260,14 @@ abstract contract BaseYieldDonatingIntegrationTest is BaseIntegrationTest {
         uint256 user2Assets = vault.redeem(user2Shares, user2, user2);
         vm.stopPrank();
 
-        // Users should receive approximately their original deposits (profit goes to donation address)
-        uint256 user1ProfitPercentage = ((user1Assets - depositAmount1) * 1e18) / depositAmount1;
-        uint256 user2ProfitPercentage = ((user2Assets - depositAmount2) * 1e18) / depositAmount2;
-
-        assertEq(user1ProfitPercentage, 0, "User 1 should have received no profit");
-        assertEq(user1ProfitPercentage, user2ProfitPercentage, "Users should have received no profit");
+        // Users should receive no donated profit. The first depositor permanently funds MINIMUM_LIQUIDITY.
+        assertApproxEqAbs(
+            user1Assets,
+            depositAmount1 - MINIMUM_LIQUIDITY,
+            2,
+            "User 1 should receive deposit less locked liquidity"
+        );
+        assertApproxEqAbs(user2Assets, depositAmount2, 2, "User 2 should receive original deposit");
 
         // Check donation address received profit shares
         uint256 donationShares = vault.balanceOf(donationAddress);

--- a/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
+++ b/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
@@ -528,7 +528,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
 
         // The overloaded maxWithdraw that takes maxLoss should also work
         uint256 maxW = ITokenizedStrategy(address(strategy)).maxWithdraw(user, 0);
-        assertEq(maxW, 10e18);
+        assertEq(maxW, 10e18 - 1_000);
     }
 
     // --- maxRedeem with maxLoss param ---
@@ -541,7 +541,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
         vm.stopPrank();
 
         uint256 maxR = ITokenizedStrategy(address(strategy)).maxRedeem(user, 0);
-        assertEq(maxR, 10e18);
+        assertEq(maxR, 10e18 - 1_000);
     }
 
     // --- redeem more than max reverts ---
@@ -687,8 +687,8 @@ contract TokenizedStrategyBranchCoverageTest is Test {
         vm.stopPrank();
     }
 
-    // --- Redeem zero assets (line 769, branch 0) ---
-    // totalAssets == 0 while totalSupply > 0 => _convertToAssets returns 0
+    // --- Redeem blocked when no assets are redeemable ---
+    // totalAssets == 0 while totalSupply > 0 => maxRedeem returns 0
 
     function test_redeem_zeroAssets_reverts() public {
         MockTokenizedStrategyWithLoss lossImpl = _freshLossImpl();
@@ -706,12 +706,15 @@ contract TokenizedStrategyBranchCoverageTest is Test {
         // Mint shares directly (totalSupply > 0, totalAssets == 0)
         lossImpl.mintShares(user, 10e18);
 
+        assertEq(lossImpl.maxRedeem(user), 0, "maxRedeem");
+        assertEq(lossImpl.maxRedeem(user, 10000), 0, "maxRedeem overload");
+
         vm.prank(user);
-        vm.expectRevert("ZERO_ASSETS");
+        vm.expectRevert("ERC4626: redeem more than max");
         lossImpl.redeem(5e18, user, user, 10000);
     }
 
-    // --- Mint zero assets => ZERO_ASSETS (line 685, branch 0) ---
+    // --- Mint blocked when no assets can back minted shares ---
 
     function test_mint_zeroAssets_reverts() public {
         MockTokenizedStrategyWithLoss lossImpl = _freshLossImpl();
@@ -729,8 +732,10 @@ contract TokenizedStrategyBranchCoverageTest is Test {
         // totalSupply > 0 but totalAssets == 0 => _convertToAssets returns 0
         lossImpl.mintShares(user, 10e18);
 
+        assertEq(lossImpl.maxMint(user), 0, "maxMint");
+
         vm.prank(user);
-        vm.expectRevert("ZERO_ASSETS");
+        vm.expectRevert("ERC4626: mint more than max");
         lossImpl.mint(1e18, user);
     }
 

--- a/test/unit/strategies/yieldDonating/AccessControl.t.sol
+++ b/test/unit/strategies/yieldDonating/AccessControl.t.sol
@@ -486,7 +486,7 @@ contract AccessControlTest is Setup {
         strategy.redeem(userShares, user, user);
 
         // Should have received their funds back
-        assertEq(asset.balanceOf(user), _amount);
+        assertEq(asset.balanceOf(user), _amount - minimumLiquidity);
     }
 
     function test_reportingDuringPendingChange() public {

--- a/test/unit/strategies/yieldDonating/Accounting.t.sol
+++ b/test/unit/strategies/yieldDonating/Accounting.t.sol
@@ -11,6 +11,11 @@ contract AccountingTest is Setup {
         super.setUp();
     }
 
+    function _requiredMaxLoss(uint256 requestedAssets, uint256 expectedOut) internal view returns (uint256) {
+        uint256 realizedLoss = requestedAssets - expectedOut;
+        return (realizedLoss * MAX_BPS + requestedAssets - 1) / requestedAssets;
+    }
+
     function test_airdropDoesNotIncreasePPS(address _address, uint256 _amount, uint16 _profitFactor) public {
         _amount = bound(_amount, minFuzzAmount, maxFuzzAmount);
         _profitFactor = uint16(bound(uint256(_profitFactor), 10, MAX_BPS));
@@ -35,14 +40,15 @@ contract AccountingTest is Setup {
         checkStrategyTotals(strategy, _amount, _amount - toAirdrop, toAirdrop, _amount);
 
         uint256 beforeBalance = asset.balanceOf(_address);
+        uint256 userShares = strategy.balanceOf(_address);
+        uint256 userAssets = strategy.convertToAssets(userShares);
         vm.prank(_address);
-        strategy.redeem(_amount, _address, _address);
+        strategy.redeem(userShares, _address, _address);
 
         // should have pulled out just the deposited amount leaving the rest deployed.
-        assertEq(asset.balanceOf(_address), beforeBalance + _amount);
-        assertEq(asset.balanceOf(address(strategy)), 0);
-        assertEq(asset.balanceOf(address(yieldSource)), toAirdrop);
-        checkStrategyTotals(strategy, 0, 0, 0, 0);
+        assertEq(asset.balanceOf(_address), beforeBalance + userAssets);
+        assertEq(strategy.totalAssets(), minimumLiquidity);
+        assertEq(strategy.totalSupply(), minimumLiquidity);
     }
 
     function test_airdropDoesNotIncreasePPS_reportRecordsIt(
@@ -104,8 +110,10 @@ contract AccountingTest is Setup {
         checkStrategyTotals(strategy, _amount + toAirdrop, _amount, toAirdrop);
 
         uint256 beforeBalance = asset.balanceOf(_address);
+        uint256 userShares = strategy.balanceOf(_address);
+        uint256 userAssets = strategy.convertToAssets(userShares);
         vm.prank(_address);
-        strategy.redeem(_amount, _address, _address);
+        strategy.redeem(userShares, _address, _address);
 
         // withdaw donation address shares
         uint256 donationShares = strategy.balanceOf(donationAddress);
@@ -116,12 +124,13 @@ contract AccountingTest is Setup {
         vm.stopPrank();
 
         // should have pulled out the deposit plus profit that was reported but not the second airdrop
-        assertEq(asset.balanceOf(_address), beforeBalance + _amount);
+        assertEq(asset.balanceOf(_address), beforeBalance + userAssets);
         // assert donation address has the airdrop
         assertEq(asset.balanceOf(donationAddress), toAirdrop, "!donationAddress");
         assertEq(asset.balanceOf(address(strategy)), 0, "!strategy");
 
-        checkStrategyTotals(strategy, 0, 0, 0, 0);
+        assertEq(strategy.totalAssets(), minimumLiquidity);
+        assertEq(strategy.totalSupply(), minimumLiquidity);
     }
 
     function test_earningYieldDoesNotIncreasePPS(address _address, uint256 _amount, uint16 _profitFactor) public {
@@ -148,13 +157,15 @@ contract AccountingTest is Setup {
         checkStrategyTotals(strategy, _amount, _amount, 0, _amount);
 
         uint256 beforeBalance = asset.balanceOf(_address);
+        uint256 userShares = strategy.balanceOf(_address);
+        uint256 userAssets = strategy.convertToAssets(userShares);
         vm.prank(_address);
-        strategy.redeem(_amount, _address, _address);
+        strategy.redeem(userShares, _address, _address);
 
         // should have pulled out just the deposit amount
-        assertEq(asset.balanceOf(_address), beforeBalance + _amount);
-        assertEq(asset.balanceOf(address(yieldSource)), toAirdrop);
-        checkStrategyTotals(strategy, 0, 0, 0, 0);
+        assertEq(asset.balanceOf(_address), beforeBalance + userAssets);
+        assertEq(strategy.totalAssets(), minimumLiquidity);
+        assertEq(strategy.totalSupply(), minimumLiquidity);
     }
 
     function test_earningYieldDoesNotIncreasePPS_reportRecordsIt(
@@ -232,12 +243,13 @@ contract AccountingTest is Setup {
         vm.stopPrank();
 
         // should have pulled out the deposit plus profit that was reported but not the second airdrop
-        assertEq(asset.balanceOf(_address), beforeBalance + _amount);
+        assertEq(asset.balanceOf(_address), beforeBalance + _amount - minimumLiquidity);
         // assert donation address has the airdrop
         assertEq(asset.balanceOf(donationAddress), toAirdrop, "!donationAddress");
         assertEq(asset.balanceOf(address(strategy)), 0, "!strategy");
 
-        checkStrategyTotals(strategy, 0, 0, 0, 0);
+        assertEq(strategy.totalAssets(), minimumLiquidity);
+        assertEq(strategy.totalSupply(), minimumLiquidity);
     }
 
     function test_tend_noIdle_harvestProfit(uint256 _amount, uint16 _profitFactor) public {
@@ -278,8 +290,10 @@ contract AccountingTest is Setup {
         assertEq(strategy.pricePerShare(), pricePerShare);
 
         uint256 beforeBalance = asset.balanceOf(user);
+        uint256 userShares = strategy.balanceOf(user);
+        uint256 userAssets = strategy.convertToAssets(userShares);
         vm.prank(user);
-        strategy.redeem(_amount, user, user);
+        strategy.redeem(userShares, user, user);
 
         // withdaw donation address shares
         uint256 donationShares = strategy.balanceOf(donationAddress);
@@ -290,11 +304,12 @@ contract AccountingTest is Setup {
         vm.stopPrank();
 
         // should have pulled out the deposit plus profit that was reported but not the second airdrop
-        assertEq(asset.balanceOf(user), beforeBalance + _amount);
+        assertEq(asset.balanceOf(user), beforeBalance + userAssets);
         // assert donation address has the airdrop
         assertEq(asset.balanceOf(donationAddress), toAirdrop, "!donationAddress");
         assertEq(asset.balanceOf(address(strategy)), 0, "!strategy");
-        checkStrategyTotals(strategy, 0, 0, 0, 0);
+        assertEq(strategy.totalAssets(), minimumLiquidity);
+        assertEq(strategy.totalSupply(), minimumLiquidity);
     }
 
     function test_tend_idleFunds_harvestProfit(uint256 _amount, uint16 _profitFactor) public {
@@ -363,13 +378,15 @@ contract AccountingTest is Setup {
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
         uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
+        vm.assume(toLose > minimumLiquidity);
         // Simulate a loss.
         vm.prank(address(yieldSource));
         asset.transfer(address(69), toLose);
 
+        uint256 requestedAssets = strategy.convertToAssets(strategy.balanceOf(_address));
         vm.expectRevert("too much loss");
         vm.prank(_address);
-        strategy.withdraw(_amount, _address, _address);
+        strategy.withdraw(requestedAssets, _address, _address);
     }
 
     function test_withdrawWithUnrealizedLoss_withMaxLoss(address _address, uint256 _amount, uint16 _lossFactor) public {
@@ -380,21 +397,25 @@ contract AccountingTest is Setup {
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
         uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
+        vm.assume(toLose > minimumLiquidity);
         // Simulate a loss.
         vm.prank(address(yieldSource));
         asset.transfer(address(69), toLose);
 
         uint256 beforeBalance = asset.balanceOf(_address);
         uint256 expectedOut = _amount - toLose;
+        uint256 requestedAssets = strategy.convertToAssets(strategy.balanceOf(_address));
+        uint256 requiredMaxLoss = _requiredMaxLoss(requestedAssets, expectedOut);
         // Withdraw the full amount before the loss is reported.
         vm.prank(_address);
-        strategy.withdraw(_amount, _address, _address, _lossFactor);
+        strategy.withdraw(requestedAssets, _address, _address, requiredMaxLoss);
 
         uint256 afterBalance = asset.balanceOf(_address);
 
         assertEq(afterBalance - beforeBalance, expectedOut);
         assertEq(strategy.pricePerShare(), wad);
-        checkStrategyTotals(strategy, 0, 0, 0, 0);
+        assertEq(strategy.totalAssets(), minimumLiquidity);
+        assertEq(strategy.totalSupply(), minimumLiquidity);
     }
 
     function test_redeemWithUnrealizedLoss(address _address, uint256 _amount, uint16 _lossFactor) public {
@@ -405,21 +426,24 @@ contract AccountingTest is Setup {
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
         uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
+        vm.assume(toLose > minimumLiquidity);
         // Simulate a loss.
         vm.prank(address(yieldSource));
         asset.transfer(address(69), toLose);
 
         uint256 beforeBalance = asset.balanceOf(_address);
         uint256 expectedOut = _amount - toLose;
+        uint256 userShares = strategy.balanceOf(_address);
         // Withdraw the full amount before the loss is reported.
         vm.prank(_address);
-        strategy.redeem(_amount, _address, _address);
+        strategy.redeem(userShares, _address, _address);
 
         uint256 afterBalance = asset.balanceOf(_address);
 
         assertEq(afterBalance - beforeBalance, expectedOut);
         assertEq(strategy.pricePerShare(), wad);
-        checkStrategyTotals(strategy, 0, 0, 0, 0);
+        assertEq(strategy.totalAssets(), minimumLiquidity);
+        assertEq(strategy.totalSupply(), minimumLiquidity);
     }
 
     function test_redeemWithUnrealizedLoss_allowNoLoss_reverts(
@@ -434,13 +458,15 @@ contract AccountingTest is Setup {
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
         uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
+        vm.assume(toLose > minimumLiquidity);
         // Simulate a loss.
         vm.prank(address(yieldSource));
         asset.transfer(address(69), toLose);
 
+        uint256 userShares = strategy.balanceOf(_address);
         vm.expectRevert("too much loss");
         vm.prank(_address);
-        strategy.redeem(_amount, _address, _address, 0);
+        strategy.redeem(userShares, _address, _address, 0);
     }
 
     function test_redeemWithUnrealizedLoss_customMaxLoss(address _address, uint256 _amount, uint16 _lossFactor) public {
@@ -451,27 +477,32 @@ contract AccountingTest is Setup {
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
         uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
+        vm.assume(toLose > minimumLiquidity);
         // Simulate a loss.
         vm.prank(address(yieldSource));
         asset.transfer(address(69), toLose);
 
         uint256 beforeBalance = asset.balanceOf(_address);
         uint256 expectedOut = _amount - toLose;
+        uint256 userShares = strategy.balanceOf(_address);
+        uint256 requestedAssets = strategy.convertToAssets(userShares);
+        uint256 requiredMaxLoss = _requiredMaxLoss(requestedAssets, expectedOut);
 
         // First set it to just under the expected loss.
         vm.expectRevert("too much loss");
         vm.prank(_address);
-        strategy.redeem(_amount, _address, _address, _lossFactor - 1);
+        strategy.redeem(userShares, _address, _address, requiredMaxLoss - 1);
 
         // Now redeem with the correct loss.
         vm.prank(_address);
-        strategy.redeem(_amount, _address, _address, _lossFactor);
+        strategy.redeem(userShares, _address, _address, requiredMaxLoss);
 
         uint256 afterBalance = asset.balanceOf(_address);
 
         assertEq(afterBalance - beforeBalance, expectedOut);
         assertEq(strategy.pricePerShare(), wad);
-        checkStrategyTotals(strategy, 0, 0, 0, 0);
+        assertEq(strategy.totalAssets(), minimumLiquidity);
+        assertEq(strategy.totalSupply(), minimumLiquidity);
     }
 
     function test_maxUintDeposit_depositsBalance(address _address, uint256 _amount) public {
@@ -492,7 +523,7 @@ contract AccountingTest is Setup {
         checkStrategyTotals(strategy, _amount, _amount, 0, _amount);
 
         assertEq(asset.balanceOf(_address), 0);
-        assertEq(strategy.balanceOf(_address), _amount);
+        assertEq(strategy.balanceOf(_address), _amount - minimumLiquidity);
         assertEq(asset.balanceOf(address(strategy)), 0);
 
         assertEq(asset.balanceOf(address(yieldSource)), _amount);
@@ -543,7 +574,8 @@ contract AccountingTest is Setup {
         // 4. User gets fair share of remaining assets
         uint256 userShares = strategy.balanceOf(user);
         uint256 userAssetValue = strategy.convertToAssets(userShares);
-        assertEq(userAssetValue, 75e18, "User should get fair share of 75 remaining assets");
+        uint256 expectedUserAssetValue = ((80e18 - minimumLiquidity) * 75e18) / 80e18;
+        assertEq(userAssetValue, expectedUserAssetValue, "User should get fair share of 75 remaining assets");
     }
 
     /**

--- a/test/unit/strategies/yieldDonating/MinimumLiquidity.t.sol
+++ b/test/unit/strategies/yieldDonating/MinimumLiquidity.t.sol
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.25;
+
+import { Setup } from "./utils/Setup.sol";
+import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
+
+/// @notice Regression suite for the Bailsec dust-share accounting chain using
+///         Uniswap V2-style minimum liquidity plus dragon recovery-surplus shares.
+contract MinimumLiquidityTest is Setup {
+    address internal constant DEAD_SHARES = address(0xdead);
+    uint256 internal constant MINIMUM_LIQUIDITY = 1_000;
+
+    /// @dev ERC-7201 base slot derived from "octant.tokenized.strategy.storage". Matches the
+    ///      `BASE_STRATEGY_STORAGE` constant inside `TokenizedStrategy`.
+    bytes32 internal constant OCTANT_STRATEGY_STORAGE =
+        keccak256(abi.encode(uint256(keccak256("octant.tokenized.strategy.storage")) - 1)) & ~bytes32(uint256(0xff));
+
+    /// @dev StrategyData.totalSupply sits at offset 8 from the base.
+    bytes32 internal constant TOTAL_SUPPLY_SLOT = bytes32(uint256(OCTANT_STRATEGY_STORAGE) + 8);
+
+    /// @dev StrategyData.totalAssets sits one slot after totalSupply.
+    bytes32 internal constant TOTAL_ASSETS_SLOT = bytes32(uint256(OCTANT_STRATEGY_STORAGE) + 9);
+
+    address internal attacker = address(0xA11CE);
+    address internal victim = address(0xB0B);
+
+    function _deposit(address account, uint256 assets) internal returns (uint256 shares) {
+        asset.mint(account, assets);
+
+        vm.startPrank(account);
+        asset.approve(address(strategy), assets);
+        shares = strategy.deposit(assets, account);
+        vm.stopPrank();
+    }
+
+    function _writeStrategyState(uint256 totalSupply_, uint256 totalAssets_) internal {
+        vm.store(address(strategy), TOTAL_SUPPLY_SLOT, bytes32(totalSupply_));
+        vm.store(address(strategy), TOTAL_ASSETS_SLOT, bytes32(totalAssets_));
+    }
+
+    function _reportForcedRecovery(uint256 oldSupply, uint256 recovery) internal {
+        _writeStrategyState({ totalSupply_: oldSupply, totalAssets_: 0 });
+        asset.mint(address(strategy), recovery);
+
+        vm.prank(keeper);
+        strategy.report();
+    }
+
+    function _enterZeroAssetDustState(uint256 initialAssets) internal {
+        uint256 attackerShares = _deposit(attacker, initialAssets);
+
+        vm.prank(attacker);
+        strategy.withdraw(attackerShares - 1, attacker, attacker, MAX_BPS);
+
+        assertEq(strategy.balanceOf(attacker), 1, "attacker dust share");
+        assertEq(strategy.balanceOf(DEAD_SHARES), MINIMUM_LIQUIDITY, "dead shares seeded");
+        assertEq(strategy.totalSupply(), MINIMUM_LIQUIDITY + 1, "only dead plus dust supply remains");
+        assertEq(strategy.totalAssets(), MINIMUM_LIQUIDITY + 1, "only locked plus dust assets remain");
+
+        yieldSource.simulateLoss(MINIMUM_LIQUIDITY + 1);
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = strategy.report();
+
+        assertEq(profit, 0, "no profit on loss report");
+        assertEq(loss, MINIMUM_LIQUIDITY + 1, "remaining assets are reported lost");
+        assertEq(strategy.totalAssets(), 0, "tracked assets reduced to zero");
+        assertEq(strategy.totalSupply(), MINIMUM_LIQUIDITY + 1, "supply remains nonzero");
+    }
+
+    function test_firstDepositSeedsDeadMinimumLiquidity() public {
+        uint256 firstDeposit = 100 ether;
+
+        uint256 shares = _deposit(user, firstDeposit);
+
+        assertEq(shares, firstDeposit - MINIMUM_LIQUIDITY, "first depositor funds locked shares");
+        assertEq(strategy.balanceOf(user), firstDeposit - MINIMUM_LIQUIDITY, "user receives remainder");
+        assertEq(strategy.balanceOf(DEAD_SHARES), MINIMUM_LIQUIDITY, "dead address receives minimum");
+        assertEq(strategy.totalSupply(), firstDeposit, "total supply stays 1:1 with assets");
+        assertEq(strategy.totalAssets(), firstDeposit, "total assets track the deposit");
+    }
+
+    function test_firstDepositAtOrBelowMinimumLiquidityReverts() public {
+        asset.mint(user, MINIMUM_LIQUIDITY);
+
+        vm.startPrank(user);
+        asset.approve(address(strategy), MINIMUM_LIQUIDITY);
+        vm.expectRevert("ZERO_SHARES");
+        strategy.deposit(MINIMUM_LIQUIDITY, user);
+        vm.stopPrank();
+
+        assertEq(strategy.totalSupply(), 0, "no dead shares minted on failed first deposit");
+    }
+
+    function test_firstDepositMaxDepositReturnsZeroWhenLimitCannotFundMinimumLiquidity() public {
+        vm.mockCall(
+            address(strategy),
+            abi.encodeWithSelector(IBaseStrategy.availableDepositLimit.selector, victim),
+            abi.encode(MINIMUM_LIQUIDITY)
+        );
+
+        assertEq(strategy.maxDeposit(victim), 0, "dust first-deposit limit is unusable");
+        assertEq(strategy.maxMint(victim), 0, "dust first-deposit limit mints no shares");
+
+        asset.mint(victim, MINIMUM_LIQUIDITY);
+        vm.startPrank(victim);
+        asset.approve(address(strategy), MINIMUM_LIQUIDITY);
+        vm.expectRevert("ERC4626: deposit more than max");
+        strategy.deposit(MINIMUM_LIQUIDITY, victim);
+        vm.stopPrank();
+
+        vm.clearMockedCalls();
+    }
+
+    function test_firstDepositMaxDepositAllowsLimitAboveMinimumLiquidity() public {
+        uint256 limit = MINIMUM_LIQUIDITY + 1;
+
+        vm.mockCall(
+            address(strategy),
+            abi.encodeWithSelector(IBaseStrategy.availableDepositLimit.selector, victim),
+            abi.encode(limit)
+        );
+
+        assertEq(strategy.maxDeposit(victim), limit, "first-deposit limit can fund minimum liquidity");
+        assertEq(strategy.maxMint(victim), 1, "only surplus over minimum liquidity is mintable");
+
+        asset.mint(victim, limit);
+        vm.startPrank(victim);
+        asset.approve(address(strategy), limit);
+        uint256 shares = strategy.deposit(strategy.maxDeposit(victim), victim);
+        vm.stopPrank();
+
+        assertEq(shares, 1, "deposits the first usable share");
+        assertEq(strategy.balanceOf(DEAD_SHARES), MINIMUM_LIQUIDITY, "dead shares seeded");
+        assertEq(strategy.totalSupply(), limit, "supply includes first user and dead shares");
+        assertEq(strategy.totalAssets(), limit, "assets track the limited first deposit");
+
+        vm.clearMockedCalls();
+    }
+
+    function test_firstDepositAndMintPreviewBoundaries() public view {
+        assertEq(strategy.previewDeposit(MINIMUM_LIQUIDITY - 1), 0, "deposit below lock mints zero");
+        assertEq(strategy.previewDeposit(MINIMUM_LIQUIDITY), 0, "deposit equal to lock mints zero");
+        assertEq(strategy.previewDeposit(MINIMUM_LIQUIDITY + 1), 1, "deposit above lock mints remainder");
+        assertEq(strategy.previewMint(0), 0, "zero first mint costs zero");
+        assertEq(strategy.previewMint(1), MINIMUM_LIQUIDITY + 1, "first mint pays lock");
+    }
+
+    function test_firstMintIncludesMinimumLiquidityCost() public {
+        uint256 requestedShares = 10 ether;
+        uint256 requiredAssets = requestedShares + MINIMUM_LIQUIDITY;
+        asset.mint(user, requiredAssets);
+
+        vm.startPrank(user);
+        asset.approve(address(strategy), requiredAssets);
+        uint256 assets = strategy.mint(requestedShares, user);
+        vm.stopPrank();
+
+        assertEq(assets, requiredAssets, "first mint pays for locked liquidity");
+        assertEq(strategy.balanceOf(user), requestedShares, "user receives exact requested shares");
+        assertEq(strategy.balanceOf(DEAD_SHARES), MINIMUM_LIQUIDITY, "dead shares seeded");
+        assertEq(strategy.totalSupply(), requiredAssets, "supply equals deposited assets");
+        assertEq(strategy.totalAssets(), requiredAssets, "assets equal minted supply");
+    }
+
+    function test_zeroAssetTerminalStateMaxViewsReturnZero() public {
+        _enterZeroAssetDustState(100 ether);
+
+        assertEq(strategy.maxDeposit(victim), 0, "terminal maxDeposit");
+        assertEq(strategy.maxMint(victim), 0, "terminal maxMint");
+        assertEq(strategy.maxWithdraw(attacker), 0, "terminal maxWithdraw");
+        assertEq(strategy.maxWithdraw(attacker, MAX_BPS), 0, "terminal maxWithdraw overload");
+        assertEq(strategy.maxRedeem(attacker), 0, "terminal maxRedeem");
+        assertEq(strategy.maxRedeem(attacker, MAX_BPS), 0, "terminal maxRedeem overload");
+        assertEq(strategy.previewDeposit(1 ether), 0, "terminal previewDeposit");
+        assertEq(strategy.previewMint(1 ether), 0, "terminal previewMint");
+        assertEq(strategy.previewWithdraw(1), 0, "terminal previewWithdraw");
+        assertEq(strategy.previewRedeem(1), 0, "terminal previewRedeem");
+        assertEq(strategy.convertToShares(1 ether), 0, "terminal convertToShares");
+        assertEq(strategy.convertToAssets(1), 0, "terminal convertToAssets");
+    }
+
+    function test_zeroAssetTerminalStateBlocksDepositMintWithdrawAndRedeem() public {
+        _enterZeroAssetDustState(100 ether);
+
+        asset.mint(victim, 1 ether);
+        vm.startPrank(victim);
+        asset.approve(address(strategy), 1 ether);
+        vm.expectRevert("ERC4626: deposit more than max");
+        strategy.deposit(1 ether, victim);
+        vm.expectRevert("ERC4626: mint more than max");
+        strategy.mint(1 ether, victim);
+        vm.stopPrank();
+
+        vm.prank(attacker);
+        vm.expectRevert("ERC4626: withdraw more than max");
+        strategy.withdraw(1, attacker, attacker, MAX_BPS);
+
+        vm.prank(attacker);
+        vm.expectRevert("ERC4626: redeem more than max");
+        strategy.redeem(1, attacker, attacker, MAX_BPS);
+    }
+
+    function test_zeroAssetTerminalStateMaxViewsRecoverAfterReport() public {
+        uint256 recovery = 100 ether;
+
+        _enterZeroAssetDustState(100 ether);
+        asset.mint(address(strategy), recovery);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        assertEq(strategy.maxDeposit(victim), type(uint256).max, "deposit capacity restored");
+        assertEq(strategy.maxMint(victim), type(uint256).max, "mint capacity restored");
+        assertEq(strategy.maxWithdraw(attacker), 1, "dust withdrawal restored at capped value");
+        assertEq(strategy.maxRedeem(attacker), 1, "dust redeem restored at capped value");
+        assertEq(strategy.maxRedeem(attacker, MAX_BPS), 1, "redeem overload restored at capped value");
+    }
+
+    function test_recoveryReportMintsSurplusToDragonAndRestoresDonationMinting() public {
+        uint256 recovery = 100 ether;
+        uint256 laterProfit = 7 ether;
+        uint256 expectedRecoveryShares = recovery - MINIMUM_LIQUIDITY - 1;
+
+        _enterZeroAssetDustState(100 ether);
+
+        asset.mint(address(strategy), recovery);
+
+        vm.prank(keeper);
+        (uint256 recoveryProfit, uint256 recoveryLoss) = strategy.report();
+
+        assertEq(recoveryProfit, recovery, "donation is reported as recovered profit");
+        assertEq(recoveryLoss, 0, "no loss on recovery");
+        assertEq(strategy.totalAssets(), recovery, "tracked assets restored");
+        assertEq(strategy.totalSupply(), recovery, "recovery restores 1:1 PPS");
+        assertEq(strategy.balanceOf(address(strategy)), 0, "no surplus recovery shares are locked");
+        assertEq(strategy.balanceOf(donationAddress), expectedRecoveryShares, "surplus recovery shares go to dragon");
+        assertEq(strategy.maxWithdraw(attacker), 1, "dust holder can only claim its dust");
+
+        asset.mint(address(yieldSource), laterProfit);
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = strategy.report();
+
+        assertEq(profit, laterProfit, "later yield reports normally");
+        assertEq(loss, 0, "no later loss");
+        assertEq(
+            strategy.balanceOf(donationAddress),
+            expectedRecoveryShares + laterProfit,
+            "dragon keeps recovery shares and receives later profit shares"
+        );
+    }
+
+    function test_recoveryAtOrBelowOldSupplyDoesNotMintSurplusToDragon() public {
+        uint256 oldSupply = MINIMUM_LIQUIDITY + 1;
+
+        _reportForcedRecovery({ oldSupply: oldSupply, recovery: oldSupply - 1 });
+        assertEq(strategy.totalAssets(), oldSupply - 1, "below-supply recovery tracked");
+        assertEq(strategy.totalSupply(), oldSupply, "below-supply recovery does not mint");
+        assertEq(strategy.balanceOf(address(strategy)), 0, "no locked surplus below supply");
+        assertEq(strategy.balanceOf(donationAddress), 0, "dragon gets no below-supply surplus");
+    }
+
+    function test_recoveryEqualToOldSupplyDoesNotMintSurplusToDragon() public {
+        uint256 oldSupply = MINIMUM_LIQUIDITY + 1;
+
+        _reportForcedRecovery({ oldSupply: oldSupply, recovery: oldSupply });
+        assertEq(strategy.totalAssets(), oldSupply, "equal-supply recovery tracked");
+        assertEq(strategy.totalSupply(), oldSupply, "equal-supply recovery does not mint");
+        assertEq(strategy.balanceOf(address(strategy)), 0, "no locked surplus at supply boundary");
+        assertEq(strategy.balanceOf(donationAddress), 0, "dragon gets no equal-supply surplus");
+    }
+
+    function test_recoveryAboveOldSupplyMintsOnlySurplusToDragon() public {
+        uint256 oldSupply = MINIMUM_LIQUIDITY + 1;
+        uint256 recovery = 100 ether;
+        uint256 expectedRecoveryShares = recovery - oldSupply;
+
+        _reportForcedRecovery({ oldSupply: oldSupply, recovery: recovery });
+        assertEq(strategy.totalAssets(), recovery, "surplus recovery tracked");
+        assertEq(strategy.totalSupply(), recovery, "dragon surplus restores one-to-one pps");
+        assertEq(strategy.balanceOf(address(strategy)), 0, "no surplus is locked");
+        assertEq(strategy.balanceOf(donationAddress), expectedRecoveryShares, "only surplus goes to dragon");
+    }
+
+    function test_bailsecChainCannotReachFirstDepositorInflation() public {
+        uint256 recovery = 100 ether;
+        uint256 victimDeposit = 150 ether;
+
+        _enterZeroAssetDustState(100 ether);
+
+        asset.mint(address(strategy), recovery);
+
+        vm.prank(keeper);
+        strategy.report();
+
+        vm.prank(attacker);
+        strategy.withdraw(1, attacker, attacker, 0);
+
+        assertEq(strategy.totalAssets(), recovery - 1, "only requested dust asset is removed");
+        assertEq(strategy.totalSupply(), recovery - 1, "dragon shares keep supply nonzero");
+
+        uint256 attackerSandwichShares = _deposit(attacker, 1);
+        uint256 victimShares = _deposit(victim, victimDeposit);
+
+        assertEq(attackerSandwichShares, 1, "attacker receives fair shares for dust");
+        assertEq(victimShares, victimDeposit, "victim deposit mints at fair 1:1 PPS");
+
+        vm.prank(attacker);
+        uint256 attackerAssets = strategy.redeem(attackerSandwichShares, attacker, attacker, 0);
+
+        assertEq(attackerAssets, 1, "attacker cannot amplify a 1 wei deposit");
+    }
+
+    function test_forcedGhostStateBlocksDepositsUntilReportLocksShares() public {
+        uint256 trackedGhostAssets = 100 ether;
+        uint256 donatedAssets = 5 ether;
+
+        _writeStrategyState({ totalSupply_: 0, totalAssets_: trackedGhostAssets });
+        asset.mint(address(yieldSource), trackedGhostAssets + donatedAssets);
+
+        assertEq(strategy.maxDeposit(victim), 0, "ghost state blocks deposits");
+        assertEq(strategy.maxMint(victim), 0, "ghost state blocks mints");
+        assertEq(strategy.previewDeposit(1 ether), 0, "ghost state does not price first depositor");
+
+        asset.mint(victim, 1 ether);
+        vm.startPrank(victim);
+        asset.approve(address(strategy), 1 ether);
+        vm.expectRevert("ERC4626: deposit more than max");
+        strategy.deposit(1 ether, victim);
+        vm.stopPrank();
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = strategy.report();
+
+        assertEq(profit, donatedAssets, "report observes donated surplus");
+        assertEq(loss, 0, "no loss while balance exceeds tracked assets");
+        assertEq(strategy.totalAssets(), trackedGhostAssets + donatedAssets, "assets are reconciled");
+        assertEq(strategy.totalSupply(), trackedGhostAssets + donatedAssets, "locked supply repairs PPS");
+        assertEq(
+            strategy.balanceOf(address(strategy)),
+            trackedGhostAssets + donatedAssets,
+            "ghost collateral is locked to the strategy"
+        );
+
+        uint256 shares = _deposit(victim, 1 ether);
+        assertEq(shares, 1 ether, "post-heal deposit mints at fair PPS");
+    }
+}

--- a/test/unit/strategies/yieldDonating/MultiUser.t.sol
+++ b/test/unit/strategies/yieldDonating/MultiUser.t.sol
@@ -23,7 +23,7 @@ contract MultiUserTest is Setup {
         mintAndDepositIntoStrategy(strategy, user, _amount);
         mintAndDepositIntoStrategy(strategy, user2, _amount);
 
-        assertEq(strategy.balanceOf(user), _amount, "user1 shares");
+        assertEq(strategy.balanceOf(user), _amount - minimumLiquidity, "user1 shares");
         assertEq(strategy.balanceOf(user2), _amount, "user2 shares");
         assertEq(strategy.pricePerShare(), wad, "PPS should be 1:1");
 
@@ -90,7 +90,11 @@ contract MultiUserTest is Setup {
         strategy.redeem(userShares, user, user);
 
         // User gets back their original deposit (not the profit)
-        assertEq(asset.balanceOf(user) - balBefore, _amount, "user should get original deposit back");
+        assertEq(
+            asset.balanceOf(user) - balBefore,
+            _amount - minimumLiquidity,
+            "user should get original deposit less locked liquidity"
+        );
     }
 
     // ==================== Dragon Router Redeems Shares ====================
@@ -182,13 +186,17 @@ contract MultiUserTest is Setup {
         uint256 user1Shares = strategy.balanceOf(user);
         uint256 user2Shares = strategy.balanceOf(user2);
 
-        assertEq(user1Shares, smallAmount, "small depositor shares");
+        assertEq(user1Shares, smallAmount - minimumLiquidity, "small depositor shares");
         assertEq(user2Shares, largeAmount, "large depositor shares");
 
         // Both can redeem for their original amount
         vm.prank(user);
         strategy.redeem(user1Shares, user, user);
-        assertEq(asset.balanceOf(user), smallAmount, "small depositor gets deposit back");
+        assertEq(
+            asset.balanceOf(user),
+            smallAmount - minimumLiquidity,
+            "small depositor gets deposit less locked liquidity"
+        );
 
         vm.prank(user2);
         strategy.redeem(user2Shares, user2, user2);
@@ -220,7 +228,7 @@ contract MultiUserTest is Setup {
         mintAndDepositIntoStrategy(strategy, user3, amount);
 
         // All users should have the same PPS since yield donating keeps PPS at 1:1
-        assertEq(strategy.balanceOf(user), amount, "user1 shares");
+        assertEq(strategy.balanceOf(user), amount - minimumLiquidity, "user1 shares");
         assertEq(strategy.balanceOf(user2), amount, "user2 shares");
         assertEq(strategy.balanceOf(user3), amount, "user3 shares");
         assertEq(strategy.pricePerShare(), wad, "PPS should be 1:1");
@@ -253,7 +261,7 @@ contract MultiUserTest is Setup {
 
         vm.prank(user);
         strategy.withdraw(user1Assets, user, user);
-        assertEq(asset.balanceOf(user), _amount1, "user1 should get back deposit");
+        assertEq(asset.balanceOf(user), _amount1 - minimumLiquidity, "user1 should get deposit less locked liquidity");
 
         uint256 user2Shares = strategy.balanceOf(user2);
         uint256 user2Assets = strategy.convertToAssets(user2Shares);

--- a/test/unit/strategies/yieldDonating/ShareTransfer.t.sol
+++ b/test/unit/strategies/yieldDonating/ShareTransfer.t.sol
@@ -15,15 +15,16 @@ contract ShareTransferTest is Setup {
 
     function test_transfer_balancesUpdate(uint256 _amount, uint256 _transferAmount) public {
         _amount = bound(_amount, minFuzzAmount, maxFuzzAmount);
-        _transferAmount = bound(_transferAmount, 1, _amount);
 
         mintAndDepositIntoStrategy(strategy, user, _amount);
+        uint256 userShares = _amount - minimumLiquidity;
+        _transferAmount = bound(_transferAmount, 1, userShares);
 
         vm.prank(user);
         bool success = strategy.transfer(user2, _transferAmount);
 
         assertTrue(success, "transfer should return true");
-        assertEq(strategy.balanceOf(user), _amount - _transferAmount, "sender balance");
+        assertEq(strategy.balanceOf(user), userShares - _transferAmount, "sender balance");
         assertEq(strategy.balanceOf(user2), _transferAmount, "receiver balance");
     }
 
@@ -31,22 +32,24 @@ contract ShareTransferTest is Setup {
         _amount = bound(_amount, minFuzzAmount, maxFuzzAmount);
 
         mintAndDepositIntoStrategy(strategy, user, _amount);
+        uint256 userShares = _amount - minimumLiquidity;
 
         vm.prank(user);
-        strategy.transfer(user2, _amount);
+        strategy.transfer(user2, userShares);
 
         assertEq(strategy.balanceOf(user), 0, "sender should have 0");
-        assertEq(strategy.balanceOf(user2), _amount, "receiver should have full amount");
+        assertEq(strategy.balanceOf(user2), userShares, "receiver should have full amount");
     }
 
     function test_transfer_moreThanBalance_reverts(uint256 _amount) public {
         _amount = bound(_amount, minFuzzAmount, maxFuzzAmount);
 
         mintAndDepositIntoStrategy(strategy, user, _amount);
+        uint256 userShares = _amount - minimumLiquidity;
 
         vm.prank(user);
         vm.expectRevert();
-        strategy.transfer(user2, _amount + 1);
+        strategy.transfer(user2, userShares + 1);
     }
 
     // ==================== Transfer to Dragon Router ====================
@@ -87,9 +90,10 @@ contract ShareTransferTest is Setup {
 
     function test_transferFrom_withApproval(uint256 _amount, uint256 _transferAmount) public {
         _amount = bound(_amount, minFuzzAmount, maxFuzzAmount);
-        _transferAmount = bound(_transferAmount, 1, _amount);
 
         mintAndDepositIntoStrategy(strategy, user, _amount);
+        uint256 userShares = _amount - minimumLiquidity;
+        _transferAmount = bound(_transferAmount, 1, userShares);
 
         // User approves user2
         vm.prank(user);
@@ -102,7 +106,7 @@ contract ShareTransferTest is Setup {
         bool success = strategy.transferFrom(user, user2, _transferAmount);
 
         assertTrue(success, "transferFrom should return true");
-        assertEq(strategy.balanceOf(user), _amount - _transferAmount, "sender balance");
+        assertEq(strategy.balanceOf(user), userShares - _transferAmount, "sender balance");
         assertEq(strategy.balanceOf(user2), _transferAmount, "receiver balance");
         assertEq(strategy.allowance(user, user2), 0, "allowance should be consumed");
     }
@@ -121,14 +125,15 @@ contract ShareTransferTest is Setup {
         _amount = bound(_amount, minFuzzAmount, maxFuzzAmount);
 
         mintAndDepositIntoStrategy(strategy, user, _amount);
+        uint256 userShares = _amount - minimumLiquidity;
 
         // Approve less than transfer amount
         vm.prank(user);
-        strategy.approve(user2, _amount / 2);
+        strategy.approve(user2, userShares / 2);
 
         vm.prank(user2);
         vm.expectRevert("ERC20: insufficient allowance");
-        strategy.transferFrom(user, user2, _amount);
+        strategy.transferFrom(user, user2, userShares);
     }
 
     // ==================== Approve ====================
@@ -200,7 +205,7 @@ contract ShareTransferTest is Setup {
         vm.prank(user);
         strategy.transfer(user2, 0);
 
-        assertEq(strategy.balanceOf(user), _amount, "sender balance unchanged");
+        assertEq(strategy.balanceOf(user), _amount - minimumLiquidity, "sender balance unchanged");
         assertEq(strategy.balanceOf(user2), 0, "receiver balance still 0");
     }
 

--- a/test/unit/strategies/yieldDonating/Shutdown.t.sol
+++ b/test/unit/strategies/yieldDonating/Shutdown.t.sol
@@ -60,7 +60,11 @@ contract ShutdownTest is Setup {
         vm.prank(user);
         strategy.redeem(userShares, user, user);
 
-        assertEq(asset.balanceOf(user) - balBefore, _amount, "user should get full deposit back");
+        assertEq(
+            asset.balanceOf(user) - balBefore,
+            _amount - minimumLiquidity,
+            "user should get deposit less locked liquidity"
+        );
         assertEq(strategy.balanceOf(user), 0, "user should have 0 shares");
     }
 
@@ -217,7 +221,7 @@ contract ShutdownTest is Setup {
         vm.prank(user);
         strategy.redeem(userShares, user, user);
 
-        assertEq(asset.balanceOf(user), _amount, "user should get full deposit back");
+        assertEq(asset.balanceOf(user), _amount - minimumLiquidity, "user should get deposit less locked liquidity");
         assertEq(strategy.balanceOf(user), 0, "user should have 0 shares");
     }
 
@@ -238,7 +242,7 @@ contract ShutdownTest is Setup {
         uint256 user1Shares = strategy.balanceOf(user);
         vm.prank(user);
         strategy.redeem(user1Shares, user, user);
-        assertEq(asset.balanceOf(user), amount1, "user1 should get deposit back");
+        assertEq(asset.balanceOf(user), amount1 - minimumLiquidity, "user1 should get deposit less locked liquidity");
 
         uint256 user2Shares = strategy.balanceOf(user2);
         vm.prank(user2);

--- a/test/unit/strategies/yieldDonating/utils/Setup.sol
+++ b/test/unit/strategies/yieldDonating/utils/Setup.sol
@@ -37,6 +37,8 @@ contract Setup is Test {
     uint256 public decimals = 18;
     uint256 public MAX_BPS = 10_000;
     uint256 public wad = 10 ** decimals;
+    uint256 public minimumLiquidity = 1_000;
+    address public deadShares = address(0xdead);
     // Fuzz from $0.01 of 1e6 stable coins up to 1 trillion of a 1e18 coin
     uint256 public maxFuzzAmount = 1e30;
     uint256 public minFuzzAmount = 10_000;

--- a/verification/kontrol/YDStrategyTest.k.sol
+++ b/verification/kontrol/YDStrategyTest.k.sol
@@ -17,13 +17,18 @@ struct YDProofState {
 /**
  * @title YDStrategyTest
  * @notice Kontrol formal verification proofs for YieldDonatingTokenizedStrategy
- * @dev Inherits 7 common proofs from StrategyBaseTest and adds 4 YD-specific proofs:
+ * @dev Inherits 7 common proofs from StrategyBaseTest and adds 6 YD-specific proofs:
  *      - testReportProfit: shares minted to dragon, PPS non-decreasing
+ *      - testFirstDepositSeedsMinimumLiquidity: first deposit locks dead shares
+ *      - testReportLocksSharesForZeroSupplyGhostCollateral: report heals zero-supply ghost collateral
  *      - testReportLossInsufficientDragon: partial burn, PPS impact bounded
  *      - testSharesRedeemableAfterDepositYD: deposit produces redeemable shares
  *      - testConversionConsistencyYD: round-trip does not create value
  */
 contract YDStrategyTest is StrategyBaseTest, YDSetup {
+    uint256 internal constant MINIMUM_LIQUIDITY = 1_000;
+    address internal constant MINIMUM_LIQUIDITY_RECEIVER = address(0xdead);
+
     YDProofState private preState;
     YDProofState private postState;
 
@@ -96,6 +101,10 @@ contract YDStrategyTest is StrategyBaseTest, YDSetup {
         );
     }
 
+    function _clearStrategyBalance(address account) internal {
+        _storeMappingUInt256(address(strategy), TS_BALANCES_SLOT, uint256(uint160(account)), 0, 0);
+    }
+
     /*//////////////////////////////////////////////////////////////
                     INVARIANTS
     //////////////////////////////////////////////////////////////*/
@@ -165,6 +174,78 @@ contract YDStrategyTest is StrategyBaseTest, YDSetup {
         _establish(Mode.Assert, postState.dragonBalance >= preState.dragonBalance);
         // totalSupply increased
         _establish(Mode.Assert, postState.totalSupply >= preState.totalSupply);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    YD-SPECIFIC: FIRST DEPOSIT MINIMUM LIQUIDITY
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice The first yield-donating deposit permanently locks 1,000 shares
+    ///         and leaves totalSupply == totalAssets.
+    function testFirstDepositSeedsMinimumLiquidity() public {
+        _assumeNonReentrant();
+
+        uint256 assets = 100 ether;
+        address receiver = makeAddr("MINIMUM_LIQUIDITY_RECEIVER");
+
+        _storeUInt256(address(strategy), TS_TOTAL_SUPPLY_SLOT, 0);
+        _storeUInt256(address(strategy), TS_TOTAL_ASSETS_SLOT, 0);
+        _clearStrategyBalance(receiver);
+        _clearStrategyBalance(MINIMUM_LIQUIDITY_RECEIVER);
+        _storeData(address(strategy), TS_FLAGS_SLOT, TS_SHUTDOWN_OFFSET, TS_SHUTDOWN_WIDTH, 0);
+
+        address depositor = makeAddr("MINIMUM_LIQUIDITY_DEPOSITOR");
+        _storeMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(depositor)), 0, assets);
+        _storeMappingUInt256(_asset, ERC20_BALANCES_SLOT, uint256(uint160(address(strategy))), 0, 0);
+
+        vm.prank(depositor);
+        (bool ok, ) = _asset.call(abi.encodeWithSignature("approve(address,uint256)", address(strategy), assets));
+        require(ok);
+
+        vm.prank(depositor);
+        uint256 shares = iStrategy.deposit(assets, receiver);
+
+        assertEq(shares, assets - MINIMUM_LIQUIDITY);
+        assertEq(_loadUInt256(address(strategy), TS_TOTAL_SUPPLY_SLOT), assets);
+        assertEq(_loadUInt256(address(strategy), TS_TOTAL_ASSETS_SLOT), assets);
+        assertEq(
+            _loadMappingUInt256(address(strategy), TS_BALANCES_SLOT, uint256(uint160(receiver)), 0),
+            assets - MINIMUM_LIQUIDITY
+        );
+        assertEq(
+            _loadMappingUInt256(address(strategy), TS_BALANCES_SLOT, uint256(uint160(MINIMUM_LIQUIDITY_RECEIVER)), 0),
+            MINIMUM_LIQUIDITY
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                    YD-SPECIFIC: GHOST COLLATERAL RECOVERY
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice If accounting reaches totalSupply == 0 while assets are positive,
+    ///         report() locks matching recovery shares to the strategy itself.
+    function testReportLocksSharesForZeroSupplyGhostCollateral() public {
+        _assumeNonReentrant();
+
+        uint256 oldTotalAssets = 75 ether;
+        uint256 newTotalAssets = 100 ether;
+
+        _storeData(address(strategy), HC_SLOT, HC_DO_HEALTH_CHECK_OFFSET, HC_DO_HEALTH_CHECK_WIDTH, 0);
+        _storeUInt256(address(strategy), TS_TOTAL_SUPPLY_SLOT, 0);
+        _storeUInt256(address(strategy), TS_TOTAL_ASSETS_SLOT, oldTotalAssets);
+        _storeUInt256(address(strategy), MOCK_NEXT_TOTAL_ASSETS_SLOT, newTotalAssets);
+        _clearStrategyBalance(address(strategy));
+        _clearStrategyBalance(_dragonRouter);
+
+        vm.prank(_keeper);
+        iStrategy.report();
+
+        assertEq(_loadUInt256(address(strategy), TS_TOTAL_ASSETS_SLOT), newTotalAssets);
+        assertEq(_loadUInt256(address(strategy), TS_TOTAL_SUPPLY_SLOT), newTotalAssets);
+        assertEq(
+            _loadMappingUInt256(address(strategy), TS_BALANCES_SLOT, uint256(uint160(address(strategy))), 0),
+            newTotalAssets
+        );
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Context

This is the pragmatic Uniswap V2-style alternative for the Bailsec dust-share accounting chain in yield-donating strategies.

The vulnerable path is:

1. A sole holder exits against stale pre-loss accounting while leaving dust shares.
2. A loss report can land at `totalAssets == 0 && totalSupply > 0`, which DoSes deposits and lets any later recovery value accrue to stale dust.
3. A follow-up dust withdrawal can drive `totalSupply == 0 && totalAssets > 0`.
4. The next first depositor can be sandwiched and diluted against the ghost collateral.

## What Changed

- Yield-donating first deposits now fund a permanent `MINIMUM_LIQUIDITY` of `1_000` shares minted to `address(0xdead)`, following the Uniswap V2 pattern.
- The first `mint()` path charges `shares + MINIMUM_LIQUIDITY`, so deposit and mint both keep `totalSupply == totalAssets` after seeding.
- Deposit/mint/redeem max views are hardened around corrupted accounting states:
  - `totalSupply == 0 && totalAssets > 0` returns zero capacity for deposit/mint until a report repairs the ghost collateral.
  - `totalSupply > 0 && totalAssets == 0` returns zero capacity for yield-donating deposit/mint/redeem while the vault is terminally unpriced.
  - `maxRedeem` also returns zero when an owner's shares currently convert to zero assets.
- `report()` now handles recovery from corrupted accounting states:
  - if `totalSupply == 0` while assets are observed, matching shares are minted and locked to the strategy itself so the next depositor cannot be treated as the first fair owner of existing assets;
  - if `oldTotalAssets == 0` with stale supply, existing supply receives at most 1 asset per share and any surplus recovery is minted to the dragon router through the normal donation-share event path.
- Existing yield-donating accounting tests were updated for the permanent 1,000-share lock and the dragon-router recovery-surplus behavior.
- Fork integration expectations were updated so first-depositor round trips and post-withdraw residual checks account for the permanent locked backing and any donation shares.

## Security Properties Covered

- First deposit seeds dead shares and leaves total supply/assets 1:1.
- Deposits at or below the minimum liquidity revert instead of minting zero useful shares.
- First `mint()` includes the dead-share cost.
- The Bailsec loss/recovery/dust-withdraw chain no longer reaches first-depositor inflation.
- Forced `totalSupply == 0 && totalAssets > 0` ghost accounting blocks deposits until `report()` locks shares and restores fair PPS.
- Zero-asset recovery cannot let stale dust capture surplus value; surplus recovery is attributed to dragon as donation yield.
- Later donation minting resumes after recovery instead of silently accruing to stale dust.
- Added Kontrol harness flow coverage for first-deposit seeding and zero-supply ghost-collateral report recovery; the default proof matrix is unchanged.

## Validation

- `forge test --match-path test/unit/strategies/yieldDonating/MinimumLiquidity.t.sol -vvv`
- `forge test --match-path 'test/unit/strategies/yieldDonating/*.t.sol' -vv`
- `forge test --match-path 'test/unit/core/tokenizedStrategy/*.t.sol' -vv`
- `forge test --match-path 'test/unit/strategies/yieldSkimming/*.t.sol' -vv`
- `git diff --check`
- `yarn build`

`yarn build` passes with existing Kontrol AST source warnings for `test/kontrol/*.k.sol` files.

## Notes For Review

This intentionally does not implement the OpenZeppelin virtual offset. It codifies the lower-touch Uniswap V2 route requested for comparison: permanent dead shares plus report-time accounting repair.

Recovery policy is split by state: no-owner ghost collateral (`totalSupply == 0 && totalAssets > 0`) is locked to the strategy to avoid first-depositor pricing, while stale-supply zero-asset recovery sends surplus above 1 asset/share to dragon because that value is recovered protocol yield rather than user-owned principal.