### PR TITLE
fix(swappers): cantina #1 reopen — forward full tokenOut to receiver

### DIFF
--- a/src/core/interfaces/ISwapper.sol
+++ b/src/core/interfaces/ISwapper.sol
@@ -24,7 +24,8 @@ interface ISwapper {
     /// @param amountIn Maximum amount of tokenIn to pull from msg.sender
     /// @param minAmountOut Minimum acceptable output amount (reverts if not met)
     /// @param receiver Address to receive the output tokens
-    /// @return amountOut Actual amount of tokenOut sent to receiver
+    /// @return amountOut Net amount produced by the swap (the tokenOut balance delta), excluding
+    ///         any pre-existing tokenOut residue that may also be swept to receiver
     function swap(
         address tokenIn,
         address tokenOut,

--- a/src/swappers/CurveSwapper.sol
+++ b/src/swappers/CurveSwapper.sol
@@ -133,7 +133,12 @@ contract CurveSwapper is ISwapper {
 
         IERC20(tokenIn).forceApprove(pool, 0);
 
-        IERC20(tokenOut).safeTransfer(receiver, amountOut);
+        // Forward the FULL tokenOut balance to receiver, not just the swap
+        // delta. Any pre-existing tokenOut sitting on the adapter (donation
+        // or quirk) would otherwise be stranded because balBefore subtracts
+        // it from amountOut. `amountOut` itself remains the true swap delta
+        // so callers/events do not see donation-inflated output.
+        IERC20(tokenOut).safeTransfer(receiver, IERC20(tokenOut).balanceOf(address(this)));
 
         // Curve pools normally pull the full `amountIn`, but any tokenIn that
         // ended up here -- whether from an unusual pool implementation or a

--- a/src/swappers/PSMSwapper.sol
+++ b/src/swappers/PSMSwapper.sol
@@ -172,7 +172,11 @@ contract PSMSwapper is ISwapper {
 
         IERC20(tokenIn).forceApprove(protocol, 0);
 
-        IERC20(tokenOut).safeTransfer(receiver, amountOut);
+        // Forward FULL tokenOut balance so any pre-existing donation is not
+        // stranded by the delta-based amountOut accounting. amountOut stays
+        // as the true swap delta -- the swap() wrapper's minAmountOut check
+        // and the emitted output remain honest, immune to donation inflation.
+        IERC20(tokenOut).safeTransfer(receiver, IERC20(tokenOut).balanceOf(address(this)));
     }
 
     /// @dev Buy gem (e.g., USDC) with DAI/USDS via PSM.
@@ -195,7 +199,10 @@ contract PSMSwapper is ISwapper {
 
         IERC20(tokenIn).forceApprove(protocol, 0);
 
-        IERC20(tokenOut).safeTransfer(receiver, amountOut);
+        // Forward FULL tokenOut balance so any pre-existing donation is not
+        // stranded by the delta-based amountOut accounting. amountOut stays
+        // as the true swap delta for the swap() wrapper's minAmountOut check.
+        IERC20(tokenOut).safeTransfer(receiver, IERC20(tokenOut).balanceOf(address(this)));
     }
 
     /// @dev Convert DAI to USDS via DaiUsds converter (always 1:1, permanently fee-free).

--- a/src/swappers/UniswapV3SwapperAdapter.sol
+++ b/src/swappers/UniswapV3SwapperAdapter.sol
@@ -127,5 +127,14 @@ contract UniswapV3SwapperAdapter is ISwapper {
         if (leftover != 0) {
             IERC20(tokenIn).safeTransfer(msg.sender, leftover);
         }
+
+        // Defense-in-depth: the router sends tokenOut directly to receiver,
+        // so the adapter should hold no tokenOut. Sweep any residue (e.g.
+        // an external donation sitting on the adapter at entry) to receiver
+        // so the ISwapper "holds no tokens between calls" invariant holds.
+        uint256 tokenOutResidue = IERC20(tokenOut).balanceOf(address(this));
+        if (tokenOutResidue != 0) {
+            IERC20(tokenOut).safeTransfer(receiver, tokenOutResidue);
+        }
     }
 }

--- a/src/swappers/UniswapV4SwapperAdapter.sol
+++ b/src/swappers/UniswapV4SwapperAdapter.sol
@@ -246,6 +246,16 @@ contract UniswapV4SwapperAdapter is ISwapper {
             IERC20(tokenIn).safeTransfer(originalCaller, localLeftover);
         }
 
+        // Defense-in-depth: the PoolManager take()s tokenOut directly to
+        // receiver, so the adapter should hold no tokenOut. Sweep any
+        // residue (e.g. an external donation sitting on the adapter at
+        // entry) to receiver so the ISwapper "holds no tokens between
+        // calls" invariant holds on every path.
+        uint256 tokenOutResidue = IERC20(tokenOut).balanceOf(address(this));
+        if (tokenOutResidue != 0) {
+            IERC20(tokenOut).safeTransfer(receiver, tokenOutResidue);
+        }
+
         return abi.encode(amountOut);
     }
 

--- a/test/unit/swappers/CurveSwapper.t.sol
+++ b/test/unit/swappers/CurveSwapper.t.sol
@@ -172,6 +172,38 @@ contract CurveSwapperTest is Test {
             "Caller should receive the prior donation back via the flush"
         );
     }
