### PR TITLE
test(kontrol): fix forwarder redeem guard proofs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -315,7 +315,13 @@ jobs:
         run: kontrol build
 
       - name: Kontrol Prove
-        run: kontrol prove --workers 4
+        env:
+          COLUMNS: "220"
+          LINES: "60"
+          TERM: xterm-256color
+          PYTHONUNBUFFERED: "1"
+        run: |
+          kontrol prove --workers 4 --hide-status-bar
         timeout-minutes: 240
 
   analyze:

--- a/kontrol.toml
+++ b/kontrol.toml
@@ -77,21 +77,25 @@ match-test                 = [
         "YSStrategyTest.testConversionSolventYS(uint256)",
         "YSStrategyTest.testConversionFallbackInsolventYS(uint256)",
         # ============================================
-        # YieldForwarder proofs (5)
+        # YieldForwarder proofs (7)
         # ============================================
         "YFTest.testReportAndForwardOnlyKeeper()",
         "YFTest.testReportAndForwardReceiverGuarantee()",
         "YFTest.testReportAndForwardNoResidualShares()",
         "YFTest.testReportAndForwardZeroSharesPassthrough()",
+        "YFTest.testReportAndForwardZeroMaxRedeemPassthrough()",
+        "YFTest.testReportAndForwardZeroAssetsPassthrough()",
         "YFTest.testReportAndForwardReturnsRedeemAssets()",
         # ============================================
-        # SwappingYieldForwarder proofs (7)
+        # SwappingYieldForwarder proofs (9)
         # ============================================
         "SYFTest.testReportSwapAndForwardOnlyKeeper()",
         "SYFTest.testReportSwapAndForwardReceiverGuarantee()",
         "SYFTest.testReportSwapAndForwardNoResidualSourceAsset()",
         "SYFTest.testReportSwapAndForwardZeroSharesPassthrough()",
         "SYFTest.testReportSwapAndForwardZeroRedeemPassthrough()",
+        "SYFTest.testReportSwapAndForwardZeroMaxRedeemPassthrough()",
+        "SYFTest.testReportSwapAndForwardZeroAssetsPassthrough()",
         "SYFTest.testReportSwapAndForwardCorrectTokenRouting()",
         "SYFTest.testInheritedReportAndForwardAccessControl()",
     ]

--- a/verification/kontrol/MockForwarderStrategy.k.sol
+++ b/verification/kontrol/MockForwarderStrategy.k.sol
@@ -19,6 +19,8 @@ pragma solidity ^0.8.0;
  *        slot 8: lastRedeemMaxLoss  -- captures maxLoss arg from redeem()
  *        slot 9: mockMaxRedeem      -- returned by maxRedeem()
  *        slot 10: mockConvertToAssets -- returned by convertToAssets()
