### PR TITLE
OCT3-234: DirectTransfer contract - generic ERC20 passthrough with logged events

### DIFF
--- a/script/deployment/staging/DeployDirectTransfer.s.sol
+++ b/script/deployment/staging/DeployDirectTransfer.s.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import "forge-std/Script.sol";
+import { console2 } from "forge-std/console2.sol";
+
+import { DirectTransfer } from "src/core/DirectTransfer.sol";
+
+/**
+ * @title DeployDirectTransfer
+ * @notice Staging deployment script for the DirectTransfer logging contract.
+ * @dev DirectTransfer is stateless and has no constructor arguments — one deployment
+ *      per chain serves every supported ERC20. The script always deploys a fresh
+ *      instance; the printed BLOCK_NUMBER is therefore the contract's actual
+ *      deployment block, safe to use as the subgraph startBlock.
+ *
+ *      Required env: PRIVATE_KEY
+ */
+contract DeployDirectTransfer is Script {
+    /// @notice The deployed DirectTransfer instance
+    DirectTransfer public directTransfer;
+
+    error DeploymentFailed();
+
+    function run() public {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        vm.startBroadcast(deployerPrivateKey);
+        directTransfer = new DirectTransfer();
+        vm.stopBroadcast();
+
+        address directTransferAddress = address(directTransfer);
+        if (directTransferAddress == address(0)) revert DeploymentFailed();
+
+        console2.log("\nDirectTransfer Deployment");
+        console2.log("------------------");
+        console2.log("BLOCK_NUMBER=", vm.toString(block.number));
+        console2.log("DIRECT_TRANSFER_ADDRESS=", vm.toString(directTransferAddress));
+        console2.log("------------------");
+        console2.log("Copy the two values above into octant-v2-subgraph/subgraphs/regen/networks.json");
+        console2.log("under the DirectTransfer entry (address + startBlock).");
+    }
+}

--- a/src/core/DirectTransfer.sol
+++ b/src/core/DirectTransfer.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { SafeERC20 } from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+/**
+ * @title DirectTransfer
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice Dedicated passthrough contract for logged ERC20 transfers between two addresses
+ * @dev Caller must first approve this contract to spend the relevant token. The contract
+ *      pulls the token from the caller via `safeTransferFrom` and pushes it to the
+ *      recipient in the same call, emitting a single event per transfer. Stateless and
+ *      token-agnostic — one deployment per chain serves every supported ERC20.
+ *
+ *      Block number, timestamp, and transaction hash are intentionally omitted from the
+ *      event payload. Every indexer attaches them to each log automatically, so emitting
+ *      them on-chain would only duplicate data and waste gas.
+ *
+ *      Intended for standard ERC20s only (e.g. WETH). Fee-on-transfer, deflationary, and
+ *      rebasing tokens are out of scope: the emitted `amount` equals the requested amount,
+ *      not the recipient's balance delta, so events would not reflect the value actually
+ *      received by `to` for such tokens.
+ */
+contract DirectTransfer {
+    using SafeERC20 for IERC20;
+
+    /// @notice Emitted on every successful transfer routed through this contract
+    /// @param token ERC20 token transferred
+    /// @param from Address sending the token (token spender, equal to msg.sender)
+    /// @param to Address receiving the token
+    /// @param amount Amount of the token transferred, in the token's smallest unit
+    event Transferred(address indexed token, address indexed from, address indexed to, uint256 amount);
+
+    /// @notice Thrown when the token address is the zero address
+    error ZeroToken();
+
+    /// @notice Thrown when the recipient address is the zero address
+    error ZeroRecipient();
+
+    /// @notice Thrown when the transfer amount is zero
+    error ZeroAmount();
+
+    /// @notice Transfer ERC20 tokens from the caller to `to` and emit a `Transferred` event
+    /// @dev Caller must have approved at least `amount` of `token` to this contract.
+    ///      Reverts if the token or recipient is the zero address or the amount is zero.
+    /// @param token ERC20 token to transfer
+    /// @param to Address receiving the token
+    /// @param amount Amount of the token to transfer, in the token's smallest unit
+    function transfer(IERC20 token, address to, uint256 amount) external {
+        if (address(token) == address(0)) revert ZeroToken();
+        if (to == address(0)) revert ZeroRecipient();
+        if (amount == 0) revert ZeroAmount();
+
+        token.safeTransferFrom(msg.sender, to, amount);
+
+        emit Transferred(address(token), msg.sender, to, amount);
+    }
+}