+
+    /// @notice The adapter must forward the FULL tokenOut balance to receiver,
+    ///         including any pre-existing donation, so the delta-based
+    ///         amountOut accounting does not strand donated tokens. amountOut
+    ///         itself must remain the true swap delta -- donations must not
+    ///         inflate the reported output.
+    function test_swap_forwardsPreExistingTokenOutDonationToReceiver() public {
+        CurveSwapper s = new CurveSwapper(address(pool), INDEX_IN, INDEX_OUT, address(tokenIn), address(tokenOut));
+
+        // Pre-existing tokenOut donation sitting on the adapter at swap entry.
+        uint256 donation = 7e18;
+        tokenOut.mint(address(s), donation);
+
+        uint256 amountIn = 100e18;
+        tokenIn.mint(address(this), amountIn);
+        tokenIn.approve(address(s), amountIn);
+
+        uint256 receiverBalBefore = tokenOut.balanceOf(receiver);
+
+        uint256 amountOut = s.swap(address(tokenIn), address(tokenOut), amountIn, 0, receiver);
+
+        // amountOut reports only the swap delta, NOT delta + donation.
+        assertEq(amountOut, amountIn, "amountOut is the swap delta, donation excluded");
+        // The adapter holds zero tokenOut after the call (no stranding).
+        assertEq(tokenOut.balanceOf(address(s)), 0, "Adapter must hold zero tokenOut after swap");
+        // Receiver got the swap output AND the pre-existing donation.
+        assertEq(
+            tokenOut.balanceOf(receiver),
+            receiverBalBefore + amountIn + donation,
+            "Receiver gets swap output plus pre-existing donation"
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════

--- a/test/unit/swappers/PSMSwapper.t.sol
+++ b/test/unit/swappers/PSMSwapper.t.sol
@@ -379,6 +379,79 @@ contract PSMSwapperTest is Test {
         assertEq(gem.balanceOf(address(s)), 0, "Adapter should not retain tokenIn");
         assertEq(gem.balanceOf(address(this)), leftover, "Preexisting tokenIn should be flushed to caller");
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // ZERO-RESIDUE INVARIANT — tokenOut (Cantina #1 reopen)
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice SELL_GEM: a pre-existing tokenOut donation must be forwarded
+    ///         to receiver instead of stranded by the delta-based amountOut
+    ///         accounting. amountOut itself must report only the swap delta.
+    function test_swap_sellGem_forwardsPreExistingTokenOutDonationToReceiver() public {
+        MockPSM mockPSM = new MockPSM(address(gem), address(dai));
+        PSMSwapper s = new PSMSwapper(address(mockPSM), PSMSwapper.Route.SELL_GEM, address(gem), address(dai), 0);
+
+        // Pre-existing tokenOut donation sitting on the adapter at swap entry.
+        uint256 donation = 7e18;
+        dai.mint(address(s), donation);
+
+        uint256 amountIn = 1000e18;
+        gem.mint(address(this), amountIn);
+        gem.approve(address(s), amountIn);
+
+        uint256 receiverBalBefore = dai.balanceOf(receiver);
+
+        uint256 amountOut = s.swap(address(gem), address(dai), amountIn, 0, receiver);
+
+        // amountOut reports only the swap delta, NOT delta + donation.
+        assertEq(amountOut, amountIn, "SELL_GEM amountOut is the swap delta, donation excluded");
+        assertEq(dai.balanceOf(address(s)), 0, "Adapter must hold zero tokenOut after swap");
+        assertEq(
+            dai.balanceOf(receiver),
+            receiverBalBefore + amountIn + donation,
+            "Receiver gets swap output plus pre-existing donation"
+        );
+    }
+
+    /// @notice BUY_GEM: a pre-existing tokenOut donation must be forwarded
+    ///         to receiver instead of stranded by the delta-based amountOut
+    ///         accounting. amountOut itself must report only the swap delta.
+    function test_swap_buyGem_forwardsPreExistingTokenOutDonationToReceiver() public {
+        MockPSM mockPSM = new MockPSM(address(dai), address(gem));
+        mockPSM.setTout(0);
+
+        PSMSwapper s = new PSMSwapper(
+            address(mockPSM),
+            PSMSwapper.Route.BUY_GEM,
+            address(dai),
+            address(gem),
+            CONVERSION_FACTOR
+        );
+
+        // Pre-existing tokenOut donation sitting on the adapter at swap entry.
+        uint256 donation = 1234;
+        gem.mint(address(s), donation);
+
+        uint256 amountIn = 1000e18;
+        dai.mint(address(this), amountIn);
+        dai.approve(address(s), amountIn);
+
+        uint256 receiverBalBefore = gem.balanceOf(receiver);
+
+        uint256 amountOut = s.swap(address(dai), address(gem), amountIn, 0, receiver);
+
+        uint256 expectedGemAmt = (amountIn * WAD) / (CONVERSION_FACTOR * WAD);
+
+        // amountOut reports only the swap delta, NOT delta + donation -- so
+        // the swap() wrapper's minAmountOut check stays honest under donation.
+        assertEq(amountOut, expectedGemAmt, "BUY_GEM amountOut is the swap delta, donation excluded");
+        assertEq(gem.balanceOf(address(s)), 0, "Adapter must hold zero tokenOut after swap");
+        assertEq(
+            gem.balanceOf(receiver),
+            receiverBalBefore + expectedGemAmt + donation,
+            "Receiver gets swap output plus pre-existing donation"
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════

--- a/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV3SwapperAdapter.t.sol
@@ -185,6 +185,43 @@ contract UniswapV3SwapperAdapterTest is Test {
         );
         assertEq(tokenA.balanceOf(address(this)), leftover, "Caller must receive unused tokenIn");
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // ZERO-RESIDUE INVARIANT — tokenOut (Cantina #1 reopen)
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice The router sends tokenOut directly to receiver, so the adapter
+    ///         normally never holds tokenOut. But a direct ERC20 donation
+    ///         sitting on the adapter at entry would be stranded without an
+    ///         explicit sweep. The adapter must flush any tokenOut residue to
+    ///         receiver before returning, upholding the ISwapper "holds no
+    ///         tokens between calls" invariant on every path.
+    function test_swap_sweepsPreExistingTokenOutDonationToReceiver() public {
+        UniswapV3SwapperAdapter s = new UniswapV3SwapperAdapter(address(router), FEE, address(0), 0);
+
+        // Pre-existing tokenOut donation sitting on the adapter at swap entry.
+        uint256 donation = 7e18;
+        tokenB.mint(address(s), donation);
+
+        uint256 amountIn = 1000e18;
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
+        router.setOutputToken(address(tokenB));
+
+        uint256 receiverBalBefore = tokenB.balanceOf(receiver);
+
+        uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);
+
+        // amountOut is what the router reports (no donation inflation, since
+        // the router itself sends tokenOut directly to receiver).
+        assertEq(amountOut, amountIn, "amountOut is the router-reported swap output");
+        assertEq(tokenB.balanceOf(address(s)), 0, "Adapter must hold zero tokenOut after swap");
+        assertEq(
+            tokenB.balanceOf(receiver),
+            receiverBalBefore + amountIn + donation,
+            "Receiver gets router output plus pre-existing donation"
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════

--- a/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
+++ b/test/unit/swappers/UniswapV4SwapperAdapter.t.sol
@@ -470,6 +470,53 @@ contract UniswapV4SwapperAdapterTest is Test {
         assertEq(tokenA.balanceOf(address(s)), 0, "Adapter should not retain tokenIn");
         assertEq(tokenA.balanceOf(address(this)), leftover, "Preexisting tokenIn should be flushed to caller");
     }
+
+    // ═══════════════════════════════════════════════════════════
+    // ZERO-RESIDUE INVARIANT — tokenOut (Cantina #1 reopen)
+    // ═══════════════════════════════════════════════════════════
+
+    /// @notice The PoolManager take()s tokenOut directly to receiver, so the
+    ///         adapter normally never holds tokenOut. A direct ERC20 donation
+    ///         sitting on the adapter at entry would otherwise be stranded.
+    ///         The adapter must sweep any tokenOut residue to receiver
+    ///         before returning, upholding the ISwapper "holds no tokens
+    ///         between calls" invariant on every path.
+    function test_swap_singleHop_sweepsPreExistingTokenOutDonationToReceiver() public {
+        UniswapV4SwapperAdapter s = new UniswapV4SwapperAdapter(
+            address(pm),
+            FEE,
+            TICK_SPACING,
+            address(0),
+            address(0),
+            0,
+            0,
+            address(0)
+        );
+
+        // Pre-existing tokenOut donation sitting on the adapter at swap entry.
+        uint256 donation = 7e18;
+        tokenB.mint(address(s), donation);
+
+        uint256 amountIn = 1000e18;
+        tokenA.mint(address(this), amountIn);
+        tokenA.approve(address(s), amountIn);
+        pm.setOutputToken(address(tokenB));
+
+        uint256 receiverBalBefore = tokenB.balanceOf(receiver);
+
+        uint256 amountOut = s.swap(address(tokenA), address(tokenB), amountIn, 0, receiver);
+
+        // amountOut comes from the PoolManager-reported delta (no donation
+        // inflation, since the PoolManager take()s tokenOut straight to
+        // receiver during the callback).
+        assertEq(amountOut, amountIn, "amountOut is the PoolManager-reported swap output");
+        assertEq(tokenB.balanceOf(address(s)), 0, "Adapter must hold zero tokenOut after swap");
+        assertEq(
+            tokenB.balanceOf(receiver),
+            receiverBalBefore + amountIn + donation,
+            "Receiver gets swap output plus pre-existing donation"
+        );
+    }
 }
 
 // ═══════════════════════════════════════════════════════════


### PR DESCRIPTION
## What this fixes

We have a few small helper contracts that swap one token for another. If someone sends tokens straight to one of these helpers (by accident or on purpose), the helper used to leave them stranded inside, with no way to get them out.

An auditor (zigtur, Cantina #1) flagged this back in April. We pushed commit d82fccab and said it was fixed. It wasn't. That patch handled the wrong token, the input instead of the output, and sent it to the wrong person. zigtur called it out in the thread and asked us to look again.

This PR does the actual fix. After a swap, the helper forwards everything it's holding to whoever was supposed to receive the output. Donated tokens go to the receiver instead of sitting there.

The number the helper reports as "swap output" still reflects only what the swap actually produced. We don't inflate it to include donated tokens. Other parts of our system check that number against a minimum payout, and a fake-bigger number could let a bad swap pass a check it should have failed.

## Tests

Each helper gets a new test. It plants some output tokens on the helper, runs a swap, and checks that the helper is empty afterwards, the receiver got everything (swap output plus the planted tokens), and the reported amount is just the swap part.

To make sure the test wasn't passing by accident, I undid the fix on the Curve helper and reran it. It failed. Restored the fix and it passed again.

69 swapper tests pass, 91 forwarder integration tests pass, lint and format clean.