+ *        slot 11: expectedMaxRedeemOwner -- required owner arg for maxRedeem()
+ *        slot 12: expectedConvertToAssetsShares -- required shares arg for convertToAssets()
  */
 contract MockForwarderStrategy {
     uint256 public mockShareBalance;
@@ -32,6 +34,8 @@ contract MockForwarderStrategy {
     uint256 public lastRedeemMaxLoss;
     uint256 public mockMaxRedeem;
     uint256 public mockConvertToAssets;
+    address public expectedMaxRedeemOwner;
+    uint256 public expectedConvertToAssetsShares;
 
     /// @notice No-op report that still records the caller
     function report() external returns (uint256, uint256) {
@@ -49,12 +53,14 @@ contract MockForwarderStrategy {
     }
 
     /// @notice Mock ERC-4626 maxRedeem guard used by SwappingYieldForwarder
-    function maxRedeem(address) external view returns (uint256) {
+    function maxRedeem(address owner) external view returns (uint256) {
+        require(owner == expectedMaxRedeemOwner);
         return mockMaxRedeem;
     }
 
     /// @notice Mock ERC-4626 convertToAssets guard used by SwappingYieldForwarder
-    function convertToAssets(uint256) external view returns (uint256) {
+    function convertToAssets(uint256 shares) external view returns (uint256) {
+        require(shares == expectedConvertToAssetsShares);
         return mockConvertToAssets;
     }
 

--- a/verification/kontrol/MockForwarderStrategy.k.sol
+++ b/verification/kontrol/MockForwarderStrategy.k.sol
@@ -58,13 +58,13 @@ contract MockForwarderStrategy {
         return mockConvertToAssets;
     }
 
-    /// @notice Mock redeem that captures arguments and zeroes share balance
+    /// @notice Mock redeem that captures arguments and burns the requested share amount
     function redeem(uint256 shares, address receiver, address owner, uint256 maxLoss) external returns (uint256) {
         lastRedeemShares = shares;
         lastRedeemReceiver = receiver;
         lastRedeemOwner = owner;
         lastRedeemMaxLoss = maxLoss;
-        mockShareBalance = 0;
+        mockShareBalance = mockShareBalance > shares ? mockShareBalance - shares : 0;
         return mockRedeemReturn;
     }
 

--- a/verification/kontrol/SYFSetup.k.sol
+++ b/verification/kontrol/SYFSetup.k.sol
@@ -63,14 +63,22 @@ contract SYFSetup is KontrolTest {
         _storeAddress(address(mockStrategy), MFS_ASSET_SLOT, address(sourceAsset));
         _storeAddress(address(mockStrategy), MFS_EXPECTED_BALANCE_OF_ACCOUNT_SLOT, address(syfForwarder));
 
-        // Set symbolic share balance and redeem return
+        // Set symbolic share balance, redeem return, and ERC-4626 guards
         uint256 shareBalance = freshUInt256Bounded();
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, shareBalance);
-        _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, shareBalance);
 
         uint256 redeemReturn = freshUInt256Bounded();
         _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, redeemReturn);
-        _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, redeemReturn);
+
+        uint256 maxRedeem = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, maxRedeem);
+
+        uint256 convertibleAssets = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, convertibleAssets);
+        _storeAddress(address(mockStrategy), MFS_EXPECTED_MAX_REDEEM_OWNER_SLOT, address(syfForwarder));
+
+        uint256 redeemShares = shareBalance < maxRedeem ? shareBalance : maxRedeem;
+        _storeUInt256(address(mockStrategy), MFS_EXPECTED_CONVERT_TO_ASSETS_SHARES_SLOT, redeemShares);
 
         // Clear argument capture slots
         _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);