--- a/test/unit/core/DirectTransfer.t.sol
+++ b/test/unit/core/DirectTransfer.t.sol
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { DirectTransfer } from "src/core/DirectTransfer.sol";
+import { MockERC20 } from "test/mocks/MockERC20.sol";
+
+contract DirectTransferTest is Test {
+    DirectTransfer internal directTransfer;
+    MockERC20 internal token;
+    MockERC20 internal otherToken;
+
+    address internal alice = address(0xA11CE);
+    address internal project = address(0xB0B);
+
+    uint256 internal constant START_BALANCE = 1_000 ether;
+
+    event Transferred(address indexed token, address indexed from, address indexed to, uint256 amount);
+
+    function setUp() public {
+        directTransfer = new DirectTransfer();
+        token = new MockERC20(18);
+        otherToken = new MockERC20(6);
+
+        token.mint(alice, START_BALANCE);
+        otherToken.mint(alice, START_BALANCE);
+    }
+
+    function test_transfer_movesTokensAndEmitsEvent() public {
+        uint256 amount = 5 ether;
+
+        vm.prank(alice);
+        token.approve(address(directTransfer), amount);
+
+        vm.expectEmit(true, true, true, true, address(directTransfer));
+        emit Transferred(address(token), alice, project, amount);
+
+        vm.prank(alice);
+        directTransfer.transfer(IERC20(address(token)), project, amount);
+
+        assertEq(token.balanceOf(alice), START_BALANCE - amount, "sender balance");
+        assertEq(token.balanceOf(project), amount, "recipient balance");
+        assertEq(token.balanceOf(address(directTransfer)), 0, "contract holds nothing");
+    }
+
+    function test_transfer_worksAcrossDifferentTokens() public {
+        uint256 amountA = 3 ether;
+        uint256 amountB = 250e6;
+
+        vm.startPrank(alice);
+        token.approve(address(directTransfer), amountA);
+        otherToken.approve(address(directTransfer), amountB);
+        directTransfer.transfer(IERC20(address(token)), project, amountA);
+        directTransfer.transfer(IERC20(address(otherToken)), project, amountB);
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(project), amountA, "token A received");
+        assertEq(otherToken.balanceOf(project), amountB, "token B received");
+    }
+
+    function test_transfer_revertsOnZeroToken() public {
+        vm.prank(alice);
+        vm.expectRevert(DirectTransfer.ZeroToken.selector);
+        directTransfer.transfer(IERC20(address(0)), project, 1);
+    }
+
+    function test_transfer_revertsOnZeroRecipient() public {
+        vm.prank(alice);
+        vm.expectRevert(DirectTransfer.ZeroRecipient.selector);
+        directTransfer.transfer(IERC20(address(token)), address(0), 1);
+    }
+
+    function test_transfer_revertsOnZeroAmount() public {
+        vm.prank(alice);
+        vm.expectRevert(DirectTransfer.ZeroAmount.selector);
+        directTransfer.transfer(IERC20(address(token)), project, 0);
+    }
+
+    function test_transfer_revertsWithoutApproval() public {
+        vm.prank(alice);
+        vm.expectRevert();
+        directTransfer.transfer(IERC20(address(token)), project, 1 ether);
+    }
+
+    function test_transfer_revertsOnInsufficientBalance() public {
+        uint256 amount = START_BALANCE + 1;
+
+        vm.prank(alice);
+        token.approve(address(directTransfer), amount);
+
+        vm.prank(alice);
+        vm.expectRevert();
+        directTransfer.transfer(IERC20(address(token)), project, amount);
+    }
+
+    function testFuzz_transfer_emitsEventWithExactValues(uint256 amount) public {
+        amount = bound(amount, 1, START_BALANCE);
+
+        vm.prank(alice);
+        token.approve(address(directTransfer), amount);
+
+        vm.expectEmit(true, true, true, true, address(directTransfer));
+        emit Transferred(address(token), alice, project, amount);
+
+        vm.prank(alice);
+        directTransfer.transfer(IERC20(address(token)), project, amount);
+
+        assertEq(token.balanceOf(project), amount);
+    }
+}


### PR DESCRIPTION
## Summary

- New stateless `DirectTransfer` contract: pulls an ERC20 from `msg.sender` via `safeTransferFrom` and forwards it to the recipient, emitting a single `Transferred(token, from, to, amount)` event per call. Token-agnostic — one deployment per chain.
- Reverts on zero token, zero recipient, or zero amount.
- Adds staging deployment script and unit tests.

Linear: [OCT3-234](https://linear.app/golemfoundation/issue/OCT3-234) (sub-issue of OCT3-47)

## Test plan

- [ ] `forge test --match-path test/unit/core/DirectTransfer.t.sol`
- [ ] `yarn lint && yarn format:check`
- [ ] Dry-run staging deployment script