### PR TITLE
fix(tokenized-strategy): bailsec #8 emit emergency withdraw event

### DIFF
--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -84,6 +84,13 @@ abstract contract TokenizedStrategy {
     event StrategyShutdown();
 
     /**
+     * @notice Emitted when an emergency withdrawal is processed after shutdown.
+     * @param caller Address that initiated the emergency withdrawal
+     * @param requestedAssets Amount of assets requested to be withdrawn
+     */
+    event EmergencyWithdraw(address indexed caller, uint256 requestedAssets);
+
+    /**
      * @notice Emitted on the initialization of any new `strategy` that uses `asset`
      * with this specific `apiVersion`.
      */
@@ -1242,6 +1249,8 @@ abstract contract TokenizedStrategy {
 
         // Withdraw from the yield source.
         IBaseStrategy(address(this)).shutdownWithdraw(amount);
+
+        emit EmergencyWithdraw(msg.sender, amount);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -466,7 +466,7 @@ abstract contract TokenizedStrategy {
 
     /// @notice API version identifier for this TokenizedStrategy implementation
     /// @dev Used for tracking strategy versions and compatibility
-    string internal constant API_VERSION = "1.0.0";
+    string internal constant API_VERSION = "1.1.0";
 
     /// @notice Reentrancy guard flag value during function execution
     /// @dev Set to 2 when a protected function is executing

--- a/src/core/interfaces/ITokenizedStrategy.sol
+++ b/src/core/interfaces/ITokenizedStrategy.sol
@@ -22,6 +22,13 @@ interface ITokenizedStrategy is IERC4626, IERC20Permit {
     event StrategyShutdown();
 
     /**
+     * @notice Emitted when an emergency withdrawal is processed after shutdown.
+     * @param caller Address that initiated the emergency withdrawal
+     * @param requestedAssets Amount of assets requested to be withdrawn
+     */
+    event EmergencyWithdraw(address indexed caller, uint256 requestedAssets);
+
+    /**
      * @notice Emitted on the initialization of any new `strategy` that uses `asset`
      * with this specific `apiVersion`.
      */

--- a/src/interfaces/IEvents.sol
+++ b/src/interfaces/IEvents.sol
@@ -18,6 +18,13 @@ interface IEvents {
     event StrategyShutdown();
 
     /**
+     * @notice Emitted when an emergency withdrawal is processed after shutdown
+     * @param caller Address that initiated the emergency withdrawal
+     * @param requestedAssets Amount of assets requested to be withdrawn
+     */
+    event EmergencyWithdraw(address indexed caller, uint256 requestedAssets);
+
+    /**
      * @notice Emitted on the initialization of any new strategy
      * @param strategy Address of the newly initialized strategy
      * @param asset Address of the underlying asset

--- a/test/integration/factories/YieldDonatingTokenizedStrategy.t.sol
+++ b/test/integration/factories/YieldDonatingTokenizedStrategy.t.sol
@@ -88,7 +88,7 @@ contract YieldDonatingTokenizedStrategyTest is Test {
     function testInheritedFunctions() public view {
         // Test accessing the API version
         string memory apiVersion = strategy.apiVersion();
-        assertEq(apiVersion, "1.0.0", "API version should match parent contract");
+        assertEq(apiVersion, "1.1.0", "API version should match parent contract");
     }
 
     /**

--- a/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
+++ b/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
@@ -7,6 +7,7 @@ import { MockYieldSource } from "test/mocks/core/MockYieldSource.sol";
 import { MockStrategy as MockBaseStrategy } from "test/mocks/core/MockBaseStrategy.sol";
 import { MockIlliquidStrategy } from "test/mocks/core/tokenized-strategies/MockIlliquidStrategy.sol";
 import { MockTokenizedStrategyWithLoss } from "test/mocks/core/MockTokenizedStrategyWithLoss.sol";
+import { TokenizedStrategy } from "src/core/TokenizedStrategy.sol";
 import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
 import { TokenizedStrategy__InvalidSigner } from "src/errors.sol";
@@ -212,7 +213,10 @@ contract TokenizedStrategyBranchCoverageTest is Test {
 
     function test_emergencyWithdraw_afterShutdown_succeeds() public {
         ITokenizedStrategy(address(strategy)).shutdownStrategy();
-        // Should not revert
+
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit TokenizedStrategy.EmergencyWithdraw(address(this), 0);
+
         ITokenizedStrategy(address(strategy)).emergencyWithdraw(0);
     }
 
@@ -1167,10 +1171,15 @@ contract TokenizedStrategyBranchCoverageTest is Test {
     // --- emergencyAdmin can emergency withdraw ---
 
     function test_emergencyWithdraw_byEmergencyAdmin() public {
-        ITokenizedStrategy(address(strategy)).setEmergencyAdmin(address(0x55));
+        address newEmergencyAdmin = address(0x55);
+
+        ITokenizedStrategy(address(strategy)).setEmergencyAdmin(newEmergencyAdmin);
         ITokenizedStrategy(address(strategy)).shutdownStrategy();
 
-        vm.prank(address(0x55));
+        vm.expectEmit(true, false, false, true, address(strategy));
+        emit TokenizedStrategy.EmergencyWithdraw(newEmergencyAdmin, 0);
+
+        vm.prank(newEmergencyAdmin);
         ITokenizedStrategy(address(strategy)).emergencyWithdraw(0);
     }
 

--- a/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
+++ b/test/unit/core/tokenizedStrategy/BranchCoverage.t.sol
@@ -71,7 +71,7 @@ contract TokenizedStrategyBranchCoverageTest is Test {
         bytes32 PERMIT_TYPEHASH = keccak256(
             "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
         );
-        bytes32 VERSION_HASH = keccak256(bytes("1.0.0"));
+        bytes32 VERSION_HASH = keccak256(bytes("1.1.0"));
         bytes32 nameHash = keccak256(bytes(ITokenizedStrategy(address(strategy)).name()));
         bytes32 domainSeparator = keccak256(
             abi.encode(EIP712DOMAIN_TYPEHASH, nameHash, VERSION_HASH, block.chainid, address(strategy))
@@ -593,9 +593,9 @@ contract TokenizedStrategyBranchCoverageTest is Test {
 
     // --- API version ---
 
-    function test_apiVersion_returns100() public view {
+    function test_apiVersion_returns110() public view {
         string memory version = ITokenizedStrategy(address(strategy)).apiVersion();
-        assertEq(keccak256(bytes(version)), keccak256(bytes("1.0.0")));
+        assertEq(keccak256(bytes(version)), keccak256(bytes("1.1.0")));
     }
 
     // --- getter functions ---

--- a/test/unit/core/tokenizedStrategy/Permit.t.sol
+++ b/test/unit/core/tokenizedStrategy/Permit.t.sol
@@ -22,7 +22,7 @@ contract TokenizedStrategyPermitTest is Test {
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     bytes32 constant PERMIT_TYPEHASH =
         keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
-    bytes32 constant VERSION_HASH = keccak256(bytes("1.0.0"));
+    bytes32 constant VERSION_HASH = keccak256(bytes("1.1.0"));
 
     function setUp() public {
         ownerPk = uint256(keccak256(abi.encodePacked("TokenizedStrategyPermitTest owner")));


### PR DESCRIPTION
## Summary

- add `EmergencyWithdraw(address indexed caller, uint256 requestedAssets)` to `TokenizedStrategy`, `ITokenizedStrategy`, and `IEvents`
- emit the event after `shutdownWithdraw(amount)` succeeds in `emergencyWithdraw`
- cover management and emergency-admin event emission paths in TokenizedStrategy tests
- bump `API_VERSION` from `1.0.0` to `1.1.0` to satisfy the contract semver check (ABI-additive change). The EIP-712 permit domain version follows `API_VERSION`, so previously issued permit signatures must be reissued against the new domain separator.

## Note
Replaces #423 which was opened from a fork; this branch lives in the upstream repo so private-container CI can run.