--- a/verification/kontrol/SYFTest.k.sol
+++ b/verification/kontrol/SYFTest.k.sol
@@ -10,16 +10,32 @@ import "test/kontrol/SharedStateSlots.k.sol";
 /**
  * @title SYFTest
  * @notice Kontrol formal verification proofs for SwappingYieldForwarder
- * @dev Proves 7 behavioral properties of the SwappingYieldForwarder contract:
+ * @dev Proves 9 behavioral properties of the SwappingYieldForwarder contract:
  *      1. Access control on reportSwapAndForward
  *      2. Swap output routed to hardcoded receiver
  *      3. No residual source asset after swap
  *      4. Zero-share passthrough (no swap/redeem)
  *      5. Zero-redeem passthrough (no swap when redeem returns 0)
- *      6. Correct token routing through swapper
- *      7. Inherited reportAndForward access control still works
+ *      6. Zero-maxRedeem passthrough (no swap/redeem)
+ *      7. Zero-convertToAssets passthrough (no swap/redeem)
+ *      8. Correct token routing through swapper
+ *      9. Inherited reportAndForward access control still works
  */
 contract SYFTest is SYFSetup {
+    function _assumeSwapPath() internal view returns (uint256 shares, uint256 redeemReturn) {
+        shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+
+        uint256 maxRedeem = _loadUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT);
+        vm.assume(maxRedeem > 0);
+
+        uint256 convertibleAssets = _loadUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT);
+        vm.assume(convertibleAssets > 0);
+
+        redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
+        vm.assume(redeemReturn > 0);
+    }
+
     /// @notice Non-keeper address always reverts with OnlyKeeper on reportSwapAndForward
     function testReportSwapAndForwardOnlyKeeper() public {
         address nonKeeper = makeAddr("NON_KEEPER");
@@ -31,11 +47,8 @@ contract SYFTest is SYFSetup {
 
     /// @notice swap() is always called with the hardcoded receiver as output recipient
     function testReportSwapAndForwardReceiverGuarantee() public {
-        // Pre-conditions: shares exist and redeem returns non-zero
-        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
-        vm.assume(shares > 0);
-        uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
-        vm.assume(redeemReturn > 0);
+        // Pre-conditions: shares are redeemable, convert to assets, and redeem returns non-zero
+        _assumeSwapPath();
 
         vm.prank(_keeper);
         syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0, block.timestamp + 1 hours);
@@ -47,11 +60,8 @@ contract SYFTest is SYFSetup {
 
     /// @notice After reportSwapAndForward, forwarder holds 0 of source asset
     function testReportSwapAndForwardNoResidualSourceAsset() public {
-        // Pre-conditions: shares exist and redeem returns non-zero
-        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
-        vm.assume(shares > 0);
-        uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
-        vm.assume(redeemReturn > 0);
+        // Pre-conditions: shares are redeemable, convert to assets, and redeem returns non-zero
+        _assumeSwapPath();
 
         vm.prank(_keeper);
         syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0, block.timestamp + 1 hours);
@@ -98,6 +108,8 @@ contract SYFTest is SYFSetup {
         // Set shares > 0 but redeem return to 0
         uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
         vm.assume(shares > 0);
+        _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, shares);
+        _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, 1);
         _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, 0);
 
         // Also zero out the forwarder's pre-loaded ERC20 balance (matches 0 redeem)
@@ -114,15 +126,76 @@ contract SYFTest is SYFSetup {
         assertEq(lastSwapReceiver, address(0));
     }
 
-    /// @notice swap() is called with tokenIn = strategy.asset() and tokenOut = targetAsset
-    function testReportSwapAndForwardCorrectTokenRouting() public {
-        // Pre-conditions: shares exist and redeem returns non-zero
+    /// @notice When maxRedeem is 0, report still runs and neither redeem nor swap is called
+    function testReportSwapAndForwardZeroMaxRedeemPassthrough() public {
         uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
         vm.assume(shares > 0);
-        uint256 redeemReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
-        vm.assume(redeemReturn > 0);
+
+        _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, 0);
+        _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, 1);
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
+
+        uint256 sentinel = type(uint256).max;
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, sentinel);
+        _storeUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT, sentinel);
+
+        vm.prank(_keeper);
+        uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0, block.timestamp + 1 hours);
+
+        assertEq(assetsOut, 0);
+
+        address lastReportCaller = _loadAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT);
+        assertEq(lastReportCaller, address(syfForwarder));
+
+        uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastShares, sentinel);
+
+        uint256 lastAmountIn = _loadUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT);
+        assertEq(lastAmountIn, sentinel);
+
+        uint256 postShares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        assertEq(postShares, shares);
+    }
+
+    /// @notice When redeemable shares floor to 0 assets, report still runs without redeeming or swapping
+    function testReportSwapAndForwardZeroAssetsPassthrough() public {
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+
+        _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, shares);
+        _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, 0);
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
+
+        uint256 sentinel = type(uint256).max;
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, sentinel);
+        _storeUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT, sentinel);
+
+        vm.prank(_keeper);
+        uint256 assetsOut = syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0, block.timestamp + 1 hours);
+
+        assertEq(assetsOut, 0);
+
+        address lastReportCaller = _loadAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT);
+        assertEq(lastReportCaller, address(syfForwarder));
+
+        uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastShares, sentinel);
+
+        uint256 lastAmountIn = _loadUInt256(address(mockSwapper), MSWP_LAST_AMOUNT_IN_SLOT);
+        assertEq(lastAmountIn, sentinel);
+
+        uint256 postShares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        assertEq(postShares, shares);
+    }
+
+    /// @notice swap() is called with tokenIn = strategy.asset() and tokenOut = targetAsset
+    function testReportSwapAndForwardCorrectTokenRouting() public {
+        // Pre-conditions: shares are redeemable, convert to assets, and redeem returns non-zero
+        (, uint256 redeemReturn) = _assumeSwapPath();
         uint256 maxLoss = freshUInt256Bounded();
         uint256 minAmountOut = freshUInt256Bounded();
+        uint256 swapReturn = _loadUInt256(address(mockSwapper), MSWP_RETURN_SLOT);
+        vm.assume(swapReturn >= minAmountOut);
 
         vm.prank(_keeper);
         syfForwarder.reportSwapAndForward(address(mockStrategy), maxLoss, minAmountOut, block.timestamp + 1 hours);

--- a/verification/kontrol/SYFTest.k.sol
+++ b/verification/kontrol/SYFTest.k.sol
@@ -22,12 +22,13 @@ import "test/kontrol/SharedStateSlots.k.sol";
  *      9. Inherited reportAndForward access control still works
  */
 contract SYFTest is SYFSetup {
-    function _assumeSwapPath() internal view returns (uint256 shares, uint256 redeemReturn) {
-        shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
-        vm.assume(shares > 0);
+    function _assumeSwapPath() internal view returns (uint256 balance, uint256 redeemShares, uint256 redeemReturn) {
+        balance = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(balance > 0);
 
         uint256 maxRedeem = _loadUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT);
         vm.assume(maxRedeem > 0);
+        redeemShares = balance < maxRedeem ? balance : maxRedeem;
 
         uint256 convertibleAssets = _loadUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT);
         vm.assume(convertibleAssets > 0);
@@ -48,7 +49,7 @@ contract SYFTest is SYFSetup {
     /// @notice swap() is always called with the hardcoded receiver as output recipient
     function testReportSwapAndForwardReceiverGuarantee() public {
         // Pre-conditions: shares are redeemable, convert to assets, and redeem returns non-zero
-        _assumeSwapPath();
+        (, uint256 redeemShares, ) = _assumeSwapPath();
 
         vm.prank(_keeper);
         syfForwarder.reportSwapAndForward(address(mockStrategy), 0, 0, block.timestamp + 1 hours);
@@ -56,6 +57,9 @@ contract SYFTest is SYFSetup {
         // Assert: swap was called with receiver == forwarder.receiver()
         address lastReceiver = _loadAddress(address(mockSwapper), MSWP_LAST_RECEIVER_SLOT);
         assertEq(lastReceiver, _receiver);
+
+        uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastShares, redeemShares);
     }
 
     /// @notice After reportSwapAndForward, forwarder holds 0 of source asset
@@ -110,6 +114,7 @@ contract SYFTest is SYFSetup {
         vm.assume(shares > 0);
         _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, shares);
         _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, 1);
+        _storeUInt256(address(mockStrategy), MFS_EXPECTED_CONVERT_TO_ASSETS_SHARES_SLOT, shares);
         _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, 0);
 
         // Also zero out the forwarder's pre-loaded ERC20 balance (matches 0 redeem)
@@ -164,6 +169,7 @@ contract SYFTest is SYFSetup {
 
         _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, shares);
         _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, 0);
