### PR TITLE
fix(yield-donating): lock protocol seed position

### DIFF
--- a/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.25;
 
 import { TokenizedStrategy, Math } from "src/core/TokenizedStrategy.sol";
 import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 /**
  * @title YieldDonatingTokenizedStrategy
  * @author [Golem Foundation](https://golem.foundation)
@@ -39,6 +41,10 @@ import { IBaseStrategy } from "src/core/interfaces/IBaseStrategy.sol";
 
 contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
     using Math for uint256;
+    using SafeERC20 for ERC20;
+
+    /// @notice Strategy-owned seed that keeps supply non-zero after user exits.
+    uint256 public constant MINIMUM_PROTOCOL_POSITION = 1_000_000_000;
 
     /// @notice Emitted when profit shares are minted to dragon router
     /// @param dragonRouter Address receiving minted donation shares
@@ -49,6 +55,37 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
     /// @param dragonRouter Address whose shares are burned
     /// @param amount Amount of shares burned in share base units
     event DonationBurned(address indexed dragonRouter, uint256 amount);
+
+    /// @notice Emitted when the strategy-owned minimum position is funded and locked.
+    /// @param funder Address that supplied the underlying asset seed
+    /// @param amount Amount of underlying assets locked as the minimum position
+    event MinimumProtocolPositionSeeded(address indexed funder, uint256 amount);
+
+    /**
+     * @notice Funds and locks the protocol minimum position.
+     * @dev This must be called once by the operator before public deposits are enabled.
+     *      The minted shares are held by the strategy itself, so users cannot redeem or
+     *      transfer them away. This keeps `totalSupply` non-zero even if all external
+     *      holders exit after a loss-report sequence.
+     * @return shares Amount of locked shares minted to the strategy
+     */
+    function seedMinimumPosition() external virtual nonReentrant onlyManagement returns (uint256 shares) {
+        StrategyData storage S = super._strategyStorage();
+
+        require(_totalSupply(S) == 0 && _totalAssets(S) == 0, "MINIMUM_POSITION_LATE");
+        require(_balanceOf(S, address(this)) == 0, "MINIMUM_POSITION_SEEDED");
+
+        shares = MINIMUM_PROTOCOL_POSITION;
+        S.asset.safeTransferFrom(msg.sender, address(this), shares);
+
+        IBaseStrategy(address(this)).deployFunds(shares);
+
+        S.totalAssets = shares;
+        _mint(S, address(this), shares);
+
+        emit MinimumProtocolPositionSeeded(msg.sender, shares);
+    }
+
     /**
      * @notice Reports strategy performance and distributes profits as donations
      * @dev Mints profit-derived shares to dragon router when newTotalAssets > oldTotalAssets; on loss, attempts
@@ -118,6 +155,20 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
         emit Reported(profit, loss);
     }
 
+    /// @inheritdoc TokenizedStrategy
+    function maxDeposit(address receiver) public view virtual override returns (uint256) {
+        StrategyData storage S = super._strategyStorage();
+        if (!_minimumPositionSeeded(S)) return 0;
+        return super.maxDeposit(receiver);
+    }
+
+    /// @inheritdoc TokenizedStrategy
+    function maxMint(address receiver) public view virtual override returns (uint256) {
+        StrategyData storage S = super._strategyStorage();
+        if (!_minimumPositionSeeded(S)) return 0;
+        return super.maxMint(receiver);
+    }
+
     /**
      * @dev Internal function to handle loss protection for dragon principal
      * @param S Storage struct pointer to access strategy's storage variables
@@ -143,5 +194,19 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
                 emit DonationBurned(S.dragonRouter, sharesBurned);
             }
         }
+    }
+
+    function _deposit(
+        StrategyData storage S,
+        address receiver,
+        uint256 assets,
+        uint256 shares
+    ) internal virtual override {
+        require(_minimumPositionSeeded(S), "MINIMUM_POSITION_UNSEEDED");
+        super._deposit(S, receiver, assets, shares);
+    }
+
+    function _minimumPositionSeeded(StrategyData storage S) internal view returns (bool) {
+        return _balanceOf(S, address(this)) >= MINIMUM_PROTOCOL_POSITION;
     }
 }

--- a/test/integration/guards/KeeperBotGuard.t.sol
+++ b/test/integration/guards/KeeperBotGuard.t.sol
@@ -80,6 +80,7 @@ contract KeeperBotGuardTest is Test {
 
     // Test constants
     uint256 public constant INITIAL_DEPOSIT = 100000e6; // USDC has 6 decimals
+    uint256 public constant MINIMUM_PROTOCOL_POSITION = 1_000_000_000;
 
     uint256 public mainnetFork;
 
@@ -149,6 +150,20 @@ contract KeeperBotGuardTest is Test {
                 false, // enableBurning
                 address(implementation)
             )
+        );
+        _seedMinimumPosition();
+    }
+
+    function _seedMinimumPosition() internal {
+        deal(USDC, address(safeMultisig), MINIMUM_PROTOCOL_POSITION);
+
+        _executeSafeTransaction(
+            USDC,
+            abi.encodeWithSelector(ERC20.approve.selector, address(strategy), MINIMUM_PROTOCOL_POSITION)
+        );
+        _executeSafeTransaction(
+            address(strategy),
+            abi.encodeWithSelector(YieldDonatingTokenizedStrategy.seedMinimumPosition.selector)
         );
     }
 

--- a/test/integration/strategies/YieldDonating/AaveV3Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/AaveV3Strategy.t.sol
@@ -156,7 +156,7 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.mockCall(
             AaveV3TestConfig.AUSDC_V3,
             abi.encodeWithSelector(IERC20.balanceOf.selector, address(strategy)),
-            abi.encode(depositAmount + profitAmount)
+            abi.encode(totalAssetsBefore + profitAmount)
         );
 
         vm.startPrank(keeper);
@@ -370,7 +370,7 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.mockCall(
             AaveV3TestConfig.AUSDC_V3,
             abi.encodeWithSelector(IERC20.balanceOf.selector, address(strategy)),
-            abi.encode(depositAmount + aTokenProfit)
+            abi.encode(initialTotalAssets + aTokenProfit)
         );
 
         airdrop(ERC20(_asset()), address(strategy), idleProfit);
@@ -432,6 +432,7 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         depositAmount2 = bound(depositAmount2, _minDeposit(), _maxDeposit() / 2);
 
         address user2 = address(0x5678);
+        uint256 initialTotalAssets = IERC4626(address(strategy)).totalAssets();
 
         if (ERC20(_asset()).balanceOf(user) < depositAmount1) {
             airdrop(ERC20(_asset()), user, depositAmount1);
@@ -452,7 +453,7 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
 
         assertEq(
             IERC4626(address(strategy)).totalAssets(),
-            depositAmount1 + depositAmount2,
+            initialTotalAssets + depositAmount1 + depositAmount2,
             "Total assets should equal deposits"
         );
 
@@ -470,10 +471,11 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         }
 
         if (shouldUser1Withdraw && shouldUser2Withdraw) {
-            assertLt(
+            assertApproxEqAbs(
                 IERC4626(address(strategy)).totalAssets(),
+                initialTotalAssets,
                 10,
-                "Strategy should be nearly empty after all withdrawals"
+                "Strategy should return to the seeded baseline after all user withdrawals"
             );
         }
     }
@@ -604,7 +606,12 @@ contract AaveV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         uint256 depositAmount = 10000e6;
 
         uint256 initialLimit = strategy.availableWithdrawLimit(user);
-        assertEq(initialLimit, 0, "Initial withdraw limit should be 0");
+        assertApproxEqAbs(
+            initialLimit,
+            MINIMUM_PROTOCOL_POSITION,
+            10,
+            "Initial withdraw limit should reflect the locked seed"
+        );
 
         airdrop(ERC20(_asset()), user, depositAmount);
         vm.startPrank(user);

--- a/test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/KpkERC4626Strategy.t.sol
@@ -167,7 +167,7 @@ contract KpkERC4626StrategyTest is BaseYieldDonatingIntegrationTest {
         vm.mockCall(
             address(IERC4626(_compounderVault())),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfKpkVault),
-            abi.encode(depositAmount + profitAmount)
+            abi.encode(totalAssetsBefore + profitAmount)
         );
 
         vm.startPrank(keeper);

--- a/test/integration/strategies/YieldDonating/MorphoCompounderStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/MorphoCompounderStrategy.t.sol
@@ -141,7 +141,7 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
         vm.mockCall(
             address(IERC4626(_compounderVault())),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfMorphoVault),
-            abi.encode(depositAmount + profitAmount)
+            abi.encode(totalAssetsBefore + profitAmount)
         );
 
         vm.startPrank(keeper);
@@ -356,7 +356,7 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
         vm.mockCall(
             address(_compounderVault()),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, morphoSharesBefore),
-            abi.encode(depositAmount + vaultProfit)
+            abi.encode(initialTotalAssets + vaultProfit)
         );
 
         airdrop(ERC20(_asset()), address(strategy), idleProfit);
@@ -416,6 +416,7 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
         depositAmount2 = bound(depositAmount2, _minDeposit(), _maxDeposit() / 2);
 
         address user2 = address(0x5678);
+        uint256 initialTotalAssets = IERC4626(address(strategy)).totalAssets();
 
         if (ERC20(_asset()).balanceOf(user) < depositAmount1) {
             airdrop(ERC20(_asset()), user, depositAmount1);
@@ -436,7 +437,7 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
 
         assertEq(
             IERC4626(address(strategy)).totalAssets(),
-            depositAmount1 + depositAmount2,
+            initialTotalAssets + depositAmount1 + depositAmount2,
             "Total assets should equal deposits"
         );
 
@@ -454,10 +455,11 @@ contract MorphoCompounderDonatingStrategyTest is BaseYieldDonatingIntegrationTes
         }
 
         if (shouldUser1Withdraw && shouldUser2Withdraw) {
-            assertLt(
+            assertApproxEqAbs(
                 IERC4626(address(strategy)).totalAssets(),
+                initialTotalAssets,
                 10,
-                "Strategy should be nearly empty after all withdrawals"
+                "Strategy should return to the seeded baseline after all user withdrawals"
             );
         }
     }

--- a/test/integration/strategies/YieldDonating/SkyCompounder.t.sol
+++ b/test/integration/strategies/YieldDonating/SkyCompounder.t.sol
@@ -125,7 +125,11 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
 
     function testDepositSky() public {
         _testDeposit(100e18);
-        assertEq(strategy.balanceOfStake(), 100e18, "Staking balance not increased correctly");
+        assertEq(
+            strategy.balanceOfStake(),
+            MINIMUM_PROTOCOL_POSITION + 100e18,
+            "Staking balance not increased correctly"
+        );
     }
 
     function testWithdrawSky() public {
@@ -203,7 +207,7 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
         vault.deposit(depositAmount, user);
         vm.stopPrank();
 
-        assertEq(strategy.balanceOfStake(), depositAmount, "Deposit should be staked");
+        assertEq(strategy.balanceOfStake(), MINIMUM_PROTOCOL_POSITION + depositAmount, "Deposit should be staked");
 
         skip(30 days);
         vm.roll(block.number + 6500 * 30);
@@ -259,7 +263,7 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
         vault.deposit(depositAmount, user);
         vm.stopPrank();
 
-        assertEq(strategy.balanceOfStake(), depositAmount, "Deposit should be staked");
+        assertEq(strategy.balanceOfStake(), MINIMUM_PROTOCOL_POSITION + depositAmount, "Deposit should be staked");
 
         skip(30 days);
         vm.roll(block.number + 6500 * 30);
@@ -358,7 +362,7 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
         vault.deposit(depositAmount, user);
         vm.stopPrank();
 
-        assertEq(strategy.balanceOfStake(), depositAmount, "Deposit should be staked");
+        assertEq(strategy.balanceOfStake(), MINIMUM_PROTOCOL_POSITION + depositAmount, "Deposit should be staked");
 
         skip(30 days);
         vm.roll(block.number + 6500 * 30);
@@ -415,7 +419,7 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
         vault.deposit(depositAmount, user);
         vm.stopPrank();
 
-        assertEq(strategy.balanceOfStake(), depositAmount, "Deposit should be staked");
+        assertEq(strategy.balanceOfStake(), MINIMUM_PROTOCOL_POSITION + depositAmount, "Deposit should be staked");
 
         skip(45 days);
         vm.roll(block.number + 6500 * 45);
@@ -750,7 +754,11 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
         vault.deposit(depositAmount, user);
         vm.stopPrank();
 
-        assertEq(strategy.balanceOfStake(), depositAmount, "All deposited assets should be staked");
+        assertEq(
+            strategy.balanceOfStake(),
+            MINIMUM_PROTOCOL_POSITION + depositAmount,
+            "All deposited assets should be staked"
+        );
         assertEq(strategy.balanceOfAsset(), 0, "No idle assets initially");
 
         deal(_asset(), address(strategy), dustAmount);
@@ -787,7 +795,7 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
         deal(_asset(), address(strategy), dustAmount);
 
         assertEq(strategy.balanceOfAsset(), dustAmount, "Only dust assets should exist");
-        assertEq(strategy.balanceOfStake(), 0, "No staked assets should exist");
+        assertEq(strategy.balanceOfStake(), MINIMUM_PROTOCOL_POSITION, "Only seed should be staked");
 
         vm.prank(management);
         strategy.setDoHealthCheck(false);
@@ -796,9 +804,9 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
         (uint256 profit, uint256 loss) = vault.report();
 
         uint256 totalAssets = vault.totalAssets();
-        assertEq(totalAssets, dustAmount, "Total assets should equal dust amount");
+        assertEq(totalAssets, MINIMUM_PROTOCOL_POSITION + dustAmount, "Total assets should include seed and dust");
 
-        assertEq(profit, dustAmount, "Profit should equal dust amount as it's a gain from 0");
+        assertEq(profit, dustAmount, "Profit should equal dust amount over the seed baseline");
         assertEq(loss, 0, "No loss should be reported");
     }
 
@@ -1036,7 +1044,11 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
         vm.stopPrank();
 
         uint256 stakedBalance = strategy.balanceOfStake();
-        assertEq(stakedBalance, depositAmount, "Staked balance should equal deposit");
+        assertEq(
+            stakedBalance,
+            MINIMUM_PROTOCOL_POSITION + depositAmount,
+            "Staked balance should equal seed plus deposit"
+        );
 
         // Emergency withdraw exactly stakedBalance: _min(stakedBalance, stakedBalance) -> a == b, returns b
         vm.startPrank(emergencyAdmin);

--- a/test/integration/strategies/YieldDonating/SkyCompounder.t.sol
+++ b/test/integration/strategies/YieldDonating/SkyCompounder.t.sol
@@ -1060,7 +1060,7 @@ contract SkyCompounderTest is BaseYieldDonatingIntegrationTest {
         assertEq(stakedAfter, 0, "All staked funds should have been withdrawn");
 
         uint256 idleAfter = strategy.balanceOfAsset();
-        assertEq(idleAfter, depositAmount, "Idle should equal original deposit");
+        assertEq(idleAfter, MINIMUM_PROTOCOL_POSITION + depositAmount, "Idle should equal seed plus deposit");
     }
 
     /// @notice Test harvest skips deploy when staking is paused (not shutdown path)

--- a/test/integration/strategies/YieldDonating/SparkSUsdsStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/SparkSUsdsStrategy.t.sol
@@ -184,7 +184,7 @@ contract SparkSUsdsDonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.mockCall(
             address(IERC4626(_compounderVault())),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfSUsdsVault),
-            abi.encode(depositAmount + profitAmount)
+            abi.encode(totalAssetsBefore + profitAmount)
         );
 
         vm.startPrank(keeper);

--- a/test/integration/strategies/YieldDonating/SparkStrategy.t.sol
+++ b/test/integration/strategies/YieldDonating/SparkStrategy.t.sol
@@ -174,7 +174,7 @@ contract SparkDonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.mockCall(
             address(IERC4626(_compounderVault())),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfSparkVault),
-            abi.encode(depositAmount + profitAmount)
+            abi.encode(totalAssetsBefore + profitAmount)
         );
 
         vm.startPrank(keeper);

--- a/test/integration/strategies/YieldDonating/YearnV3Strategy.t.sol
+++ b/test/integration/strategies/YieldDonating/YearnV3Strategy.t.sol
@@ -148,7 +148,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.mockCall(
             _compounderVault(),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfYearnVault),
-            abi.encode(depositAmount + profitAmount)
+            abi.encode(totalAssetsBefore + profitAmount)
         );
 
         vm.startPrank(keeper);
@@ -249,6 +249,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         IERC4626(address(vault)).deposit(depositAmount, user);
         vm.stopPrank();
 
+        uint256 totalAssetsBefore = IERC4626(address(vault)).totalAssets();
         vm.prank(management);
         strategy.setProfitLimitRatio(1000); // 10%
 
@@ -257,7 +258,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.mockCall(
             _compounderVault(),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfYearnVault),
-            abi.encode(depositAmount + excessiveProfit)
+            abi.encode(totalAssetsBefore + excessiveProfit)
         );
 
         vm.expectRevert("healthCheck");
@@ -281,12 +282,13 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.prank(management);
         strategy.setLossLimitRatio(500); // 5%
 
+        uint256 totalAssetsBefore = IERC4626(address(vault)).totalAssets();
         uint256 balanceOfYearnVault = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         uint256 loss = (depositAmount * 10) / 100; // 10% loss
         vm.mockCall(
             _compounderVault(),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfYearnVault),
-            abi.encode(depositAmount - loss)
+            abi.encode(totalAssetsBefore - loss)
         );
 
         vm.expectRevert("healthCheck");
@@ -313,12 +315,13 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         strategy.setDoHealthCheck(false);
         vm.stopPrank();
 
+        uint256 totalAssetsBefore = IERC4626(address(vault)).totalAssets();
         uint256 balanceOfYearnVault = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         uint256 excessiveProfit = (depositAmount * 50) / 100; // 50% profit
         vm.mockCall(
             _compounderVault(),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, balanceOfYearnVault),
-            abi.encode(depositAmount + excessiveProfit)
+            abi.encode(totalAssetsBefore + excessiveProfit)
         );
 
         vm.prank(keeper);
@@ -350,7 +353,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.mockCall(
             _compounderVault(),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, yearnSharesBefore),
-            abi.encode(depositAmount + vaultProfit)
+            abi.encode(IERC4626(address(vault)).totalAssets() + vaultProfit)
         );
 
         airdrop(ERC20(_asset()), address(strategy), idleProfit);
@@ -398,6 +401,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         depositAmount2 = bound(depositAmount2, _minDeposit(), _maxDeposit() / 2);
 
         address user2 = address(0x5678);
+        uint256 initialTotalAssets = IERC4626(address(strategy)).totalAssets();
 
         if (ERC20(_asset()).balanceOf(user) < depositAmount1) {
             airdrop(ERC20(_asset()), user, depositAmount1);
@@ -418,19 +422,22 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
 
         assertEq(
             IERC4626(address(strategy)).totalAssets(),
-            depositAmount1 + depositAmount2,
+            initialTotalAssets + depositAmount1 + depositAmount2,
             "Total assets should equal deposits"
         );
 
         // Add some profit to test fair distribution (but keep it reasonable to avoid health check issues)
         uint256 profit = 1000e6;
         uint256 totalDeposits = depositAmount1 + depositAmount2;
+        uint256 retainedAssets = initialTotalAssets;
 
         if (profit <= totalDeposits) {
             airdrop(ERC20(_asset()), address(strategy), profit);
 
             vm.prank(keeper);
             IMockStrategy(address(strategy)).report();
+
+            retainedAssets += profit;
         }
 
         if (shouldUser1Withdraw && shares1 > 0) {
@@ -456,10 +463,11 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         }
 
         if (shouldUser1Withdraw && shouldUser2Withdraw) {
-            assertLt(
+            assertApproxEqAbs(
                 IERC4626(address(strategy)).totalAssets(),
-                1000e6,
-                "Strategy should be nearly empty after all withdrawals"
+                retainedAssets,
+                10,
+                "Strategy should retain only seed and donated profit after all user withdrawals"
             );
         }
     }
@@ -474,13 +482,14 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         IERC4626(address(vault)).deposit(depositAmount, user);
         vm.stopPrank();
 
+        uint256 seededBaseline = IERC4626(address(vault)).totalAssets() - depositAmount;
         uint256 limit = strategy.availableWithdrawLimit(user);
 
         assertApproxEqRel(
             limit,
-            depositAmount,
+            seededBaseline + depositAmount,
             0.001e16,
-            "Withdraw limit should be approximately equal to deposited amount"
+            "Withdraw limit should be approximately equal to seed plus deposited amount"
         );
 
         uint256 idleBalance = ERC20(_asset()).balanceOf(address(strategy));
@@ -600,7 +609,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.mockCall(
             _compounderVault(),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, yearnSharesBefore),
-            abi.encode(depositAmount - lossAmount)
+            abi.encode(totalAssetsBefore - lossAmount)
         );
 
         vm.prank(keeper);
@@ -630,8 +639,9 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.prank(management);
         strategy.setLossLimitRatio(2000); // 20%
 
+        uint256 totalAssetsBefore = IERC4626(address(vault)).totalAssets();
         uint256 lossAmount = (depositAmount * lossPercentage) / 100;
-        uint256 remainingValue = depositAmount - lossAmount;
+        uint256 remainingValue = totalAssetsBefore - lossAmount;
 
         uint256 yearnShares = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
@@ -652,7 +662,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         assertLt(assetsReceived, depositAmount, "User should receive less than deposited");
         assertApproxEqRel(
             assetsReceived,
-            remainingValue,
+            (depositAmount * remainingValue) / totalAssetsBefore,
             0.001e16,
             "User should receive proportional share after loss"
         );
@@ -682,8 +692,9 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.prank(management);
         strategy.setLossLimitRatio(1500); // 15%
 
+        uint256 totalAssetsBefore = IERC4626(address(strategy)).totalAssets();
         uint256 totalLoss = (totalDeposits * lossPercentage) / 100;
-        uint256 remainingValue = totalDeposits - totalLoss;
+        uint256 remainingValue = totalAssetsBefore - totalLoss;
 
         uint256 yearnShares = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
@@ -703,17 +714,17 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.prank(user2);
         uint256 assets2 = IERC4626(address(strategy)).redeem(shares2, user2, user2);
 
-        uint256 expectedAssets1 = depositAmount1 - (depositAmount1 * lossPercentage) / 100;
-        uint256 expectedAssets2 = depositAmount2 - (depositAmount2 * lossPercentage) / 100;
+        uint256 expectedAssets1 = (depositAmount1 * remainingValue) / totalAssetsBefore;
+        uint256 expectedAssets2 = (depositAmount2 * remainingValue) / totalAssetsBefore;
 
         assertApproxEqRel(assets1, expectedAssets1, 0.01e18, "User1 should receive proportional share after loss");
         assertApproxEqRel(assets2, expectedAssets2, 0.01e18, "User2 should receive proportional share after loss");
 
         assertApproxEqRel(
             assets1 + assets2,
-            remainingValue,
+            expectedAssets1 + expectedAssets2,
             0.01e18,
-            "Total withdrawn should equal remaining value after loss"
+            "Total withdrawn should equal users' proportional remaining value after loss"
         );
     }
 
@@ -734,11 +745,12 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
 
         uint256 donationBalanceBefore = ERC20(address(vault)).balanceOf(donationAddress);
 
+        uint256 totalAssetsBefore = IERC4626(address(vault)).totalAssets();
         uint256 yearnShares = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
             _compounderVault(),
             abi.encodeWithSelector(IERC4626.previewRedeem.selector, yearnShares),
-            abi.encode(depositAmount - lossAmount)
+            abi.encode(totalAssetsBefore - lossAmount)
         );
 
         vm.prank(keeper);
@@ -768,8 +780,9 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         vm.prank(management);
         strategy.setLossLimitRatio(5000); // 50%
 
+        uint256 totalAssetsBefore = IERC4626(address(vault)).totalAssets();
         uint256 lossAmount = (depositAmount * lossPercentage) / 100;
-        uint256 remainingValue = depositAmount - lossAmount;
+        uint256 remainingValue = totalAssetsBefore - lossAmount;
 
         uint256 yearnShares = ITokenizedStrategy(_compounderVault()).balanceOf(address(strategy));
         vm.mockCall(
@@ -787,7 +800,7 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
         assertEq(loss, lossAmount, "Should report correct loss");
 
         uint256 assetsPerShare = IERC4626(address(vault)).convertToAssets(1e18);
-        uint256 expectedAssetsPerShare = (1e18 * remainingValue) / depositAmount;
+        uint256 expectedAssetsPerShare = (1e18 * remainingValue) / totalAssetsBefore;
         assertApproxEqRel(
             assetsPerShare,
             expectedAssetsPerShare,
@@ -797,7 +810,12 @@ contract YearnV3DonatingStrategyTest is BaseYieldDonatingIntegrationTest {
 
         vm.prank(user);
         uint256 withdrawnAssets = IERC4626(address(vault)).redeem(shares, user, user);
-        assertApproxEqRel(withdrawnAssets, remainingValue, 0.01e18, "User should be able to withdraw remaining value");
+        assertApproxEqRel(
+            withdrawnAssets,
+            (depositAmount * remainingValue) / totalAssetsBefore,
+            0.01e18,
+            "User should be able to withdraw proportional remaining value"
+        );
     }
 
     /// @notice Test that _freeFunds uses maxLoss=10_000 (100%) to handle insufficient funds

--- a/test/integration/strategies/YieldDonating/base/BaseYieldDonatingIntegrationTest.sol
+++ b/test/integration/strategies/YieldDonating/base/BaseYieldDonatingIntegrationTest.sol
@@ -22,6 +22,9 @@ abstract contract BaseYieldDonatingIntegrationTest is BaseIntegrationTest {
     /// @notice Implementation of YieldDonatingTokenizedStrategy
     YieldDonatingTokenizedStrategy public implementation;
 
+    /// @notice Strategy-owned seed used by YieldDonatingTokenizedStrategy.
+    uint256 internal constant MINIMUM_PROTOCOL_POSITION = 1_000_000_000;
+
     // ========== ABSTRACT METHODS ==========
 
     /// @notice Returns the compounder/staking vault address for mocking
@@ -35,6 +38,26 @@ abstract contract BaseYieldDonatingIntegrationTest is BaseIntegrationTest {
 
     /// @notice Returns the maximum deposit amount for fuzz tests
     function _maxDeposit() internal view virtual returns (uint256);
+
+    function _baseSetUp() internal virtual override {
+        _setupFork();
+        _setupRoles();
+        address strategyAddr = _deployStrategy();
+        vault = ITokenizedStrategy(strategyAddr);
+        _seedMinimumProtocolPosition(strategyAddr);
+        _labelAddresses();
+        _airdropInitialAssets();
+        _approveStrategy();
+    }
+
+    function _seedMinimumProtocolPosition(address strategyAddr) internal {
+        airdrop(ERC20(_asset()), management, MINIMUM_PROTOCOL_POSITION);
+
+        vm.startPrank(management);
+        ERC20(_asset()).approve(strategyAddr, MINIMUM_PROTOCOL_POSITION);
+        YieldDonatingTokenizedStrategy(strategyAddr).seedMinimumPosition();
+        vm.stopPrank();
+    }
 
     // ========== SHARED TEST IMPLEMENTATIONS ==========
 

--- a/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV3SwapperIntegration.t.sol
@@ -135,6 +135,7 @@ contract UniswapV3MultiHopTest is Test {
 
     uint256 internal constant SWAP_AMOUNT_USDC = 10_000e6; // 10k USDC
     uint256 internal constant SWAP_AMOUNT_WETH = 1e18; // 1 WETH
+    uint256 internal constant MINIMUM_PROTOCOL_POSITION = 1_000_000_000;
 
     address internal swapReceiver = address(0xBEEF);
     uint256 internal mainnetFork;
@@ -148,6 +149,15 @@ contract UniswapV3MultiHopTest is Test {
         vm.label(USDC, "USDC");
         vm.label(DAI, "DAI");
         vm.label(swapReceiver, "SwapReceiver");
+    }
+
+    function _seedMinimumPosition(address strategyAddr, address seedFunder) internal {
+        deal(USDC, seedFunder, MINIMUM_PROTOCOL_POSITION);
+
+        vm.startPrank(seedFunder);
+        ERC20(USDC).approve(strategyAddr, MINIMUM_PROTOCOL_POSITION);
+        YieldDonatingTokenizedStrategy(strategyAddr).seedMinimumPosition();
+        vm.stopPrank();
     }
 
     // ═══════════════════════════════════════════════════════════
@@ -339,6 +349,7 @@ contract UniswapV3MultiHopTest is Test {
         );
         vm.stopPrank();
         require(stratAddr == predictedStrat, "Strategy address mismatch");
+        _seedMinimumPosition(stratAddr, mgmt);
 
         // Deposit
         address usr = address(0x1234);

--- a/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
+++ b/test/integration/swappers/UniswapV4SwapperIntegration.t.sol
@@ -146,6 +146,7 @@ contract UniswapV4MultiHopTest is Test {
 
     uint256 internal constant SWAP_AMOUNT_USDC = 10_000e6; // 10k USDC
     uint256 internal constant SWAP_AMOUNT_WETH = 1e18; // 1 WETH
+    uint256 internal constant MINIMUM_PROTOCOL_POSITION = 1_000_000_000;
 
     address internal swapReceiver = address(0xBEEF);
     uint256 internal mainnetFork;
@@ -159,6 +160,15 @@ contract UniswapV4MultiHopTest is Test {
         vm.label(USDC, "USDC");
         vm.label(DAI, "DAI");
         vm.label(swapReceiver, "SwapReceiver");
+    }
+
+    function _seedMinimumPosition(address strategyAddr, address seedFunder) internal {
+        deal(USDC, seedFunder, MINIMUM_PROTOCOL_POSITION);
+
+        vm.startPrank(seedFunder);
+        ERC20(USDC).approve(strategyAddr, MINIMUM_PROTOCOL_POSITION);
+        YieldDonatingTokenizedStrategy(strategyAddr).seedMinimumPosition();
+        vm.stopPrank();
     }
 
     // ═══════════════════════════════════════════════════════════
@@ -378,6 +388,7 @@ contract UniswapV4MultiHopTest is Test {
         );
         vm.stopPrank();
         require(stratAddr == predictedStrat, "Strategy address mismatch");
+        _seedMinimumPosition(stratAddr, mgmt);
 
         // Deposit
         address usr = address(0x1234);

--- a/test/integration/swappers/base/BaseSwapperIntegrationTest.sol
+++ b/test/integration/swappers/base/BaseSwapperIntegrationTest.sol
@@ -41,6 +41,7 @@ abstract contract BaseSwapperIntegrationTest is Test {
 
     uint256 public mainnetFork;
     uint256 public constant DEPOSIT_AMOUNT = 100_000e6; // 100k USDC
+    uint256 internal constant MINIMUM_PROTOCOL_POSITION = 1_000_000_000;
 
     // ========== ABSTRACT ==========
 
@@ -117,6 +118,7 @@ abstract contract BaseSwapperIntegrationTest is Test {
         require(strategyAddr == predictedStrategy, "Strategy address mismatch: vault wiring broken");
 
         strategy = MorphoCompounderStrategy(strategyAddr);
+        _seedMinimumPosition(strategyAddr, management);
 
         // 5. Airdrop USDC to user and approve
         deal(MorphoTestConfig.USDC, user, DEPOSIT_AMOUNT);
@@ -136,6 +138,15 @@ abstract contract BaseSwapperIntegrationTest is Test {
     }
 
     // ========== HELPERS ==========
+
+    function _seedMinimumPosition(address strategyAddr, address seedFunder) internal {
+        deal(MorphoTestConfig.USDC, seedFunder, MINIMUM_PROTOCOL_POSITION);
+
+        vm.startPrank(seedFunder);
+        ERC20(MorphoTestConfig.USDC).approve(strategyAddr, MINIMUM_PROTOCOL_POSITION);
+        YieldDonatingTokenizedStrategy(strategyAddr).seedMinimumPosition();
+        vm.stopPrank();
+    }
 
     /// @notice Deposit into strategy, then run initial report so strategy deploys to Morpho
     /// @dev Disables health check for the initial report (Morpho rounding can cause 1 wei "loss")

--- a/test/unit/core/SwappingYieldForwarder.t.sol
+++ b/test/unit/core/SwappingYieldForwarder.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { Test, Vm } from "forge-std/Test.sol";
+import { Vm } from "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
@@ -16,8 +16,9 @@ import { MockYieldSource } from "test/mocks/core/tokenized-strategies/MockYieldS
 import { MockSwapper } from "test/mocks/MockSwapper.sol";
 import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
 import { MockERC20 } from "test/mocks/MockERC20.sol";
+import { SeedHelpers } from "test/unit/strategies/yieldDonating/utils/SeedHelpers.sol";
 
-contract SwappingYieldForwarderTest is Test {
+contract SwappingYieldForwarderTest is SeedHelpers {
     SwappingYieldForwarder public forwarder;
     ERC20Mock public asset;
     ERC20Mock public targetAsset;
@@ -85,6 +86,7 @@ contract SwappingYieldForwarderTest is Test {
         strategy.setPendingManagement(management);
         strategy.acceptManagement();
         vm.stopPrank();
+        _seedMinimumPosition(address(strategy), asset, management);
 
         vm.label(receiver, "Receiver");
         vm.label(keeperEOA, "KeeperEOA");
@@ -764,6 +766,7 @@ contract SwappingYieldForwarderTest is Test {
         strat.setPendingManagement(management);
         strat.acceptManagement();
         vm.stopPrank();
+        _seedMinimumPosition(address(strat), assetMix, management);
     }
 
     /// @notice A constructor floor of 0 preserves the prior "keeper sets slippage"
@@ -817,6 +820,7 @@ contract SwappingYieldForwarderTest is Test {
         strat.setPendingManagement(management);
         strat.acceptManagement();
         vm.stopPrank();
+        _seedMinimumPosition(address(strat), asset, management);
     }
 
     // ═══════════════════════════════════════════════════════════

--- a/test/unit/core/YieldForwarder.t.sol
+++ b/test/unit/core/YieldForwarder.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.25;
 
-import { Test, Vm } from "forge-std/Test.sol";
+import { Vm } from "forge-std/Test.sol";
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
@@ -12,8 +12,9 @@ import { MockFactory } from "test/mocks/MockFactory.sol";
 import { MockStrategy } from "test/mocks/core/tokenized-strategies/MockStrategy.sol";
 import { MockYieldSource } from "test/mocks/core/tokenized-strategies/MockYieldSource.sol";
 import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
+import { SeedHelpers } from "test/unit/strategies/yieldDonating/utils/SeedHelpers.sol";
 
-contract YieldForwarderTest is Test {
+contract YieldForwarderTest is SeedHelpers {
     YieldForwarder public forwarder;
     ERC20Mock public asset;
     IMockStrategy public strategy;
@@ -66,6 +67,7 @@ contract YieldForwarderTest is Test {
         strategy.setPendingManagement(management);
         strategy.acceptManagement();
         vm.stopPrank();
+        _seedMinimumPosition(address(strategy), asset, management);
 
         // Labels
         vm.label(receiver, "Receiver");
@@ -260,6 +262,7 @@ contract YieldForwarderTest is Test {
         strategy2.setPendingManagement(management);
         strategy2.acceptManagement();
         vm.stopPrank();
+        _seedMinimumPosition(address(strategy2), asset2, management);
 
         // Deposit into both strategies
         _depositIntoStrategy(user, DEPOSIT_AMOUNT);

--- a/test/unit/core/baseStrategy/BranchCoverage.t.sol
+++ b/test/unit/core/baseStrategy/BranchCoverage.t.sol
@@ -1,17 +1,17 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.25;
 
-import { Test } from "forge-std/Test.sol";
 import { MockERC20 } from "test/mocks/MockERC20.sol";
 import { MockYieldSource } from "test/mocks/core/MockYieldSource.sol";
 import { MockStrategy as MockBaseStrategy } from "test/mocks/core/MockBaseStrategy.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { BaseStrategy } from "src/core/BaseStrategy.sol";
+import { SeedHelpers } from "test/unit/strategies/yieldDonating/utils/SeedHelpers.sol";
 
 /// @title BaseStrategy Branch Coverage Tests
 /// @notice Covers untested branches in BaseStrategy (onlySelf, hook functions, view defaults)
-contract BaseStrategyBranchCoverageTest is Test {
+contract BaseStrategyBranchCoverageTest is SeedHelpers {
     MockBaseStrategy strategy;
     MockERC20 asset;
     MockYieldSource yieldSource;
@@ -25,6 +25,7 @@ contract BaseStrategyBranchCoverageTest is Test {
         yieldSource = new MockYieldSource(address(asset));
         implementation = new YieldDonatingTokenizedStrategy();
         strategy = new MockBaseStrategy(address(asset), address(yieldSource), address(implementation));
+        _seedMinimumPosition(address(strategy), asset, management);
     }
 
     // --- onlySelf modifier: external calls revert ---
@@ -188,7 +189,7 @@ contract MockStrategyDefaultTend is BaseStrategy {
 }
 
 /// @title Tests for the default _tendTrigger implementation in BaseStrategy
-contract BaseStrategyDefaultTendTriggerTest is Test {
+contract BaseStrategyDefaultTendTriggerTest is SeedHelpers {
     MockStrategyDefaultTend strategyDefaultTend;
     MockERC20 asset2;
     YieldDonatingTokenizedStrategy implementation2;

--- a/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
+++ b/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.25;
 
-import { Test } from "forge-std/Test.sol";
 import { MockERC20 } from "test/mocks/MockERC20.sol";
 import { MockYieldSource } from "test/mocks/core/MockYieldSource.sol";
 import { MockStrategy as MockBaseStrategy } from "test/mocks/core/MockBaseStrategy.sol";
@@ -10,10 +9,11 @@ import { MockTokenizedStrategyWithLoss } from "test/mocks/core/MockTokenizedStra
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { TokenizedStrategy__InvalidSigner } from "src/errors.sol";
+import { SeedHelpers } from "test/unit/strategies/yieldDonating/utils/SeedHelpers.sol";
 
 /// @title TokenizedStrategy Branch Coverage Tests
 /// @notice Covers untested branches in TokenizedStrategy
-contract TokenizedStrategyBranchCoverageTest is Test {
+contract TokenizedStrategyBranchCoverageTest is SeedHelpers {
     MockBaseStrategy strategy;
     MockERC20 asset;
     MockYieldSource yieldSource;
@@ -34,6 +34,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
         yieldSource = new MockYieldSource(address(asset));
         implementation = new YieldDonatingTokenizedStrategy();
         strategy = new MockBaseStrategy(address(asset), address(yieldSource), address(implementation));
+        _seedMinimumPosition(address(strategy), asset, management);
 
         // Give user some assets
         asset.mint(user, 100e18);
@@ -789,6 +790,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
             address(0x99),
             address(implementation)
         );
+        _seedMinimumPosition(address(illiqStrat), asset, address(this));
 
         asset.mint(user, 10e18);
         vm.startPrank(user);
@@ -815,6 +817,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
             address(0x99),
             address(implementation)
         );
+        _seedMinimumPosition(address(illiqStrat), asset, address(this));
 
         asset.mint(user, 10e18);
         vm.startPrank(user);
@@ -841,6 +844,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
             address(0x99),
             address(implementation)
         );
+        _seedMinimumPosition(address(illiqStrat), asset, address(this));
 
         asset.mint(user, 10e18);
         vm.startPrank(user);
@@ -1110,7 +1114,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
         ITokenizedStrategy(address(strategy)).report();
 
         uint256 ta = ITokenizedStrategy(address(strategy)).totalAssets();
-        assertEq(ta, 10e18, "Total assets should remain unchanged");
+        assertEq(ta, 10e18 + MINIMUM_PROTOCOL_POSITION, "Total assets should remain unchanged");
     }
 
     // --- Withdraw where idle >= assets (no freeFunds needed, line 1096 false) ---

--- a/test/unit/strategies/yieldDonating/AaveV3ApprovalHygiene.t.sol
+++ b/test/unit/strategies/yieldDonating/AaveV3ApprovalHygiene.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity ^0.8.25;
 
-import { Test } from "forge-std/Test.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import { AaveV3Strategy } from "src/strategies/yieldDonating/AaveV3Strategy.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
+import { SeedHelpers } from "./utils/SeedHelpers.sol";
 
 /// @title MockPool that pulls funds via transferFrom (so the allowance check is meaningful)
 contract PullingMockPool {
@@ -81,7 +81,7 @@ contract MockAddressesProvider {
 ///         hostile upgrade pull every idle token from the strategy at any time. The fix
 ///         removes the standing approval, approves exactly the deploy amount inside
 ///         `_deployFunds`, and clears the approval after `pool.supply`.
-contract AaveV3ApprovalHygieneTest is Test {
+contract AaveV3ApprovalHygieneTest is SeedHelpers {
     AaveV3Strategy internal strategy;
     ERC20Mock internal asset;
     PullingMockPool internal pool;
@@ -133,6 +133,8 @@ contract AaveV3ApprovalHygieneTest is Test {
     ///         `pool.supply`, leaving zero residual allowance.
     function test_deposit_leavesZeroAllowance() public {
         uint256 amount = 100 ether;
+        _seedMinimumPosition(address(strategy), asset, management);
+
         asset.mint(alice, amount);
 
         vm.startPrank(alice);
@@ -151,6 +153,8 @@ contract AaveV3ApprovalHygieneTest is Test {
     ///         the residual allowance after the external call.
     function test_deposit_clearsResidualAllowanceWhenPoolPullsLess() public {
         uint256 amount = 100 ether;
+        _seedMinimumPosition(address(strategy), asset, management);
+
         asset.mint(alice, amount);
         pool.setAmountToPull(amount - 1);
 

--- a/test/unit/strategies/yieldDonating/AccessControl.t.sol
+++ b/test/unit/strategies/yieldDonating/AccessControl.t.sol
@@ -144,13 +144,13 @@ contract AccessControlTest is Setup {
         vm.expectRevert(BaseStrategy.NotSelf.selector);
         strategy.deployFunds(_amount);
 
-        assertEq(asset.balanceOf(address(yieldSource)), 0);
+        assertEq(asset.balanceOf(address(yieldSource)), minimumProtocolPosition);
 
         vm.prank(address(strategy));
         strategy.deployFunds(_amount);
 
         // make sure we deposited into the funds
-        assertEq(asset.balanceOf(address(yieldSource)), _amount, "!out");
+        assertEq(asset.balanceOf(address(yieldSource)), _amount + minimumProtocolPosition, "!out");
     }
 
     function test_accessControl_freeFunds(address _address, uint256 _amount) public {
@@ -161,7 +161,7 @@ contract AccessControlTest is Setup {
         mintAndDepositIntoStrategy(strategy, user, _amount);
 
         // assure the deposit worked correctly
-        assertEq(asset.balanceOf(address(yieldSource)), _amount);
+        assertEq(asset.balanceOf(address(yieldSource)), _amount + minimumProtocolPosition);
         assertEq(asset.balanceOf(address(strategy)), 0);
 
         // doesn't work from random address
@@ -180,7 +180,7 @@ contract AccessControlTest is Setup {
         vm.prank(address(strategy));
         strategy.freeFunds(_amount);
 
-        assertEq(asset.balanceOf(address(yieldSource)), 0);
+        assertEq(asset.balanceOf(address(yieldSource)), minimumProtocolPosition);
         assertEq(asset.balanceOf(address(strategy)), _amount, "!out");
     }
 
@@ -192,7 +192,7 @@ contract AccessControlTest is Setup {
         mintAndDepositIntoStrategy(strategy, user, _amount);
 
         // assure the deposit worked correctly
-        assertEq(asset.balanceOf(address(yieldSource)), _amount);
+        assertEq(asset.balanceOf(address(yieldSource)), _amount + minimumProtocolPosition);
         assertEq(asset.balanceOf(address(strategy)), 0);
 
         // doesn't work from random address
@@ -208,7 +208,7 @@ contract AccessControlTest is Setup {
         vm.prank(address(strategy));
         uint256 amountOut = strategy.harvestAndReport();
 
-        assertEq(amountOut, _amount, "!out");
+        assertEq(amountOut, _amount + minimumProtocolPosition, "!out");
     }
 
     function test_accessControl_tendThis(address _address, uint256 _amount) public {

--- a/test/unit/strategies/yieldDonating/Accounting.t.sol
+++ b/test/unit/strategies/yieldDonating/Accounting.t.sol
@@ -41,7 +41,7 @@ contract AccountingTest is Setup {
         // should have pulled out just the deposited amount leaving the rest deployed.
         assertEq(asset.balanceOf(_address), beforeBalance + _amount);
         assertEq(asset.balanceOf(address(strategy)), 0);
-        assertEq(asset.balanceOf(address(yieldSource)), toAirdrop);
+        assertEq(asset.balanceOf(address(yieldSource)), toAirdrop + minimumProtocolPosition);
         checkStrategyTotals(strategy, 0, 0, 0, 0);
     }
 
@@ -153,7 +153,7 @@ contract AccountingTest is Setup {
 
         // should have pulled out just the deposit amount
         assertEq(asset.balanceOf(_address), beforeBalance + _amount);
-        assertEq(asset.balanceOf(address(yieldSource)), toAirdrop);
+        assertEq(asset.balanceOf(address(yieldSource)), toAirdrop + minimumProtocolPosition);
         checkStrategyTotals(strategy, 0, 0, 0, 0);
     }
 
@@ -184,7 +184,7 @@ contract AccountingTest is Setup {
         // airdrop to strategy
         uint256 toAirdrop = (_amount * _profitFactor) / MAX_BPS;
         asset.mint(address(yieldSource), toAirdrop);
-        assertEq(asset.balanceOf(address(yieldSource)), _amount + toAirdrop, "!yieldSource");
+        assertEq(asset.balanceOf(address(yieldSource)), _amount + toAirdrop + minimumProtocolPosition, "!yieldSource");
 
         // nothing should change
         assertEq(strategy.pricePerShare(), pricePerShare);
@@ -265,7 +265,7 @@ contract AccountingTest is Setup {
 
         // Should have deposited the toAirdrop amount but no other changes
         checkStrategyTotals(strategy, _amount, _amount, 0);
-        assertEq(asset.balanceOf(address(yieldSource)), _amount + toAirdrop, "!yieldSource");
+        assertEq(asset.balanceOf(address(yieldSource)), _amount + toAirdrop + minimumProtocolPosition, "!yieldSource");
         assertEq(strategy.pricePerShare(), wad, "!pps");
 
         // Make sure we now report the profit correctly
@@ -314,14 +314,18 @@ contract AccountingTest is Setup {
         uint256 expectedDeposit = _amount / 2;
         checkStrategyTotals(strategy, _amount, expectedDeposit, _amount - expectedDeposit, _amount);
 
-        assertEq(asset.balanceOf(address(yieldSource)), expectedDeposit, "!yieldSource");
+        uint256 expectedYieldSourceBalance = (minimumProtocolPosition / 2) +
+            ((_amount + minimumProtocolPosition / 2) / 2);
+        uint256 expectedIdleBalance = _amount + minimumProtocolPosition - expectedYieldSourceBalance;
+
+        assertEq(asset.balanceOf(address(yieldSource)), expectedYieldSourceBalance, "!yieldSource");
         // should still be 1
         assertEq(strategy.pricePerShare(), wad);
 
         // airdrop to strategy to simulate a harvesting of rewards
         uint256 toAirdrop = (_amount * _profitFactor) / MAX_BPS;
         asset.mint(address(strategy), toAirdrop);
-        assertEq(asset.balanceOf(address(strategy)), _amount - expectedDeposit + toAirdrop);
+        assertEq(asset.balanceOf(address(strategy)), expectedIdleBalance + toAirdrop);
 
         vm.prank(keeper);
         strategy.tend();
@@ -329,7 +333,7 @@ contract AccountingTest is Setup {
         // Should have withdrawn all the funds from the yield source
         checkStrategyTotals(strategy, _amount, 0, _amount, _amount);
         assertEq(asset.balanceOf(address(yieldSource)), 0, "!yieldSource");
-        assertEq(asset.balanceOf(address(strategy)), _amount + toAirdrop);
+        assertEq(asset.balanceOf(address(strategy)), _amount + toAirdrop + minimumProtocolPosition);
         assertEq(strategy.pricePerShare(), wad, "!pps");
 
         // Make sure we now report the profit correctly
@@ -342,7 +346,7 @@ contract AccountingTest is Setup {
             (_amount + toAirdrop) / 2,
             (_amount + toAirdrop) - ((_amount + toAirdrop) / 2)
         );
-        assertEq(asset.balanceOf(address(yieldSource)), (_amount + toAirdrop) / 2);
+        assertEq(asset.balanceOf(address(yieldSource)), (_amount + toAirdrop + minimumProtocolPosition) / 2);
 
         skip(profitMaxUnlockTime);
 
@@ -363,6 +367,7 @@ contract AccountingTest is Setup {
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
         uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
+        vm.assume(toLose > minimumProtocolPosition);
         // Simulate a loss.
         vm.prank(address(yieldSource));
         asset.transfer(address(69), toLose);
@@ -385,7 +390,8 @@ contract AccountingTest is Setup {
         asset.transfer(address(69), toLose);
 
         uint256 beforeBalance = asset.balanceOf(_address);
-        uint256 expectedOut = _amount - toLose;
+        uint256 userLoss = toLose > minimumProtocolPosition ? toLose - minimumProtocolPosition : 0;
+        uint256 expectedOut = _amount - userLoss;
         // Withdraw the full amount before the loss is reported.
         vm.prank(_address);
         strategy.withdraw(_amount, _address, _address, _lossFactor);
@@ -410,7 +416,8 @@ contract AccountingTest is Setup {
         asset.transfer(address(69), toLose);
 
         uint256 beforeBalance = asset.balanceOf(_address);
-        uint256 expectedOut = _amount - toLose;
+        uint256 userLoss = toLose > minimumProtocolPosition ? toLose - minimumProtocolPosition : 0;
+        uint256 expectedOut = _amount - userLoss;
         // Withdraw the full amount before the loss is reported.
         vm.prank(_address);
         strategy.redeem(_amount, _address, _address);
@@ -434,6 +441,7 @@ contract AccountingTest is Setup {
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
         uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
+        vm.assume(toLose > minimumProtocolPosition);
         // Simulate a loss.
         vm.prank(address(yieldSource));
         asset.transfer(address(69), toLose);
@@ -451,21 +459,25 @@ contract AccountingTest is Setup {
         mintAndDepositIntoStrategy(strategy, _address, _amount);
 
         uint256 toLose = (_amount * _lossFactor) / MAX_BPS;
+        vm.assume(toLose > minimumProtocolPosition);
         // Simulate a loss.
         vm.prank(address(yieldSource));
         asset.transfer(address(69), toLose);
 
         uint256 beforeBalance = asset.balanceOf(_address);
-        uint256 expectedOut = _amount - toLose;
+        uint256 userLoss = toLose - minimumProtocolPosition;
+        uint256 expectedOut = _amount - userLoss;
+        uint256 effectiveMaxLoss = (userLoss * MAX_BPS + _amount - 1) / _amount;
+        vm.assume(effectiveMaxLoss > 0);
 
         // First set it to just under the expected loss.
         vm.expectRevert("too much loss");
         vm.prank(_address);
-        strategy.redeem(_amount, _address, _address, _lossFactor - 1);
+        strategy.redeem(_amount, _address, _address, effectiveMaxLoss - 1);
 
         // Now redeem with the correct loss.
         vm.prank(_address);
-        strategy.redeem(_amount, _address, _address, _lossFactor);
+        strategy.redeem(_amount, _address, _address, effectiveMaxLoss);
 
         uint256 afterBalance = asset.balanceOf(_address);
 
@@ -495,7 +507,7 @@ contract AccountingTest is Setup {
         assertEq(strategy.balanceOf(_address), _amount);
         assertEq(asset.balanceOf(address(strategy)), 0);
 
-        assertEq(asset.balanceOf(address(yieldSource)), _amount);
+        assertEq(asset.balanceOf(address(yieldSource)), _amount + minimumProtocolPosition);
     }
 
     // ===== BURN CONVERSION TESTS =====
@@ -535,15 +547,15 @@ contract AccountingTest is Setup {
         assertEq(strategy.balanceOf(donationAddress), 0, "All dragon shares should be burned");
 
         // 2. Shares reduced by burned amount only
-        assertEq(strategy.totalSupply(), 80e18, "Should have 80 shares (100 - 20 burned)");
+        assertEq(strategy.totalSupply(), 80e18 + minimumProtocolPosition, "Should have 80 shares plus seed");
 
         // 3. Assets reduced by full loss amount
-        assertEq(strategy.totalAssets(), 75e18, "Should have 75 assets (100 - 25 loss)");
+        assertEq(strategy.totalAssets(), 75e18 + minimumProtocolPosition, "Should have 75 assets plus seed");
 
         // 4. User gets fair share of remaining assets
         uint256 userShares = strategy.balanceOf(user);
         uint256 userAssetValue = strategy.convertToAssets(userShares);
-        assertEq(userAssetValue, 75e18, "User should get fair share of 75 remaining assets");
+        assertApproxEqAbs(userAssetValue, 75e18, minimumProtocolPosition, "User should get fair share");
     }
 
     /**
@@ -568,8 +580,8 @@ contract AccountingTest is Setup {
 
         // Should only burn 20 shares to cover 20 token loss
         assertEq(strategy.balanceOf(donationAddress), 10e18, "10 dragon shares should remain");
-        assertEq(strategy.totalSupply(), 80e18, "Should have 80 total shares (100 - 20 burned)");
-        assertEq(strategy.totalAssets(), 80e18, "Should have 80 total assets (100 - 20 loss)");
+        assertEq(strategy.totalSupply(), 80e18 + minimumProtocolPosition, "Should have 80 shares plus seed");
+        assertEq(strategy.totalAssets(), 80e18 + minimumProtocolPosition, "Should have 80 assets plus seed");
 
         // Scenario 2: Minimal dragon shares, large loss
         vm.startPrank(user);
@@ -582,8 +594,8 @@ contract AccountingTest is Setup {
 
         // Should burn all 19 dragon shares, covering 19 tokens
         assertEq(strategy.balanceOf(donationAddress), 0, "All dragon shares should be burned");
-        assertEq(strategy.totalSupply(), 61e18, "Should have 61 total shares (80 - 19)");
-        assertEq(strategy.totalAssets(), 30e18, "Should have 30 total assets (80 - 50)");
+        assertEq(strategy.totalSupply(), 61e18 + minimumProtocolPosition, "Should have 61 shares plus seed");
+        assertEq(strategy.totalAssets(), 30e18 + minimumProtocolPosition, "Should have 30 assets plus seed");
     }
 
     /**
@@ -621,8 +633,8 @@ contract AccountingTest is Setup {
         );
 
         // Verify assets reduced but shares unchanged
-        assertEq(strategy.totalAssets(), 75e18, "Total assets should be 75 after loss");
-        assertEq(strategy.totalSupply(), 100e18, "Total shares should remain 100");
+        assertEq(strategy.totalAssets(), 75e18 + minimumProtocolPosition, "Total assets should include seed");
+        assertEq(strategy.totalSupply(), 100e18 + minimumProtocolPosition, "Total shares should include seed");
     }
 
     /**
@@ -653,8 +665,8 @@ contract AccountingTest is Setup {
         // totalAssets = 120, totalSupply = 150, PPS = 120/150 = 0.8
         uint256 totalAssets = strategy.totalAssets();
         uint256 totalSupply = strategy.totalSupply();
-        assertEq(totalAssets, 120e18, "Should have 120 assets after 30 loss");
-        assertEq(totalSupply, 150e18, "Supply unchanged when burning disabled");
+        assertEq(totalAssets, 120e18 + minimumProtocolPosition, "Should have 120 assets plus seed");
+        assertEq(totalSupply, 150e18 + minimumProtocolPosition, "Supply should include seed");
 
         // Step 3: Enable burning and trigger a small loss with non-zero remainder
         vm.prank(management);
@@ -720,7 +732,7 @@ contract AccountingTest is Setup {
         strategy.report();
 
         // After the fix, the 20 burned shares should have covered exactly 20 assets of loss
-        assertEq(strategy.totalAssets(), 75e18, "Should have 75 assets (100 - 25 loss)");
-        assertEq(strategy.totalSupply(), 80e18, "Should have 80 shares (100 - 20 burned)");
+        assertEq(strategy.totalAssets(), 75e18 + minimumProtocolPosition, "Should have 75 assets plus seed");
+        assertEq(strategy.totalSupply(), 80e18 + minimumProtocolPosition, "Should have 80 shares plus seed");
     }
 }

--- a/test/unit/strategies/yieldDonating/BailsecAvailableDepositLimitSentinel.t.sol
+++ b/test/unit/strategies/yieldDonating/BailsecAvailableDepositLimitSentinel.t.sol
@@ -1,21 +1,28 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity >=0.8.25;
 
-import { Test } from "forge-std/Test.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 import { YearnV3Strategy } from "src/strategies/yieldDonating/YearnV3Strategy.sol";
+import { SeedHelpers } from "./utils/SeedHelpers.sol";
 
 /// @notice Minimal vault that always advertises `type(uint256).max` as `maxDeposit`.
 /// @dev Mirrors the ERC-4626 "infinite capacity" sentinel returned by unrestricted Yearn/Morpho/Spark vaults.
 contract InfiniteCapacityVaultMock {
     address public immutable asset;
+    mapping(address => uint256) public balanceOf;
 
     constructor(address underlying) {
         asset = underlying;
+    }
+
+    function deposit(uint256 assets, address receiver) external returns (uint256) {
+        IERC20(asset).transferFrom(msg.sender, address(this), assets);
+        balanceOf[receiver] += assets;
+        return assets;
     }
 
     function maxDeposit(address) external pure returns (uint256) {
@@ -26,16 +33,12 @@ contract InfiniteCapacityVaultMock {
         return 0;
     }
 
-    function balanceOf(address) external pure returns (uint256) {
-        return 0;
+    function convertToAssets(uint256 shares) external pure returns (uint256) {
+        return shares;
     }
 
-    function convertToAssets(uint256) external pure returns (uint256) {
-        return 0;
-    }
-
-    function previewRedeem(uint256) external pure returns (uint256) {
-        return 0;
+    function previewRedeem(uint256 shares) external pure returns (uint256) {
+        return shares;
     }
 }
 
@@ -44,7 +47,7 @@ contract InfiniteCapacityVaultMock {
 ///         becomes `uint256.max - idle`; `TokenizedStrategy._maxMint` then runs `_convertToShares` with
 ///         that near-max assets argument and overflows in `mulDiv` whenever share price != 1.
 ///         Post-fix the function returns the sentinel verbatim so `_maxMint` short-circuits.
-contract BailsecAvailableDepositLimitSentinelTest is Test {
+contract BailsecAvailableDepositLimitSentinelTest is SeedHelpers {
     ERC20Mock internal asset;
     YieldDonatingTokenizedStrategy internal implementation;
     InfiniteCapacityVaultMock internal yearnVault;
@@ -74,6 +77,7 @@ contract BailsecAvailableDepositLimitSentinelTest is Test {
             false,
             address(implementation)
         );
+        _seedMinimumPosition(address(strategy), asset, management);
 
         // Seed idle balance directly on the strategy so the pre-fix arithmetic clobbers the sentinel.
         asset.mint(address(strategy), IDLE_BALANCE);

--- a/test/unit/strategies/yieldDonating/BailsecExactApprovalYearnV3.t.sol
+++ b/test/unit/strategies/yieldDonating/BailsecExactApprovalYearnV3.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity >=0.8.25;
 
-import { Test } from "forge-std/Test.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
 import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 import { YearnV3Strategy } from "src/strategies/yieldDonating/YearnV3Strategy.sol";
+import { SeedHelpers } from "./utils/SeedHelpers.sol";
 
 /// @notice Minimal Yearn-v3-shaped vault that mints 1:1 shares and pulls exactly `assets`.
 /// @dev Exposes just enough `ITokenizedStrategy` surface for the constructor + deposit + deploy
@@ -54,19 +54,19 @@ contract PassthroughVaultMock {
 ///      residual approval after the call.
 contract UnderPullVaultMock {
     address public immutable asset;
-    uint256 public immutable pullAmount;
+    uint256 public immutable pullBps;
 
     mapping(address => uint256) private _shares;
 
-    constructor(address underlying, uint256 _pullAmount) {
+    constructor(address underlying, uint256 _pullBps) {
         asset = underlying;
-        pullAmount = _pullAmount;
+        pullBps = _pullBps;
     }
 
-    function deposit(uint256, address receiver) external returns (uint256) {
-        IERC20(asset).transferFrom(msg.sender, address(this), pullAmount);
-        _shares[receiver] += pullAmount;
-        return pullAmount;
+    function deposit(uint256 assets, address receiver) external returns (uint256 shares) {
+        shares = (assets * pullBps) / 10_000;
+        IERC20(asset).transferFrom(msg.sender, address(this), shares);
+        _shares[receiver] += shares;
     }
 
     function balanceOf(address owner) external view returns (uint256) {
@@ -95,7 +95,7 @@ contract UnderPullVaultMock {
 ///         exposing the full idle balance to any hostile upgrade of the (upgradeable-proxy) vault.
 ///         Post-fix the allowance is granted per-deploy in `_deployFunds` and explicitly cleared
 ///         after the vault call, even if the target under-pulls.
-contract BailsecExactApprovalYearnV3Test is Test {
+contract BailsecExactApprovalYearnV3Test is SeedHelpers {
     ERC20Mock internal asset;
     YieldDonatingTokenizedStrategy internal implementation;
     PassthroughVaultMock internal yearnVault;
@@ -138,6 +138,8 @@ contract BailsecExactApprovalYearnV3Test is Test {
     }
 
     function test_bailsec_60_deployFundsLeavesZeroAllowance() public {
+        _seedMinimumPosition(address(strategy), asset, management);
+
         asset.mint(user, DEPOSIT_AMOUNT);
         vm.startPrank(user);
         asset.approve(address(strategy), DEPOSIT_AMOUNT);
@@ -155,8 +157,8 @@ contract BailsecExactApprovalYearnV3Test is Test {
     }
 
     function test_bailsec_60_deployFundsClearsResidualAllowanceIfVaultUnderPulls() public {
-        uint256 pulled = DEPOSIT_AMOUNT / 2;
-        UnderPullVaultMock underPullVault = new UnderPullVaultMock(address(asset), pulled);
+        uint256 pullBps = 5_000;
+        UnderPullVaultMock underPullVault = new UnderPullVaultMock(address(asset), pullBps);
         YearnV3Strategy underPullStrategy = new YearnV3Strategy(
             address(underPullVault),
             address(asset),
@@ -169,6 +171,7 @@ contract BailsecExactApprovalYearnV3Test is Test {
             false,
             address(implementation)
         );
+        _seedMinimumPosition(address(underPullStrategy), asset, management);
 
         asset.mint(user, DEPOSIT_AMOUNT);
         vm.startPrank(user);
@@ -183,7 +186,7 @@ contract BailsecExactApprovalYearnV3Test is Test {
         );
         assertEq(
             asset.balanceOf(address(underPullStrategy)),
-            DEPOSIT_AMOUNT - pulled,
+            (DEPOSIT_AMOUNT + MINIMUM_PROTOCOL_POSITION / 2) / 2,
             "mock invariant: unpulled assets remain idle on the strategy"
         );
     }

--- a/test/unit/strategies/yieldDonating/BailsecPreviewRedeem.t.sol
+++ b/test/unit/strategies/yieldDonating/BailsecPreviewRedeem.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity >=0.8.25;
 
-import { Test } from "forge-std/Test.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import { ERC4626 } from "@openzeppelin/contracts/token/ERC20/extensions/ERC4626.sol";
@@ -13,6 +12,7 @@ import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/Yie
 import { ERC4626Strategy } from "src/strategies/yieldDonating/ERC4626Strategy.sol";
 import { YearnV3Strategy } from "src/strategies/yieldDonating/YearnV3Strategy.sol";
 import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
+import { SeedHelpers } from "./utils/SeedHelpers.sol";
 
 /// @notice ERC4626 target vault that charges an exit fee, so `previewRedeem(shares)` < `convertToAssets(shares)`.
 /// @dev Uses OpenZeppelin's docs-level ERC4626Fees reference to keep fee accounting EIP-4626 compliant.
@@ -43,7 +43,7 @@ contract ExitFeeVaultMock is ERC4626Fees {
 ///         Post-fix they use `previewRedeem`, the EIP-4626 view required to reflect any exit-fee
 ///         policy. Exercised across `ERC4626Strategy`, `YearnV3Strategy`, and
 ///         `MorphoCompounderStrategy`; `SparkStrategy` inherits the fix from `ERC4626Strategy`.
-contract BailsecPreviewRedeemTest is Test {
+contract BailsecPreviewRedeemTest is SeedHelpers {
     ERC20Mock internal asset;
     YieldDonatingTokenizedStrategy internal implementation;
     ExitFeeVaultMock internal targetVault;
@@ -64,6 +64,8 @@ contract BailsecPreviewRedeemTest is Test {
     }
 
     function _depositThenReport(address strategyAddr) internal {
+        _seedMinimumPosition(strategyAddr, asset, management);
+
         asset.mint(user, DEPOSIT_AMOUNT);
         vm.startPrank(user);
         asset.approve(strategyAddr, DEPOSIT_AMOUNT);

--- a/test/unit/strategies/yieldDonating/BailsecZeroSharesDeployFunds.t.sol
+++ b/test/unit/strategies/yieldDonating/BailsecZeroSharesDeployFunds.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity >=0.8.25;
 
-import { Test } from "forge-std/Test.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
@@ -10,24 +9,31 @@ import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/Yie
 import { ERC4626Strategy } from "src/strategies/yieldDonating/ERC4626Strategy.sol";
 import { YearnV3Strategy } from "src/strategies/yieldDonating/YearnV3Strategy.sol";
 import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
+import { SeedHelpers } from "./utils/SeedHelpers.sol";
 
 /// @notice Minimal 4626-shaped vault that always credits zero shares on deposit.
 /// @dev Simulates the "downstream vault rounds minted shares to zero" regime
 ///      (high PPS + tiny deposit) without having to stage the inflation manually.
 contract ZeroSharesVaultMock {
     address public immutable asset;
+    bool public zeroShares;
 
     constructor(address underlying) {
         asset = underlying;
     }
 
-    function deposit(uint256 assets, address /*receiver*/) external returns (uint256) {
-        IERC20(asset).transferFrom(msg.sender, address(this), assets);
-        return 0;
+    function setZeroShares(bool _zeroShares) external {
+        zeroShares = _zeroShares;
     }
 
-    function balanceOf(address) external pure returns (uint256) {
-        return 0;
+    function deposit(uint256 assets, address /*receiver*/) external returns (uint256 shares) {
+        IERC20(asset).transferFrom(msg.sender, address(this), assets);
+        if (zeroShares) return 0;
+        return assets;
+    }
+
+    function balanceOf(address owner) external view returns (uint256) {
+        return owner == address(0) ? 0 : IERC20(asset).balanceOf(address(this));
     }
 
     function maxDeposit(address) external pure returns (uint256) {
@@ -38,12 +44,12 @@ contract ZeroSharesVaultMock {
         return 0;
     }
 
-    function previewRedeem(uint256) external pure returns (uint256) {
-        return 0;
+    function previewRedeem(uint256 shares) external pure returns (uint256) {
+        return shares;
     }
 
-    function convertToAssets(uint256) external pure returns (uint256) {
-        return 0;
+    function convertToAssets(uint256 shares) external pure returns (uint256) {
+        return shares;
     }
 }
 
@@ -55,7 +61,7 @@ contract ZeroSharesVaultMock {
 ///         `MorphoCompounderStrategy`; `SparkStrategy` inherits the fix from `ERC4626Strategy`.
 ///         For #57's withdraw leg, `_freeFunds` relies on `TokenizedStrategy._withdraw` balance-diff
 ///         accounting because target `withdraw` returns shares burned rather than assets received.
-contract BailsecZeroSharesDeployFundsTest is Test {
+contract BailsecZeroSharesDeployFundsTest is SeedHelpers {
     ERC20Mock internal asset;
     YieldDonatingTokenizedStrategy internal implementation;
     ZeroSharesVaultMock internal targetVault;
@@ -75,6 +81,9 @@ contract BailsecZeroSharesDeployFundsTest is Test {
     }
 
     function _expectDepositReverts(address strategyAddr, string memory reason) internal {
+        _seedMinimumPosition(strategyAddr, asset, management);
+        targetVault.setZeroShares(true);
+
         asset.mint(user, DEPOSIT_AMOUNT);
         vm.startPrank(user);
         asset.approve(strategyAddr, DEPOSIT_AMOUNT);

--- a/test/unit/strategies/yieldDonating/ERC4626BranchCoverage.t.sol
+++ b/test/unit/strategies/yieldDonating/ERC4626BranchCoverage.t.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity >=0.8.25;
 
-import { Test } from "forge-std/Test.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
 
@@ -9,6 +8,7 @@ import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 import { ERC4626Strategy } from "src/strategies/yieldDonating/ERC4626Strategy.sol";
 import { MorphoCompounderStrategy } from "src/strategies/yieldDonating/MorphoCompounderStrategy.sol";
+import { SeedHelpers } from "./utils/SeedHelpers.sol";
 
 /// @notice 4626-shaped vault used by the branch-coverage tests below.
 /// @dev    Implements only the surface exercised by `_deployFunds` and
@@ -69,7 +69,7 @@ contract UnboundedVaultMock {
 ///            keys off (the pre-fix subtraction clobbered the sentinel into
 ///            `uint256.max - idle`, routing through `_convertToShares` and
 ///            risking a mulDiv overflow once PPS drifts off 1:1).
-contract ERC4626BranchCoverageTest is Test {
+contract ERC4626BranchCoverageTest is SeedHelpers {
     ERC20Mock internal asset;
     YieldDonatingTokenizedStrategy internal implementation;
     UnboundedVaultMock internal targetVault;
@@ -132,6 +132,7 @@ contract ERC4626BranchCoverageTest is Test {
             0,
             "constructor leaked a standing allowance against the target vault"
         );
+        _seedMinimumPosition(strategyAddr, asset, management);
 
         // Deposit routes through `_deployFunds`, which approves exactly the
         // deposit amount and clears allowance after the vault call.
@@ -149,6 +150,7 @@ contract ERC4626BranchCoverageTest is Test {
     }
 
     function _assertResidualApprovalClearedOnUnderPull(address strategyAddr) internal {
+        _seedMinimumPosition(strategyAddr, asset, management);
         targetVault.setPullBps(5_000);
 
         asset.mint(user, DEPOSIT_AMOUNT);
@@ -170,6 +172,8 @@ contract ERC4626BranchCoverageTest is Test {
     }
 
     function _assertMaxMintSentinel(address strategyAddr) internal {
+        _seedMinimumPosition(strategyAddr, asset, management);
+
         // Seed a non-zero idle balance so we exercise the subtraction branch;
         // without this the pre-fix code path would coincidentally return the
         // sentinel because `max - 0 == max`.

--- a/test/unit/strategies/yieldDonating/ProtocolSeededMinimumPosition.t.sol
+++ b/test/unit/strategies/yieldDonating/ProtocolSeededMinimumPosition.t.sol
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.25;
+
+import { IMockStrategy } from "test/mocks/core/IMockStrategy.sol";
+import { MockStrategy } from "test/mocks/core/tokenized-strategies/MockStrategy.sol";
+import { MockYieldSource } from "test/mocks/core/tokenized-strategies/MockYieldSource.sol";
+import { Setup } from "./utils/Setup.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+
+/// @notice Regression coverage for Bailsec's protocol-seeded minimum-position mitigation.
+contract ProtocolSeededMinimumPositionTest is Setup {
+    address internal attacker = address(0xA77A);
+    address internal victim = address(0xB0B);
+
+    function _deployUnseededStrategy()
+        internal
+        returns (IMockStrategy unseededStrategy, MockYieldSource freshYieldSource)
+    {
+        freshYieldSource = new MockYieldSource(address(asset));
+        unseededStrategy = IMockStrategy(
+            address(
+                new MockStrategy(
+                    address(asset),
+                    address(freshYieldSource),
+                    management,
+                    keeper,
+                    emergencyAdmin,
+                    donationAddress,
+                    address(implementation)
+                )
+            )
+        );
+
+        vm.startPrank(management);
+        unseededStrategy.setKeeper(keeper);
+        unseededStrategy.setEmergencyAdmin(emergencyAdmin);
+        unseededStrategy.setPendingManagement(management);
+        unseededStrategy.acceptManagement();
+        vm.stopPrank();
+    }
+
+    function testSeedMinimumPositionLocksStrategyOwnedShares() public {
+        (IMockStrategy unseededStrategy, MockYieldSource freshYieldSource) = _deployUnseededStrategy();
+
+        assertEq(unseededStrategy.maxDeposit(user), 0, "deposits should stay closed before seed");
+        assertEq(unseededStrategy.maxMint(user), 0, "mints should stay closed before seed");
+
+        asset.mint(user, 1 ether);
+        vm.startPrank(user);
+        asset.approve(address(unseededStrategy), 1 ether);
+        vm.expectRevert("MINIMUM_POSITION_UNSEEDED");
+        unseededStrategy.deposit(1 ether, user);
+        vm.stopPrank();
+
+        asset.mint(management, minimumProtocolPosition);
+        vm.startPrank(management);
+        asset.approve(address(unseededStrategy), minimumProtocolPosition);
+        uint256 seededShares = YieldDonatingTokenizedStrategy(address(unseededStrategy)).seedMinimumPosition();
+        vm.stopPrank();
+
+        assertEq(seededShares, minimumProtocolPosition, "seed shares");
+        assertEq(unseededStrategy.totalSupply(), minimumProtocolPosition, "seeded supply");
+        assertEq(unseededStrategy.totalAssets(), minimumProtocolPosition, "seeded assets");
+        assertEq(unseededStrategy.balanceOf(address(unseededStrategy)), minimumProtocolPosition, "locked shares");
+        assertEq(asset.balanceOf(address(freshYieldSource)), minimumProtocolPosition, "seed deployed");
+        assertEq(unseededStrategy.balanceOf(management), 0, "management should not hold redeemable seed shares");
+        assertEq(unseededStrategy.maxDeposit(user), type(uint256).max, "deposits open after seed");
+        assertEq(unseededStrategy.maxMint(user), type(uint256).max, "mints open after seed");
+    }
+
+    function testSeedMinimumPositionCannotRunAfterVaultIsLive() public {
+        asset.mint(management, minimumProtocolPosition);
+        vm.startPrank(management);
+        asset.approve(address(strategy), minimumProtocolPosition);
+        vm.expectRevert("MINIMUM_POSITION_LATE");
+        YieldDonatingTokenizedStrategy(address(strategy)).seedMinimumPosition();
+        vm.stopPrank();
+    }
+
+    function testBailsecDustHolderCannotResetSupplyOrInflateVictimDeposit() public {
+        uint256 attackerDeposit = 100 ether;
+        uint256 recovery = 100 ether;
+        uint256 victimDeposit = 150 ether;
+
+        asset.mint(attacker, attackerDeposit);
+        vm.startPrank(attacker);
+        asset.approve(address(strategy), attackerDeposit);
+        strategy.deposit(attackerDeposit, attacker);
+        vm.stopPrank();
+
+        assertEq(strategy.balanceOf(attacker), attackerDeposit, "attacker starts at 1:1 PPS");
+        assertEq(strategy.totalSupply(), minimumProtocolPosition + attackerDeposit, "seed plus attacker supply");
+        assertEq(strategy.totalAssets(), minimumProtocolPosition + attackerDeposit, "seed plus attacker assets");
+
+        yieldSource.simulateLoss(minimumProtocolPosition + 1);
+
+        vm.prank(attacker);
+        uint256 burnedShares = strategy.withdraw(attackerDeposit - 1, attacker, attacker);
+
+        assertEq(burnedShares, attackerDeposit - 1, "stale withdraw burns requested assets at 1:1");
+        assertEq(strategy.balanceOf(attacker), 1, "attacker leaves one dust share");
+        assertEq(strategy.totalAssets(), minimumProtocolPosition + 1, "tracked assets stale until report");
+
+        vm.prank(keeper);
+        (uint256 profit, uint256 loss) = strategy.report();
+
+        assertEq(profit, 0, "loss report profit");
+        assertEq(loss, minimumProtocolPosition + 1, "loss report realizes seed plus dust shortfall");
+        assertEq(strategy.totalAssets(), 0, "assets can still hit zero");
+        assertEq(strategy.totalSupply(), minimumProtocolPosition + 1, "locked seed keeps supply non-zero");
+
+        asset.mint(address(yieldSource), recovery);
+
+        vm.prank(keeper);
+        (profit, loss) = strategy.report();
+
+        assertEq(profit, recovery, "recovery report profit");
+        assertEq(loss, 0, "recovery report loss");
+        assertEq(strategy.totalAssets(), recovery, "recovery tracked");
+        assertEq(strategy.balanceOf(donationAddress), 0, "zero-asset recovery still mints no dragon shares");
+        assertEq(strategy.totalSupply(), minimumProtocolPosition + 1, "recovery cannot reset supply");
+
+        uint256 attackerRedeemable = strategy.maxWithdraw(attacker);
+
+        vm.prank(attacker);
+        uint256 attackerRecovered = strategy.redeem(1, attacker, attacker);
+
+        assertEq(attackerRecovered, attackerRedeemable, "attacker only receives dust pro-rata recovery");
+        assertLt(attackerRecovered, recovery / 1_000_000, "attacker recovery must be economically dust");
+        assertEq(strategy.balanceOf(attacker), 0, "attacker dust burned");
+        assertEq(strategy.totalSupply(), minimumProtocolPosition, "locked seed remains after attacker exits");
+        assertGt(strategy.totalAssets(), 0, "recovered assets remain backed by locked seed");
+
+        asset.mint(attacker, 1);
+        vm.startPrank(attacker);
+        asset.approve(address(strategy), 1);
+        vm.expectRevert("ZERO_SHARES");
+        strategy.deposit(1, attacker);
+        vm.stopPrank();
+
+        asset.mint(victim, victimDeposit);
+        vm.startPrank(victim);
+        asset.approve(address(strategy), victimDeposit);
+        uint256 victimShares = strategy.deposit(victimDeposit, victim);
+        vm.stopPrank();
+
+        assertGt(victimShares, 1, "victim should not be floored to one dust share");
+        assertApproxEqAbs(
+            strategy.convertToAssets(victimShares),
+            victimDeposit,
+            strategy.convertToAssets(1) + 1,
+            "victim deposit should price at current PPS"
+        );
+        assertEq(strategy.balanceOf(attacker), 0, "attacker has no claim after dust redeem");
+    }
+}

--- a/test/unit/strategies/yieldDonating/ReportLifecycle.t.sol
+++ b/test/unit/strategies/yieldDonating/ReportLifecycle.t.sol
@@ -142,7 +142,11 @@ contract ReportLifecycleTest is Setup {
         assertEq(reportedLoss, loss, "loss mismatch");
         assertEq(strategy.balanceOf(donationAddress), 0, "all dragon shares should be burned");
         // Remaining loss affects all holders via PPS reduction
-        assertEq(strategy.totalAssets(), amount - loss, "total assets should reflect full loss");
+        assertEq(
+            strategy.totalAssets(),
+            amount - loss + minimumProtocolPosition,
+            "total assets should reflect full loss"
+        );
     }
 
     function test_reportLoss_burningEnabled_emitsDonationBurned() public {
@@ -195,7 +199,7 @@ contract ReportLifecycleTest is Setup {
         assertEq(strategy.balanceOf(donationAddress), dragonBalBefore, "dragon shares should not change");
         assertEq(strategy.totalSupply(), totalSupplyBefore, "total supply should not change");
         // PPS drops for all holders
-        assertEq(strategy.totalAssets(), amount - loss, "total assets should reflect loss");
+        assertEq(strategy.totalAssets(), amount - loss + minimumProtocolPosition, "total assets should reflect loss");
     }
 
     // ==================== Report with Zero Change ====================
@@ -317,7 +321,11 @@ contract ReportLifecycleTest is Setup {
         assertEq(reportedProfit, _profit, "profit mismatch");
         assertEq(reportedLoss, 0, "should be zero loss");
         assertEq(strategy.pricePerShare(), ppsBefore, "PPS should not change");
-        assertEq(strategy.totalAssets(), _amount + _profit, "totalAssets should include profit");
+        assertEq(
+            strategy.totalAssets(),
+            _amount + _profit + minimumProtocolPosition,
+            "totalAssets should include profit"
+        );
         assertGt(strategy.balanceOf(donationAddress), 0, "dragon should get shares");
     }
 

--- a/test/unit/strategies/yieldDonating/Shutdown.t.sol
+++ b/test/unit/strategies/yieldDonating/Shutdown.t.sol
@@ -123,7 +123,7 @@ contract ShutdownTest is Setup {
 
         // Funds should be pulled from yield source to strategy
         assertEq(asset.balanceOf(address(strategy)), _amount, "funds should be in strategy");
-        assertEq(asset.balanceOf(address(yieldSource)), 0, "yield source should be empty");
+        assertEq(asset.balanceOf(address(yieldSource)), minimumProtocolPosition, "yield source should keep seed");
     }
 
     function test_emergencyWithdraw_byEmergencyAdmin(uint256 _amount) public {
@@ -190,7 +190,7 @@ contract ShutdownTest is Setup {
         (, uint256 reportedLoss) = strategy.report();
 
         assertEq(reportedLoss, loss, "loss mismatch");
-        assertEq(strategy.totalAssets(), amount - loss, "total assets should reflect loss");
+        assertEq(strategy.totalAssets(), amount - loss + minimumProtocolPosition, "total assets should reflect loss");
         // Burning should still work after shutdown
         assertLt(strategy.balanceOf(donationAddress), 20e18, "dragon shares should be partially burned");
     }

--- a/test/unit/strategies/yieldDonating/SkyCompounderBranchCoverage.t.sol
+++ b/test/unit/strategies/yieldDonating/SkyCompounderBranchCoverage.t.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import { Test } from "forge-std/Test.sol";
 import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 import { SkyCompounderStrategy } from "src/strategies/yieldDonating/SkyCompounderStrategy.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { SeedHelpers } from "./utils/SeedHelpers.sol";
 
 /// @title Inline mock staking contract for SkyCompounder tests
 contract MockStaking is ERC20 {
@@ -42,7 +42,7 @@ contract MockStaking is ERC20 {
 
 /// @title SkyCompounderStrategy branch coverage tests
 /// @notice Covers 4 uncovered branches + 1 uncovered function (setMinAmountOut)
-contract SkyCompounderBranchCoverageTest is Test {
+contract SkyCompounderBranchCoverageTest is SeedHelpers {
     // USDS address hardcoded in SkyCompounderStrategy
     address constant USDS = 0xdC035D45d973E3EC169d2276DDab16f1e407384F;
 
@@ -146,6 +146,7 @@ contract SkyCompounderBranchCoverageTest is Test {
     /// @notice _harvestAndReport when isShutdown() == true takes the shutdown path (line 256)
     function test_harvestAndReport_shutdownPath() public {
         SkyCompounderStrategy strategy = _deployStrategy();
+        _seedMinimumPosition(address(strategy), ERC20Mock(USDS), management);
 
         // Mint USDS to deposit
         ERC20Mock(USDS).mint(address(this), 100e18);

--- a/test/unit/strategies/yieldDonating/YieldDonatingDustMint.t.sol
+++ b/test/unit/strategies/yieldDonating/YieldDonatingDustMint.t.sol
@@ -27,6 +27,7 @@ contract YieldDonatingDustMintTest is Setup {
 
     function setUp() public override {
         super.setUp();
+        yieldSource.simulateLoss(minimumProtocolPosition);
     }
 
     /// @notice Direct write to the strategy's namespaced storage. Used to construct a

--- a/test/unit/strategies/yieldDonating/utils/SeedHelpers.sol
+++ b/test/unit/strategies/yieldDonating/utils/SeedHelpers.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity >=0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { MockERC20 as CoreMockERC20 } from "test/mocks/MockERC20.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+
+abstract contract SeedHelpers is Test {
+    uint256 internal constant MINIMUM_PROTOCOL_POSITION = 1_000_000_000;
+
+    function _seedMinimumPosition(address strategyAddr, ERC20Mock asset, address management) internal {
+        asset.mint(management, MINIMUM_PROTOCOL_POSITION);
+
+        vm.startPrank(management);
+        asset.approve(strategyAddr, MINIMUM_PROTOCOL_POSITION);
+        YieldDonatingTokenizedStrategy(strategyAddr).seedMinimumPosition();
+        vm.stopPrank();
+    }
+
+    function _seedMinimumPosition(address strategyAddr, CoreMockERC20 asset, address management) internal {
+        asset.mint(management, MINIMUM_PROTOCOL_POSITION);
+
+        vm.startPrank(management);
+        asset.approve(strategyAddr, MINIMUM_PROTOCOL_POSITION);
+        YieldDonatingTokenizedStrategy(strategyAddr).seedMinimumPosition();
+        vm.stopPrank();
+    }
+}

--- a/test/unit/strategies/yieldDonating/utils/Setup.sol
+++ b/test/unit/strategies/yieldDonating/utils/Setup.sol
@@ -40,6 +40,7 @@ contract Setup is Test {
     // Fuzz from $0.01 of 1e6 stable coins up to 1 trillion of a 1e18 coin
     uint256 public maxFuzzAmount = 1e30;
     uint256 public minFuzzAmount = 10_000;
+    uint256 public minimumProtocolPosition = 1_000_000_000;
     uint256 public profitMaxUnlockTime = 10 days;
 
     bytes32 public constant BASE_STRATEGY_STORAGE = bytes32(uint256(keccak256("yearn.base.strategy.storage")) - 1);
@@ -74,6 +75,7 @@ contract Setup is Test {
 
         // Deploy strategy and set variables
         strategy = IMockStrategy(setUpStrategy());
+        seedMinimumPosition(strategy);
 
         // label all the used addresses for traces
         vm.label(keeper, "keeper");
@@ -119,7 +121,18 @@ contract Setup is Test {
         return address(_strategy);
     }
 
+    function seedMinimumPosition(IMockStrategy _strategy) public {
+        asset.mint(management, minimumProtocolPosition);
+
+        vm.startPrank(management);
+        asset.approve(address(_strategy), minimumProtocolPosition);
+        YieldDonatingTokenizedStrategy(address(_strategy)).seedMinimumPosition();
+        vm.stopPrank();
+    }
+
     function setUpIlliquidStrategy() public returns (address) {
+        yieldSource = new MockYieldSource(address(asset));
+
         IMockStrategy _strategy = IMockStrategy(
             address(
                 new MockIlliquidStrategy(
@@ -147,10 +160,14 @@ contract Setup is Test {
         _strategy.acceptManagement();
         vm.stopPrank();
 
+        seedMinimumPosition(_strategy);
+
         return address(_strategy);
     }
 
     function setUpFaultyStrategy() public returns (address) {
+        yieldSource = new MockYieldSource(address(asset));
+
         IMockStrategy _strategy = IMockStrategy(
             address(
                 new MockFaultyStrategy(
@@ -175,6 +192,8 @@ contract Setup is Test {
         vm.prank(management);
         _strategy.acceptManagement();
 
+        seedMinimumPosition(_strategy);
+
         return address(_strategy);
     }
 
@@ -198,12 +217,16 @@ contract Setup is Test {
         uint256 _balance = ERC20Mock(_strategy.asset()).balanceOf(address(_strategy));
         uint256 _idle = _balance > _assets ? _assets : _balance;
         uint256 _debt = _assets - _idle;
-        assertEq(_assets, _totalAssets, "!totalAssets");
-        assertEq(_debt, _totalDebt, "!totalDebt");
-        assertEq(_idle, _totalIdle, "!totalIdle");
+        uint256 lockedSeedAssets = _strategy.convertToAssets(_strategy.balanceOf(address(_strategy)));
+        uint256 lockedSeedShares = _strategy.balanceOf(address(_strategy));
+
+        assertEq(_assets, _totalAssets + lockedSeedAssets, "!totalAssets");
+        assertGe(_debt, _totalDebt, "!totalDebt");
+        assertGe(_idle, _totalIdle, "!totalIdle");
+        assertEq((_debt - _totalDebt) + (_idle - _totalIdle), lockedSeedAssets, "!seedAccounting");
         assertEq(_totalAssets, _totalDebt + _totalIdle, "!Added");
         // We give supply a buffer or 1 wei for rounding
-        assertApproxEqRel(_strategy.totalSupply(), _totalSupply, 1e13, "!supply");
+        assertApproxEqRel(_strategy.totalSupply(), _totalSupply + lockedSeedShares, 1e13, "!supply");
     }
 
     // For checks without totalSupply while profit is unlocking
@@ -217,9 +240,12 @@ contract Setup is Test {
         uint256 _balance = ERC20Mock(_strategy.asset()).balanceOf(address(_strategy));
         uint256 _idle = _balance > _assets ? _assets : _balance;
         uint256 _debt = _assets - _idle;
-        assertEq(_assets, _totalAssets, "!totalAssets");
-        assertEq(_debt, _totalDebt, "!totalDebt");
-        assertEq(_idle, _totalIdle, "!totalIdle");
+        uint256 lockedSeedAssets = _strategy.convertToAssets(_strategy.balanceOf(address(_strategy)));
+
+        assertEq(_assets, _totalAssets + lockedSeedAssets, "!totalAssets");
+        assertGe(_debt, _totalDebt, "!totalDebt");
+        assertGe(_idle, _totalIdle, "!totalIdle");
+        assertEq((_debt - _totalDebt) + (_idle - _totalIdle), lockedSeedAssets, "!seedAccounting");
         assertEq(_totalAssets, _totalDebt + _totalIdle, "!Added");
     }
 

--- a/verification/kontrol/YDSetup.k.sol
+++ b/verification/kontrol/YDSetup.k.sol
@@ -78,11 +78,13 @@ contract YDSetup is KontrolTest {
         _storeAddress(address(strategy), TS_EMERGENCY_ADMIN_SLOT, _emergencyAdmin);
         _storeAddress(address(strategy), TS_DRAGON_ROUTER_SLOT, _dragonRouter);
 
-        // Symbolic totalSupply and totalAssets
-        uint256 totalSupply = freshUInt256Bounded();
+        // Symbolic totalSupply and totalAssets, preserving the locked protocol seed.
+        uint256 seedBalance = implementation.MINIMUM_PROTOCOL_POSITION();
+        uint256 totalSupply = seedBalance + freshUInt256Bounded();
         _storeUInt256(address(strategy), TS_TOTAL_SUPPLY_SLOT, totalSupply);
         uint256 totalAssets = freshUInt256Bounded();
         _storeUInt256(address(strategy), TS_TOTAL_ASSETS_SLOT, totalAssets);
+        _storeMappingUInt256(address(strategy), TS_BALANCES_SLOT, uint256(uint160(address(strategy))), 0, seedBalance);
 
         // Flags: decimals=18, entered=NOT_ENTERED(1), shutdown=false(0), enableBurning=true(1)
         _storeData(address(strategy), TS_FLAGS_SLOT, TS_DECIMALS_OFFSET, TS_DECIMALS_WIDTH, 18);
@@ -95,6 +97,7 @@ contract YDSetup is KontrolTest {
 
         // Symbolic dragon router balance
         uint256 dragonBalance = freshUInt256Bounded();
+        vm.assume(dragonBalance <= totalSupply - seedBalance);
         _storeMappingUInt256(address(strategy), TS_BALANCES_SLOT, uint256(uint160(_dragonRouter)), 0, dragonBalance);
 
         // Warp to a later timestamp

--- a/verification/kontrol/YDStrategyTest.k.sol
+++ b/verification/kontrol/YDStrategyTest.k.sol
@@ -213,6 +213,8 @@ contract YDStrategyTest is StrategyBaseTest, YDSetup {
         assertEq(postState.dragonBalance, 0);
         // totalSupply decreased by exactly the dragon balance
         assertEq(postState.totalSupply, preState.totalSupply - preState.dragonBalance);
+        // The strategy-owned seed remains locked, so burning dragon shares cannot reset supply to zero.
+        assertGe(postState.totalSupply, implementation.MINIMUM_PROTOCOL_POSITION());
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Context

Bailsec reported a dust-share accounting chain in the yield-donating vault:

1. A sole holder can withdraw against stale pre-loss accounting while leaving 1 wei of shares.
2. A later loss report can land at `totalAssets == 0 && totalSupply > 0`, DoSing deposits and causing zero-share dragon mints on recovery.
3. After recovery, the dust holder can burn the final external dust share while only removing a tiny asset amount, pushing the vault toward `totalSupply == 0 && totalAssets > 0`.
4. The next first depositor can then be sandwiched and diluted by floor rounding against the ghost collateral.

This PR implements Bailsec's protocol-seeded minimum-position recommendation as the low-complexity mitigation path.

## What Changed

- Adds `MINIMUM_PROTOCOL_POSITION = 1_000_000_000` to `YieldDonatingTokenizedStrategy`.
- Adds `seedMinimumPosition()`, callable once by management while the strategy has no supply/assets.
- The seed is pulled from management, deployed into the underlying yield source, tracked as `totalAssets`, and minted as locked strategy-owned shares.
- Blocks deposits/mints until the locked seed exists:
  - `maxDeposit()` and `maxMint()` return `0` pre-seed.
  - `_deposit()` reverts with `MINIMUM_POSITION_UNSEEDED` pre-seed.
- Updates unit/integration fixtures so yield-donating strategies are seeded before normal test flows.
- Updates the Kontrol YD setup to model the locked strategy-owned seed and asserts dragon-share burning cannot reset supply below the seed.

## Design Notes

I kept this as a management-only post-deploy activation step instead of putting the deposit inside `initialize()`. `TokenizedStrategy.initialize()` runs during the base strategy constructor, before concrete strategy wrappers have finished configuring their downstream yield source. Calling `deployFunds()` from that phase would couple initialization to partially constructed strategy state.

Operationally, deployment/factory scripts should call `seedMinimumPosition()` before opening a strategy to public deposits. The guard makes an unseeded deployment fail closed instead of relying on operator discipline.

The mitigation does not claim to make a catastrophic `totalAssets == 0 && totalSupply > 0` state pleasant. Deposits can still remain blocked while accounting is at zero. The important security property is that supply cannot be reset to zero after recovery, so the first-depositor inflation branch is no longer reachable and recovered value is anchored by the locked protocol seed rather than an attacker-controlled final dust share.

## Regression Coverage

`ProtocolSeededMinimumPosition.t.sol` covers the adversarial Bailsec chain:

- pre-seed deposits/mints are closed;
- management can seed exactly once and receives no redeemable shares;
- attacker leaves 1 wei of shares before a loss report;
- report can still take `totalAssets` to zero, but supply remains `seed + dust`;
- recovery from zero old assets still mints no dragon shares, matching the dangerous edge being mitigated;
- attacker can redeem only their dust pro-rata recovery;
- total supply remains the locked seed after the attacker exits;
- attacker cannot front-run with a 1 wei first-deposit reset;
- victim deposit receives proportional shares instead of being floored to 1 wei.

## Validation

- `yarn format:check`
- `yarn lint` (passes with the repo's existing Solhint warning set)
- `forge build --skip test script`
- `forge test --match-path 'test/unit/strategies/yieldDonating/**' --summary` (`208 passed`)
- `forge test --match-path 'test/unit/**' --summary` (`1969 passed`)
- `yarn build`
- `kontrol build`

Not run locally:

- `forge test --match-path 'test/integration/strategies/YieldDonating/**' --summary` needs `TEST_RPC_URL` in this checkout.
- `yarn storage:check` is blocked by pre-existing `PgEtherToken` storage snapshot drift outside this PR.
