### PR TITLE
docs(erc4626): warn against fee-charging target vaults

### DIFF
--- a/src/strategies/yieldDonating/ERC4626Strategy.sol
+++ b/src/strategies/yieldDonating/ERC4626Strategy.sol
@@ -172,8 +172,8 @@ contract ERC4626Strategy is BaseHealthCheck {
     function _harvestAndReport() internal view override returns (uint256 _totalAssets) {
         // get strategy's balance in the vault (shares)
         uint256 shares = IERC4626(targetVault).balanceOf(address(this));
-        // EIP-4626 requires previewRedeem to reflect any exit-fee policy the target vault enforces;
-        // convertToAssets returns the gross value and would overstate totalAssets for fee-charging vaults.
+        // Fee-charging target vaults are not supported. previewRedeem is used as a defensive read
+        // so post-fee value would still be tracked correctly if one were encountered.
         uint256 vaultAssets = IERC4626(targetVault).previewRedeem(shares);
 
         uint256 idleAssets = IERC20(asset).balanceOf(address(this));

--- a/src/strategies/yieldDonating/ERC4626Strategy.sol
+++ b/src/strategies/yieldDonating/ERC4626Strategy.sol
@@ -41,8 +41,14 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
  *      strategy is deployed against it. Do not treat ERC-4626 conformance as a
  *      blanket security guarantee.
  *
+ *      FEE-CHARGING TARGET VAULTS — NOT SUPPORTED:
+ *      Do NOT deploy against a target ERC-4626 vault that charges a withdrawal
+ *      or exit fee. Deposit accounting credits the full pre-fee amount; new
+ *      depositors can exit before the next `report()` and drain existing users.
+ *
  * @custom:security ERC4626 vault convertToAssets must be manipulation-resistant
  * @custom:security Target vault must be audited individually before deployment
+ * @custom:security Target vault must NOT charge withdrawal/exit fees
  */
 contract ERC4626Strategy is BaseHealthCheck {
     using SafeERC20 for IERC20;

--- a/src/strategies/yieldDonating/ERC4626Strategy.sol
+++ b/src/strategies/yieldDonating/ERC4626Strategy.sol
@@ -42,13 +42,14 @@ import { IERC4626 } from "@openzeppelin/contracts/interfaces/IERC4626.sol";
  *      blanket security guarantee.
  *
  *      FEE-CHARGING TARGET VAULTS — NOT SUPPORTED:
- *      Do NOT deploy against a target ERC-4626 vault that charges a withdrawal
- *      or exit fee. Deposit accounting credits the full pre-fee amount; new
- *      depositors can exit before the next `report()` and drain existing users.
+ *      Do NOT deploy against a target ERC-4626 vault that charges an
+ *      entry/deposit or withdrawal/exit fee. Deposit accounting credits the
+ *      full pre-fee amount; new depositors can exit before the next `report()`
+ *      and drain existing users.
  *
  * @custom:security ERC4626 vault convertToAssets must be manipulation-resistant
  * @custom:security Target vault must be audited individually before deployment
- * @custom:security Target vault must NOT charge withdrawal/exit fees
+ * @custom:security Target vault must NOT charge entry/deposit or withdrawal/exit fees
  */
 contract ERC4626Strategy is BaseHealthCheck {
     using SafeERC20 for IERC20;
@@ -172,8 +173,8 @@ contract ERC4626Strategy is BaseHealthCheck {
     function _harvestAndReport() internal view override returns (uint256 _totalAssets) {
         // get strategy's balance in the vault (shares)
         uint256 shares = IERC4626(targetVault).balanceOf(address(this));
-        // Fee-charging target vaults are not supported. previewRedeem is used as a defensive read
-        // so post-fee value would still be tracked correctly if one were encountered.
+        // EIP-4626 requires previewRedeem to reflect any exit-fee policy the target vault enforces;
+        // convertToAssets returns the gross value and would overstate totalAssets for fee-charging vaults.
         uint256 vaultAssets = IERC4626(targetVault).previewRedeem(shares);
 
         uint256 idleAssets = IERC20(asset).balanceOf(address(this));

--- a/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
+++ b/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
@@ -30,12 +30,12 @@ import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
  *      - MultistrategyVault enforces actual loss limits via updateDebt
  *
  *      FEE-CHARGING TARGET VAULTS — NOT SUPPORTED:
- *      Do NOT deploy against a Morpho vault that charges a withdrawal or exit fee.
- *      Deposit accounting credits the full pre-fee amount; new depositors can exit
- *      before the next `report()` and drain existing users.
+ *      Do NOT deploy against a Morpho vault that charges an entry/deposit or
+ *      withdrawal/exit fee. Deposit accounting credits the full pre-fee amount;
+ *      new depositors can exit before the next `report()` and drain existing users.
  *
  * @custom:security Morpho vault convertToAssets must be manipulation-resistant
- * @custom:security Morpho vault must NOT charge withdrawal/exit fees
+ * @custom:security Morpho vault must NOT charge entry/deposit or withdrawal/exit fees
  */
 contract MorphoCompounderStrategy is BaseHealthCheck {
     using SafeERC20 for IERC20;
@@ -169,8 +169,8 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
     function _harvestAndReport() internal view override returns (uint256 _totalAssets) {
         // Get strategy's share balance in the compounder vault
         uint256 shares = ITokenizedStrategy(compounderVault).balanceOf(address(this));
-        // Fee-charging target vaults are not supported. previewRedeem is used as a defensive read
-        // so post-fee value would still be tracked correctly if one were encountered.
+        // EIP-4626 requires previewRedeem to reflect any exit-fee policy the target vault enforces;
+        // convertToAssets returns the gross value and would overstate totalAssets for fee-charging vaults.
         uint256 vaultAssets = ITokenizedStrategy(compounderVault).previewRedeem(shares);
 
         // Include idle funds as per BaseStrategy specification

--- a/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
+++ b/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
@@ -163,8 +163,8 @@ contract MorphoCompounderStrategy is BaseHealthCheck {
     function _harvestAndReport() internal view override returns (uint256 _totalAssets) {
         // Get strategy's share balance in the compounder vault
         uint256 shares = ITokenizedStrategy(compounderVault).balanceOf(address(this));
-        // EIP-4626 requires previewRedeem to reflect any exit-fee policy the target vault enforces;
-        // convertToAssets returns the gross value and would overstate totalAssets for fee-charging vaults.
+        // Fee-charging target vaults are not supported. previewRedeem is used as a defensive read
+        // so post-fee value would still be tracked correctly if one were encountered.
         uint256 vaultAssets = ITokenizedStrategy(compounderVault).previewRedeem(shares);
 
         // Include idle funds as per BaseStrategy specification

--- a/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
+++ b/src/strategies/yieldDonating/MorphoCompounderStrategy.sol
@@ -29,7 +29,13 @@ import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
  *      - Accepts 100% loss on withdrawals to prevent revert cascades
  *      - MultistrategyVault enforces actual loss limits via updateDebt
  *
+ *      FEE-CHARGING TARGET VAULTS — NOT SUPPORTED:
+ *      Do NOT deploy against a Morpho vault that charges a withdrawal or exit fee.
+ *      Deposit accounting credits the full pre-fee amount; new depositors can exit
+ *      before the next `report()` and drain existing users.
+ *
  * @custom:security Morpho vault convertToAssets must be manipulation-resistant
+ * @custom:security Morpho vault must NOT charge withdrawal/exit fees
  */
 contract MorphoCompounderStrategy is BaseHealthCheck {
     using SafeERC20 for IERC20;

--- a/src/strategies/yieldDonating/SparkStrategy.sol
+++ b/src/strategies/yieldDonating/SparkStrategy.sol
@@ -20,7 +20,14 @@ import { IERC20 } from "@openzeppelin/contracts/interfaces/IERC20.sol";
  *      - Swept tokens are sent to the dragon router (donation address)
  *      - Callable by both keepers and management for operational flexibility
  *
+ *      FEE-CHARGING TARGET VAULTS — NOT SUPPORTED:
+ *      Inherits ERC4626Strategy's accounting and the same hazard. Do NOT deploy
+ *      against a Spark vault that charges an entry/deposit or withdrawal/exit
+ *      fee. Deposit accounting credits the full pre-fee amount; new depositors
+ *      can exit before the next `report()` and drain existing users.
+ *
  * @custom:security Only sweep tokens that are not critical to strategy operation
+ * @custom:security Target Spark vault must NOT charge entry/deposit or withdrawal/exit fees
  */
 contract SparkStrategy is ERC4626Strategy {
     using SafeERC20 for IERC20;

--- a/src/strategies/yieldDonating/YearnV3Strategy.sol
+++ b/src/strategies/yieldDonating/YearnV3Strategy.sol
@@ -166,8 +166,8 @@ contract YearnV3Strategy is BaseHealthCheck {
     function _harvestAndReport() internal view override returns (uint256 _totalAssets) {
         // get strategy's balance in the vault
         uint256 shares = ITokenizedStrategy(yearnVault).balanceOf(address(this));
-        // EIP-4626 requires previewRedeem to reflect any exit-fee policy the target vault enforces;
-        // convertToAssets returns the gross value and would overstate totalAssets for fee-charging vaults.
+        // Fee-charging target vaults are not supported. previewRedeem is used as a defensive read
+        // so post-fee value would still be tracked correctly if one were encountered.
         uint256 vaultAssets = ITokenizedStrategy(yearnVault).previewRedeem(shares);
 
         uint256 idleAssets = IERC20(asset).balanceOf(address(this));

--- a/src/strategies/yieldDonating/YearnV3Strategy.sol
+++ b/src/strategies/yieldDonating/YearnV3Strategy.sol
@@ -29,12 +29,12 @@ import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
  *      - MultistrategyVault performs actual loss validation via updateDebt
  *
  *      FEE-CHARGING TARGET VAULTS — NOT SUPPORTED:
- *      Do NOT deploy against a Yearn vault that charges a withdrawal or exit fee.
- *      Deposit accounting credits the full pre-fee amount; new depositors can exit
- *      before the next `report()` and drain existing users.
+ *      Do NOT deploy against a Yearn vault that charges an entry/deposit or
+ *      withdrawal/exit fee. Deposit accounting credits the full pre-fee amount;
+ *      new depositors can exit before the next `report()` and drain existing users.
  *
  * @custom:security Yearn vault convertToAssets must be manipulation-resistant
- * @custom:security Yearn vault must NOT charge withdrawal/exit fees
+ * @custom:security Yearn vault must NOT charge entry/deposit or withdrawal/exit fees
  */
 contract YearnV3Strategy is BaseHealthCheck {
     using SafeERC20 for IERC20;
@@ -172,8 +172,8 @@ contract YearnV3Strategy is BaseHealthCheck {
     function _harvestAndReport() internal view override returns (uint256 _totalAssets) {
         // get strategy's balance in the vault
         uint256 shares = ITokenizedStrategy(yearnVault).balanceOf(address(this));
-        // Fee-charging target vaults are not supported. previewRedeem is used as a defensive read
-        // so post-fee value would still be tracked correctly if one were encountered.
+        // EIP-4626 requires previewRedeem to reflect any exit-fee policy the target vault enforces;
+        // convertToAssets returns the gross value and would overstate totalAssets for fee-charging vaults.
         uint256 vaultAssets = ITokenizedStrategy(yearnVault).previewRedeem(shares);
 
         uint256 idleAssets = IERC20(asset).balanceOf(address(this));

--- a/src/strategies/yieldDonating/YearnV3Strategy.sol
+++ b/src/strategies/yieldDonating/YearnV3Strategy.sol
@@ -28,7 +28,13 @@ import { ITokenizedStrategy } from "src/core/interfaces/ITokenizedStrategy.sol";
  *      - Accepts 100% loss on withdrawals to prevent revert cascades
  *      - MultistrategyVault performs actual loss validation via updateDebt
  *
+ *      FEE-CHARGING TARGET VAULTS — NOT SUPPORTED:
+ *      Do NOT deploy against a Yearn vault that charges a withdrawal or exit fee.
+ *      Deposit accounting credits the full pre-fee amount; new depositors can exit
+ *      before the next `report()` and drain existing users.
+ *
  * @custom:security Yearn vault convertToAssets must be manipulation-resistant
+ * @custom:security Yearn vault must NOT charge withdrawal/exit fees
  */
 contract YearnV3Strategy is BaseHealthCheck {
     using SafeERC20 for IERC20;


### PR DESCRIPTION
## Summary
- Adds a NatSpec block to `ERC4626Strategy` codifying that target ERC-4626 vaults charging withdrawal/exit fees are **not supported**.
- Adds a matching `@custom:security` tag to the contract header.

## Why
On a fee-charging target vault, deposit accounting credits the full pre-fee asset amount to `totalAssets` immediately, while the post-fee redeemable value is only reflected on the next `report()`. In that window, a new depositor can withdraw at the pre-fee accounting and silently drain existing depositors.

This was acknowledged verbally with Bailsec as a deployment-time constraint (Bailsec final report — Issue_59, currently rated Informational, conditionally Critical if fee-charging target vaults are ever supported). This PR moves the constraint from "team is aware" to "documented in the source so future deployers and auditors see it."

## Test plan
- [x] `forge build --skip test script` — clean compile (documentation only, no behaviour change).
- [ ] Reviewer confirms NatSpec wording matches the team's expectation.

## Out of scope
A deployment-time on-chain guard (e.g. `require(previewRedeem(unit) == unit)` in `initialize`) would harden this further but is intentionally not included here per the agreed scope ("short NatSpec, option 1").