+        _storeUInt256(address(mockStrategy), MFS_EXPECTED_CONVERT_TO_ASSETS_SHARES_SLOT, shares);
         _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
 
         uint256 sentinel = type(uint256).max;
@@ -191,7 +197,7 @@ contract SYFTest is SYFSetup {
     /// @notice swap() is called with tokenIn = strategy.asset() and tokenOut = targetAsset
     function testReportSwapAndForwardCorrectTokenRouting() public {
         // Pre-conditions: shares are redeemable, convert to assets, and redeem returns non-zero
-        (, uint256 redeemReturn) = _assumeSwapPath();
+        (, uint256 redeemShares, uint256 redeemReturn) = _assumeSwapPath();
         uint256 maxLoss = freshUInt256Bounded();
         uint256 minAmountOut = freshUInt256Bounded();
         uint256 swapReturn = _loadUInt256(address(mockSwapper), MSWP_RETURN_SLOT);
@@ -225,6 +231,9 @@ contract SYFTest is SYFSetup {
 
         uint256 lastRedeemMaxLoss = _loadUInt256(address(mockStrategy), MFS_LAST_MAX_LOSS_SLOT);
         assertEq(lastRedeemMaxLoss, maxLoss);
+
+        uint256 lastRedeemShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastRedeemShares, redeemShares);
     }
 
     /// @notice Inherited reportAndForward() on SwappingYieldForwarder still enforces keeper check

--- a/verification/kontrol/SharedStateSlots.k.sol
+++ b/verification/kontrol/SharedStateSlots.k.sol
@@ -135,6 +135,8 @@ uint256 constant MFS_LAST_OWNER_SLOT = 7;
 uint256 constant MFS_LAST_MAX_LOSS_SLOT = 8;
 uint256 constant MFS_MAX_REDEEM_SLOT = 9;
 uint256 constant MFS_CONVERT_TO_ASSETS_SLOT = 10;
+uint256 constant MFS_EXPECTED_MAX_REDEEM_OWNER_SLOT = 11;
+uint256 constant MFS_EXPECTED_CONVERT_TO_ASSETS_SHARES_SLOT = 12;
 
 // ============================================
 // MockForwarderSwapper (MSWP_) constants

--- a/verification/kontrol/SharedStateSlots.k.sol
+++ b/verification/kontrol/SharedStateSlots.k.sol
@@ -72,10 +72,11 @@ uint256 constant TS_ENABLE_BURNING_WIDTH = 1;
 // ============================================
 // YieldSkimming-specific (YS_) constants
 // ============================================
-// Storage at keccak256("octant.yieldSkimming.exchangeRate") - 1
-// = 0x07fb4a10feb8168b5b4e83e7b226bebb72233fd2b17be5642e2b2896eed0348a
+// Storage at keccak256(abi.encode(uint256(keccak256("octant.yieldSkimming.exchangeRate")) - 1))
+// & ~bytes32(uint256(0xff))
+// = 0x66b3d9d1383d5ce25503fdc2e0f4d387777e50a9b5be65141986eec7395fef00
 
-uint256 constant YS_BASE = uint256(0x07fb4a10feb8168b5b4e83e7b226bebb72233fd2b17be5642e2b2896eed0348a);
+uint256 constant YS_BASE = uint256(0x66b3d9d1383d5ce25503fdc2e0f4d387777e50a9b5be65141986eec7395fef00);
 
 uint256 constant YS_TOTAL_DEBT_OWED_TO_USER_SLOT = YS_BASE + 0;
 uint256 constant YS_LAST_REPORTED_RATE_SLOT = YS_BASE + 1;

--- a/verification/kontrol/YFSetup.k.sol
+++ b/verification/kontrol/YFSetup.k.sol
@@ -43,12 +43,18 @@ contract YFSetup is KontrolTest {
         _storeAddress(address(mockStrategy), MFS_ASSET_SLOT, address(0xA55E7));
         _storeAddress(address(mockStrategy), MFS_EXPECTED_BALANCE_OF_ACCOUNT_SLOT, address(forwarder));
 
-        // Set symbolic share balance and redeem return
+        // Set symbolic share balance, redeem return, and ERC-4626 guards
         uint256 shareBalance = freshUInt256Bounded();
         _storeUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT, shareBalance);
 
         uint256 redeemReturn = freshUInt256Bounded();
         _storeUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT, redeemReturn);
+
+        uint256 maxRedeem = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, maxRedeem);
+
+        uint256 convertibleAssets = freshUInt256Bounded();
+        _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, convertibleAssets);
 
         // Clear argument capture slots (so we can detect if redeem was called)
         _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);

--- a/verification/kontrol/YFSetup.k.sol
+++ b/verification/kontrol/YFSetup.k.sol
@@ -55,6 +55,10 @@ contract YFSetup is KontrolTest {
 
         uint256 convertibleAssets = freshUInt256Bounded();
         _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, convertibleAssets);
+        _storeAddress(address(mockStrategy), MFS_EXPECTED_MAX_REDEEM_OWNER_SLOT, address(forwarder));
+
+        uint256 redeemShares = shareBalance < maxRedeem ? shareBalance : maxRedeem;
+        _storeUInt256(address(mockStrategy), MFS_EXPECTED_CONVERT_TO_ASSETS_SHARES_SLOT, redeemShares);
 
         // Clear argument capture slots (so we can detect if redeem was called)
         _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, 0);

--- a/verification/kontrol/YFTest.k.sol
+++ b/verification/kontrol/YFTest.k.sol
@@ -146,6 +146,7 @@ contract YFTest is YFSetup {
 
         _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, shares);
         _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, 0);
+        _storeUInt256(address(mockStrategy), MFS_EXPECTED_CONVERT_TO_ASSETS_SHARES_SLOT, shares);
         _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
 
         uint256 sentinel = type(uint256).max;

--- a/verification/kontrol/YFTest.k.sol
+++ b/verification/kontrol/YFTest.k.sol
@@ -9,14 +9,36 @@ import "test/kontrol/SharedStateSlots.k.sol";
 /**
  * @title YFTest
  * @notice Kontrol formal verification proofs for YieldForwarder
- * @dev Proves 5 behavioral properties of the YieldForwarder contract:
+ * @dev Proves 7 behavioral properties of the YieldForwarder contract:
  *      1. Access control: only keeper can call reportAndForward
  *      2. Receiver guarantee: redeem always targets the hardcoded receiver
- *      3. No residual shares: forwarder holds 0 shares after execution
+ *      3. No residual shares when the full balance is redeemable
  *      4. Zero-share passthrough: returns 0 without calling redeem when no shares
- *      5. Return value correctness: return matches mock redeem output
+ *      5. Zero-maxRedeem passthrough: returns 0 without calling redeem
+ *      6. Zero-convertToAssets passthrough: returns 0 without calling redeem
+ *      7. Return value correctness: return matches mock redeem output
  */
 contract YFTest is YFSetup {
+    function _assumeRedeemPath() internal view returns (uint256 balance, uint256 maxRedeem, uint256 redeemShares) {
+        balance = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(balance > 0);
+
+        maxRedeem = _loadUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT);
+        vm.assume(maxRedeem > 0);
+
+        redeemShares = balance < maxRedeem ? balance : maxRedeem;
+
+        uint256 convertibleAssets = _loadUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT);
+        vm.assume(convertibleAssets > 0);
+    }
+
+    function _assumeFullRedeemPath() internal view returns (uint256 balance) {
+        (balance, , ) = _assumeRedeemPath();
+
+        uint256 maxRedeem = _loadUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT);
+        vm.assume(maxRedeem >= balance);
+    }
+
     /// @notice Non-keeper address always reverts with OnlyKeeper
     function testReportAndForwardOnlyKeeper() public {
         address nonKeeper = makeAddr("NON_KEEPER");
@@ -28,9 +50,8 @@ contract YFTest is YFSetup {
 
     /// @notice redeem() is always called with the hardcoded receiver as recipient
     function testReportAndForwardReceiverGuarantee() public {
-        // Pre-condition: shares exist to trigger the redeem path
-        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
-        vm.assume(shares > 0);
+        // Pre-condition: shares are redeemable and convert to non-zero assets
+        (, , uint256 redeemShares) = _assumeRedeemPath();
         uint256 maxLoss = freshUInt256Bounded();
 
         vm.prank(_keeper);
@@ -45,13 +66,15 @@ contract YFTest is YFSetup {
 
         uint256 lastMaxLoss = _loadUInt256(address(mockStrategy), MFS_LAST_MAX_LOSS_SLOT);
         assertEq(lastMaxLoss, maxLoss);
+
+        uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastShares, redeemShares);
     }
 
-    /// @notice After reportAndForward, forwarder holds 0 shares on the strategy
+    /// @notice After reportAndForward, forwarder holds 0 shares when the full balance is redeemable
     function testReportAndForwardNoResidualShares() public {
-        // Pre-condition: shares exist
-        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
-        vm.assume(shares > 0);
+        // Pre-condition: shares exist and all are redeemable
+        _assumeFullRedeemPath();
 
         vm.prank(_keeper);
         forwarder.reportAndForward(address(mockStrategy), 0);
@@ -89,11 +112,64 @@ contract YFTest is YFSetup {
         assertEq(lastShares, sentinel);
     }
 
-    /// @notice Return value of reportAndForward equals the value returned by redeem
-    function testReportAndForwardReturnsRedeemAssets() public {
-        // Pre-condition: shares exist
+    /// @notice When maxRedeem is 0, report still runs and redeem is never called
+    function testReportAndForwardZeroMaxRedeemPassthrough() public {
         uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
         vm.assume(shares > 0);
+
+        _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, 0);
+        _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, 1);
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
+
+        uint256 sentinel = type(uint256).max;
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, sentinel);
+
+        vm.prank(_keeper);
+        uint256 assets = forwarder.reportAndForward(address(mockStrategy), 0);
+
+        assertEq(assets, 0);
+
+        address lastReportCaller = _loadAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT);
+        assertEq(lastReportCaller, address(forwarder));
+
+        uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastShares, sentinel);
+
+        uint256 postShares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        assertEq(postShares, shares);
+    }
+
+    /// @notice When redeemable shares floor to 0 assets, report still runs and redeem is never called
+    function testReportAndForwardZeroAssetsPassthrough() public {
+        uint256 shares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        vm.assume(shares > 0);
+
+        _storeUInt256(address(mockStrategy), MFS_MAX_REDEEM_SLOT, shares);
+        _storeUInt256(address(mockStrategy), MFS_CONVERT_TO_ASSETS_SLOT, 0);
+        _storeAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT, address(0));
+
+        uint256 sentinel = type(uint256).max;
+        _storeUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT, sentinel);
+
+        vm.prank(_keeper);
+        uint256 assets = forwarder.reportAndForward(address(mockStrategy), 0);
+
+        assertEq(assets, 0);
+
+        address lastReportCaller = _loadAddress(address(mockStrategy), MFS_LAST_REPORT_CALLER_SLOT);
+        assertEq(lastReportCaller, address(forwarder));
+
+        uint256 lastShares = _loadUInt256(address(mockStrategy), MFS_LAST_SHARES_SLOT);
+        assertEq(lastShares, sentinel);
+
+        uint256 postShares = _loadUInt256(address(mockStrategy), MFS_SHARE_BALANCE_SLOT);
+        assertEq(postShares, shares);
+    }
+
+    /// @notice Return value of reportAndForward equals the value returned by redeem
+    function testReportAndForwardReturnsRedeemAssets() public {
+        // Pre-condition: shares are redeemable and convert to non-zero assets
+        _assumeRedeemPath();
 
         uint256 expectedReturn = _loadUInt256(address(mockStrategy), MFS_REDEEM_RETURN_SLOT);
 


### PR DESCRIPTION
## Summary
- update YieldForwarder Kontrol setup to model maxRedeem and convertToAssets guards explicitly
- constrain forwarder success-path proofs to reachable redeem/swap paths
- add maxRedeem=0 and zero-convertToAssets early-return proofs for YF/SYF
- constrain SYF token-routing proof so mock swap output satisfies minAmountOut