### PR TITLE
Add Aave V3 strategy factory deploy scripts

### DIFF
--- a/script/deploy/DEPLOYMENT_GUIDE.md
+++ b/script/deploy/DEPLOYMENT_GUIDE.md
@@ -14,6 +14,7 @@ The deployment script `DeployAllStrategiesAndFactories.s.sol` deploys the follow
 2. **SkyCompounderStrategyFactory** - Factory for deploying Sky Compounder yield donating strategies
 3. **PaymentSplitterFactory** - Factory for deploying PaymentSplitter contracts with minimal proxies
 4. **YearnV3StrategyFactory** - Factory for deploying YearnV3 yield donating strategies
+5. **AaveV3StrategyFactory** - Factory for deploying Aave V3 yield donating strategies
 
 ## Prerequisites
 
@@ -103,6 +104,7 @@ All salts use a date-based format (DDMMYYYY) for versioning:
 - SkyCompounderStrategyFactory: `keccak256("SKY_COMPOUNDER_FACTORY_05112025")`
 - PaymentSplitterFactory: `keccak256("PAYMENT_SPLITTER_FACTORY_05112025")`
 - YearnV3StrategyFactory: `keccak256("YEARN_V3_STRATEGY_FACTORY_05112025")`
+- AaveV3StrategyFactory: `keccak256("AAVE_V3_STRATEGY_FACTORY_05112025")`
 
 ## What the Script Does
 
@@ -111,7 +113,7 @@ All salts use a date-based format (DDMMYYYY) for versioning:
 3. **Safe Execution Flow**:
    - Safe calls `execTransaction` (once)
    - `execTransaction` calls `MultiSendCallOnly`
-   - `MultiSendCallOnly` makes 5 calls to CREATE2 factory at `0x4e59b44847b379578588920cA78FbF26c0B4956C`
+   - `MultiSendCallOnly` makes 6 calls to CREATE2 factory at `0x4e59b44847b379578588920cA78FbF26c0B4956C`
    - Each call uses calldata format: `salt (32 bytes) + bytecode`
    - CREATE2 factory deploys each contract deterministically
 4. **Sends to Safe Backend**: Submits the transaction to Safe's backend for owner signatures

--- a/script/deploy/DeployAaveV3StrategyFactory.sol
+++ b/script/deploy/DeployAaveV3StrategyFactory.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
+
+contract DeployAaveV3StrategyFactory is Script {
+    // Salt for deterministic deployment
+    bytes32 public constant DEPLOYMENT_SALT = keccak256("OCTANT_AAVE_V3_STRATEGY_FACTORY_V2");
+
+    AaveV3StrategyFactory public aaveV3StrategyFactory;
+
+    function deploy() public virtual returns (address) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        console.log("Deploying AaveV3StrategyFactory with CREATE2...");
+        console.log("Deployer:", vm.addr(deployerPrivateKey));
+
+        // Deploy using CREATE2 with salt
+        aaveV3StrategyFactory = new AaveV3StrategyFactory{ salt: DEPLOYMENT_SALT }();
+        address factoryAddress = address(aaveV3StrategyFactory);
+
+        console.log("AaveV3StrategyFactory deployed at:", factoryAddress);
+
+        vm.stopBroadcast();
+        return factoryAddress;
+    }
+}

--- a/script/deploy/DeployAllStrategiesAndFactories.s.sol
+++ b/script/deploy/DeployAllStrategiesAndFactories.s.sol
@@ -12,6 +12,7 @@ import { MorphoCompounderStrategyFactory } from "src/factories/MorphoCompounderS
 import { SkyCompounderStrategyFactory } from "src/factories/SkyCompounderStrategyFactory.sol";
 import { PaymentSplitterFactory } from "src/factories/PaymentSplitterFactory.sol";
 import { YearnV3StrategyFactory } from "src/factories/yieldDonating/YearnV3StrategyFactory.sol";
+import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
 
 /**
  * @title DeployAllStrategiesAndFactories
@@ -28,6 +29,7 @@ contract DeployAllStrategiesAndFactories is Script, BatchScript {
     bytes32 public constant SKY_FACTORY_SALT = keccak256("SKY_COMPOUNDER_FACTORY_05112025");
     bytes32 public constant PAYMENT_SPLITTER_FACTORY_SALT = keccak256("PAYMENT_SPLITTER_FACTORY_05112025");
     bytes32 public constant YEARN_V3_FACTORY_SALT = keccak256("YEARN_V3_STRATEGY_FACTORY_05112025");
+    bytes32 public constant AAVE_V3_FACTORY_SALT = keccak256("AAVE_V3_STRATEGY_FACTORY_05112025");
 
     // Deployed addresses (to be logged)
     address public yieldDonatingStrategy;
@@ -35,6 +37,7 @@ contract DeployAllStrategiesAndFactories is Script, BatchScript {
     address public skyFactory;
     address public paymentSplitterFactory;
     address public yearnV3Factory;
+    address public aaveV3Factory;
 
     // Safe address
     address public safe;
@@ -92,6 +95,10 @@ contract DeployAllStrategiesAndFactories is Script, BatchScript {
         // YearnV3StrategyFactory
         bytes memory yearnV3CreationCode = type(YearnV3StrategyFactory).creationCode;
         yearnV3Factory = _computeCreate2Address(CREATE2_FACTORY, YEARN_V3_FACTORY_SALT, keccak256(yearnV3CreationCode));
+
+        // AaveV3StrategyFactory
+        bytes memory aaveV3CreationCode = type(AaveV3StrategyFactory).creationCode;
+        aaveV3Factory = _computeCreate2Address(CREATE2_FACTORY, AAVE_V3_FACTORY_SALT, keccak256(aaveV3CreationCode));
     }
 
     function _addStrategyDeployments() internal {
@@ -141,6 +148,14 @@ contract DeployAllStrategiesAndFactories is Script, BatchScript {
         );
         addToBatch(CREATE2_FACTORY, 0, yearnV3DeployData);
         console.log("- YearnV3StrategyFactory at:", yearnV3Factory);
+
+        // Deploy AaveV3StrategyFactory
+        bytes memory aaveV3DeployData = abi.encodePacked(
+            AAVE_V3_FACTORY_SALT,
+            type(AaveV3StrategyFactory).creationCode
+        );
+        addToBatch(CREATE2_FACTORY, 0, aaveV3DeployData);
+        console.log("- AaveV3StrategyFactory at:", aaveV3Factory);
     }
 
     function _logDeploymentSummary() internal view {
@@ -153,10 +168,11 @@ contract DeployAllStrategiesAndFactories is Script, BatchScript {
         console.log("- SkyCompounderStrategyFactory:", skyFactory);
         console.log("- PaymentSplitterFactory:", paymentSplitterFactory);
         console.log("- YearnV3StrategyFactory:", yearnV3Factory);
+        console.log("- AaveV3StrategyFactory:", aaveV3Factory);
         console.log("\nBatch transaction created:");
         console.log("- Safe will call execTransaction once");
         console.log("- execTransaction calls MultiSendCallOnly");
-        console.log("- MultiSendCallOnly makes 5 calls to CREATE2 factory");
+        console.log("- MultiSendCallOnly makes 6 calls to CREATE2 factory");
         console.log("- CREATE2 factory deploys each contract deterministically");
         console.log("\nTransaction sent to Safe for signing.");
         console.log("========================\n");

--- a/script/deploy/DeployNewStrategiesAndFactories.s.sol
+++ b/script/deploy/DeployNewStrategiesAndFactories.s.sol
@@ -14,6 +14,7 @@ import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
 import { MorphoCompounderStrategyFactory } from "src/factories/MorphoCompounderStrategyFactory.sol";
 import { SkyCompounderStrategyFactory } from "src/factories/SkyCompounderStrategyFactory.sol";
 import { YearnV3StrategyFactory } from "src/factories/yieldDonating/YearnV3StrategyFactory.sol";
+import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
 
 // RegenStaker ecosystem
 import { AddressSetFactory } from "src/factories/AddressSetFactory.sol";
@@ -26,7 +27,7 @@ import { RegenStakerWithoutDelegateSurrogateVotes } from "src/regen/RegenStakerW
  * @title DeployNewStrategiesAndFactories
  * @author Golem Foundation
  * @notice Deploys new tokenized strategies, factories, and RegenStaker infrastructure via Safe multisig
- * @dev Due to the EIP-7825 per-transaction gas limit of 16,777,216 gas (2^24), all 10 contracts
+ * @dev Due to the EIP-7825 per-transaction gas limit of 16,777,216 gas (2^24), all 11 contracts
  *      cannot be deployed in a single transaction. The deployment is split
  *      into three Safe MultiSend batches:
  *
@@ -37,9 +38,10 @@ import { RegenStakerWithoutDelegateSurrogateVotes } from "src/regen/RegenStakerW
  *        - LidoStrategyFactory
  *        - MorphoCompounderStrategyFactory
  *
- *      Batch 2: Remaining YieldDonating factories (2 contracts)
+ *      Batch 2: Remaining YieldDonating factories (3 contracts)
  *        - SkyCompounderStrategyFactory
  *        - YearnV3StrategyFactory
+ *        - AaveV3StrategyFactory
  *
  *      Batch 3 (~3M gas): RegenStaker infrastructure (3 contracts)
  *        - AddressSetFactory
@@ -85,6 +87,7 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
     bytes32 public constant MORPHO_FACTORY_SALT = keccak256("MORPHO_COMPOUNDER_FACTORY_11022026");
     bytes32 public constant SKY_FACTORY_SALT = keccak256("SKY_COMPOUNDER_FACTORY_11022026");
     bytes32 public constant YEARN_V3_FACTORY_SALT = keccak256("YEARN_V3_STRATEGY_FACTORY_11022026");
+    bytes32 public constant AAVE_V3_FACTORY_SALT = keccak256("AAVE_V3_STRATEGY_FACTORY_11022026");
 
     // RegenStaker ecosystem salts
     bytes32 public constant ADDRESS_SET_FACTORY_SALT = keccak256("ADDRESS_SET_FACTORY_11022026");
@@ -106,6 +109,7 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
     // Batch 2
     address public skyFactory;
     address public yearnV3Factory;
+    address public aaveV3Factory;
 
     // Batch 3
     address public addressSetFactory;
@@ -222,6 +226,10 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
             YEARN_V3_FACTORY_SALT,
             keccak256(type(YearnV3StrategyFactory).creationCode)
         );
+        aaveV3Factory = _computeCreate2AddressViaFactory(
+            AAVE_V3_FACTORY_SALT,
+            keccak256(type(AaveV3StrategyFactory).creationCode)
+        );
     }
 
     function _calculateBatch3Addresses() internal {
@@ -278,6 +286,9 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
 
         _addCreate2Deployment(YEARN_V3_FACTORY_SALT, type(YearnV3StrategyFactory).creationCode);
         console.log("- YearnV3StrategyFactory:", yearnV3Factory);
+
+        _addCreate2Deployment(AAVE_V3_FACTORY_SALT, type(AaveV3StrategyFactory).creationCode);
+        console.log("- AaveV3StrategyFactory:", aaveV3Factory);
     }
 
     function _addBatch3Deployments() internal {
@@ -324,9 +335,10 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
     function _logBatch2Summary() internal view {
         console.log("\n=== BATCH 2 SUMMARY ===");
         console.log("Safe Address:", safe);
-        console.log("Contracts: 2 (nonce N+1)");
+        console.log("Contracts: 3 (nonce N+1)");
         console.log("  SkyCompounderStrategyFactory:", skyFactory);
         console.log("  YearnV3StrategyFactory:", yearnV3Factory);
+        console.log("  AaveV3StrategyFactory:", aaveV3Factory);
         console.log("Transaction sent to Safe for signing.\n");
     }
 
@@ -342,7 +354,7 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
 
     function _logFullSummary() internal pure {
         console.log("=== FULL DEPLOYMENT SUMMARY ===");
-        console.log("Total contracts: 10 across 3 Safe transactions");
+        console.log("Total contracts: 11 across 3 Safe transactions");
         console.log("All transactions proposed to Safe for signing.");
         console.log("Execute batch 1, then batch 2, then batch 3.");
         console.log("================================\n");

--- a/script/deployment/staging/DeployProtocol.s.sol
+++ b/script/deployment/staging/DeployProtocol.s.sol
@@ -8,6 +8,7 @@ import { DeployLinearAllowanceSingletonForGnosisSafe } from "script/deploy/Deplo
 import { DeployPaymentSplitterFactory } from "script/deploy/DeployPaymentSplitterFactory.sol";
 import { DeploySkyCompounderStrategyFactory } from "script/deploy/DeploySkyCompounderStrategyFactory.sol";
 import { DeployMorphoCompounderStrategyFactory } from "script/deploy/DeployMorphoCompounderStrategyFactory.sol";
+import { DeployAaveV3StrategyFactory } from "script/deploy/DeployAaveV3StrategyFactory.sol";
 import { DeployAllocationMechanismFactory } from "script/deploy/DeployAllocationMechanismFactory.sol";
 import { DeployYearnV3StrategyFactory } from "script/deploy/DeployYearnV3StrategyFactory.s.sol";
 import { DeployLidoStrategyFactory } from "script/deploy/DeployLidoStrategyFactory.sol";
@@ -24,6 +25,7 @@ contract DeployProtocol is Script {
     DeployPaymentSplitterFactory public deployPaymentSplitterFactory;
     DeploySkyCompounderStrategyFactory public deploySkyCompounderStrategyFactory;
     DeployMorphoCompounderStrategyFactory public deployMorphoCompounderStrategyFactory;
+    DeployAaveV3StrategyFactory public deployAaveV3StrategyFactory;
     DeployAllocationMechanismFactory public deployAllocationMechanismFactory;
     DeployYearnV3StrategyFactory public deployYearnV3StrategyFactory;
     DeployLidoStrategyFactory public deployLidoStrategyFactory;
@@ -36,6 +38,7 @@ contract DeployProtocol is Script {
     address public paymentSplitterFactoryAddress;
     address public skyCompounderStrategyFactoryAddress;
     address public morphoCompounderStrategyFactoryAddress;
+    address public aaveV3StrategyFactoryAddress;
     address public regenStakerFactoryAddress;
     address public allocationMechanismFactoryAddress;
     // External strategy contracts (tracked for reference, not deployed by this script)
@@ -59,6 +62,7 @@ contract DeployProtocol is Script {
         deployPaymentSplitterFactory = new DeployPaymentSplitterFactory();
         deploySkyCompounderStrategyFactory = new DeploySkyCompounderStrategyFactory();
         deployMorphoCompounderStrategyFactory = new DeployMorphoCompounderStrategyFactory();
+        deployAaveV3StrategyFactory = new DeployAaveV3StrategyFactory();
         deployAllocationMechanismFactory = new DeployAllocationMechanismFactory();
         deployYearnV3StrategyFactory = new DeployYearnV3StrategyFactory();
         deployLidoStrategyFactory = new DeployLidoStrategyFactory();
@@ -77,6 +81,7 @@ contract DeployProtocol is Script {
         paymentSplitterFactoryAddress = addresses.paymentSplitterFactory;
         skyCompounderStrategyFactoryAddress = addresses.skyCompounderStrategyFactory;
         morphoCompounderStrategyFactoryAddress = addresses.morphoCompounderStrategyFactory;
+        aaveV3StrategyFactoryAddress = addresses.aaveV3StrategyFactory;
         regenStakerFactoryAddress = addresses.regenStakerFactory;
         allocationMechanismFactoryAddress = addresses.allocationMechanismFactory;
         yieldDonatingTokenizedStrategyAddress = addresses.yieldDonatingTokenizedStrategy;
@@ -126,6 +131,13 @@ contract DeployProtocol is Script {
             if (morphoCompounderStrategyFactoryAddress == address(0)) revert DeploymentFailed();
         }
 
+        // Deploy Aave V3 Strategy Factory
+        if (aaveV3StrategyFactoryAddress == address(0)) {
+            deployAaveV3StrategyFactory.deploy();
+            aaveV3StrategyFactoryAddress = address(deployAaveV3StrategyFactory.aaveV3StrategyFactory());
+            if (aaveV3StrategyFactoryAddress == address(0)) revert DeploymentFailed();
+        }
+
         // Regen Staker Factory must be pre-deployed via Safe multisig
         // Use script/deploy/DeployRegenStakerFactory.s.sol with SAFE_ADDRESS env var
         if (regenStakerFactoryAddress == address(0)) {
@@ -159,6 +171,7 @@ contract DeployProtocol is Script {
         console2.log("Payment Splitter Factory:                 ", paymentSplitterFactoryAddress);
         console2.log("Sky Compounder Strategy Factory:          ", skyCompounderStrategyFactoryAddress);
         console2.log("Morpho Compounder Strategy Vault Factory: ", morphoCompounderStrategyFactoryAddress);
+        console2.log("Aave V3 Strategy Factory:                 ", aaveV3StrategyFactoryAddress);
         console2.log("Regen Staker Factory:                     ", regenStakerFactoryAddress);
         console2.log("Allocation Mechanism Factory:             ", allocationMechanismFactoryAddress);
         console2.log("Yearn V3 Strategy Factory:                ", yearnV3StrategyFactoryAddress);
@@ -191,6 +204,10 @@ contract DeployProtocol is Script {
                 "MORPHO_COMPOUNDER_STRATEGY_FACTORY_ADDRESS=",
                 vm.toString(morphoCompounderStrategyFactoryAddress)
             )
+        );
+        vm.writeLine(
+            contractAddressFilename,
+            string.concat("AAVE_V3_STRATEGY_FACTORY_ADDRESS=", vm.toString(aaveV3StrategyFactoryAddress))
         );
         vm.writeLine(
             contractAddressFilename,

--- a/script/helpers/DeployedAddresses.sol
+++ b/script/helpers/DeployedAddresses.sol
@@ -31,6 +31,7 @@ contract DeployedAddresses is Script {
         address paymentSplitterFactory;
         address skyCompounderStrategyFactory;
         address morphoCompounderStrategyFactory;
+        address aaveV3StrategyFactory;
         address regenEarningPowerCalculatorFactory;
         address regenStakerFactory;
         address allocationMechanismFactory;
@@ -83,6 +84,7 @@ contract DeployedAddresses is Script {
                 paymentSplitterFactory: 0x5711765E0756B45224fc1FdA1B41ab344682bBcb,
                 skyCompounderStrategyFactory: 0xbe5352d0eCdB13D9f74c244B634FdD729480Bb6F,
                 morphoCompounderStrategyFactory: 0x052d20B0e0b141988bD32772C735085e45F357c1,
+                aaveV3StrategyFactory: address(0),
                 regenEarningPowerCalculatorFactory: 0xD916da52d277b28CaDFfEE5350bA98cf3d8fa441,
                 regenStakerFactory: 0x6a8250C95d2e866e95fe4749eD540357B8e44a9a,
                 allocationMechanismFactory: address(0),
@@ -112,6 +114,7 @@ contract DeployedAddresses is Script {
                 paymentSplitterFactory: address(0),
                 skyCompounderStrategyFactory: address(0),
                 morphoCompounderStrategyFactory: address(0),
+                aaveV3StrategyFactory: address(0),
                 regenEarningPowerCalculatorFactory: address(0),
                 regenStakerFactory: address(0),
                 allocationMechanismFactory: 0x4fc209Fbc5eFE0549cdB878f206942a91bBC17d2,
@@ -139,6 +142,7 @@ contract DeployedAddresses is Script {
                 paymentSplitterFactory: 0x5711765E0756B45224fc1FdA1B41ab344682bBcb,
                 skyCompounderStrategyFactory: 0xbe5352d0eCdB13D9f74c244B634FdD729480Bb6F,
                 morphoCompounderStrategyFactory: 0x052d20B0e0b141988bD32772C735085e45F357c1,
+                aaveV3StrategyFactory: address(0),
                 // RegenStaker and AllocationMechanism - deploy fresh (protocol-specific)
                 regenEarningPowerCalculatorFactory: 0xD916da52d277b28CaDFfEE5350bA98cf3d8fa441,
                 regenStakerFactory: 0x6a8250C95d2e866e95fe4749eD540357B8e44a9a,
@@ -169,6 +173,7 @@ contract DeployedAddresses is Script {
                 paymentSplitterFactory: address(0),
                 skyCompounderStrategyFactory: address(0),
                 morphoCompounderStrategyFactory: address(0),
+                aaveV3StrategyFactory: address(0),
                 regenEarningPowerCalculatorFactory: address(0),
                 regenStakerFactory: address(0),
                 allocationMechanismFactory: address(0),

--- a/script/prod/DeployProtocol.s.sol
+++ b/script/prod/DeployProtocol.s.sol
@@ -18,6 +18,7 @@ import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
 import { MorphoCompounderStrategyFactory } from "src/factories/MorphoCompounderStrategyFactory.sol";
 import { SkyCompounderStrategyFactory } from "src/factories/SkyCompounderStrategyFactory.sol";
 import { YearnV3StrategyFactory } from "src/factories/yieldDonating/YearnV3StrategyFactory.sol";
+import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
 import { AddressSetFactory } from "src/factories/AddressSetFactory.sol";
 import { RegenEarningPowerCalculatorFactory } from "src/factories/RegenEarningPowerCalculatorFactory.sol";
 import { RegenStakerFactory } from "src/factories/RegenStakerFactory.sol";
@@ -101,6 +102,7 @@ contract DeployProtocol is Script, BatchScript {
     bytes32 internal _morphoFactorySalt;
     bytes32 internal _skyFactorySalt;
     bytes32 internal _yearnV3FactorySalt;
+    bytes32 internal _aaveV3FactorySalt;
     bytes32 internal _addressSetFactorySalt;
     bytes32 internal _calcFactorySalt;
     bytes32 internal _stakerFactorySalt;
@@ -116,7 +118,7 @@ contract DeployProtocol is Script, BatchScript {
     //  INITIALIZATION
     // ═════════════════════════════════════════════════════════════════════════
 
-    /// @dev Resolves SAFE_ADDRESS and SALT_TIMESTAMP from env, computes all 15
+    /// @dev Resolves SAFE_ADDRESS and SALT_TIMESTAMP from env, computes all 16
     ///      salts, and logs the full deployment configuration. Guarded by
     ///      _initialized to run exactly once.
     function _initialize() internal {
@@ -139,6 +141,7 @@ contract DeployProtocol is Script, BatchScript {
         _morphoFactorySalt = keccak256(abi.encodePacked("MORPHO_COMPOUNDER_FACTORY_", _saltTimestamp));
         _skyFactorySalt = keccak256(abi.encodePacked("SKY_COMPOUNDER_FACTORY_", _saltTimestamp));
         _yearnV3FactorySalt = keccak256(abi.encodePacked("YEARN_V3_STRATEGY_FACTORY_", _saltTimestamp));
+        _aaveV3FactorySalt = keccak256(abi.encodePacked("AAVE_V3_STRATEGY_FACTORY_", _saltTimestamp));
         _addressSetFactorySalt = keccak256(abi.encodePacked("ADDRESS_SET_FACTORY_", _saltTimestamp));
         _calcFactorySalt = keccak256(abi.encodePacked("REGEN_EARNING_POWER_CALCULATOR_FACTORY_", _saltTimestamp));
         _stakerFactorySalt = keccak256(abi.encodePacked("REGEN_STAKER_FACTORY_", _saltTimestamp));
@@ -263,7 +266,7 @@ contract DeployProtocol is Script, BatchScript {
         return address(uint160(uint256(hash)));
     }
 
-    /// @notice Compute and log all 15 deterministic addresses from CREATE2 math.
+    /// @notice Compute and log all 16 deterministic addresses from CREATE2 math.
     ///         Requires SAFE_ADDRESS env var. Uses SALT_TIMESTAMP if set,
     ///         otherwise auto-generates via FFI.
     ///
@@ -303,6 +306,10 @@ contract DeployProtocol is Script, BatchScript {
             "EXPECTED_YEARN_FACTORY:",
             _computeCreate2AddressViaFactory(_yearnV3FactorySalt, type(YearnV3StrategyFactory).creationCode)
         );
+        console.log(
+            "EXPECTED_AAVE_FACTORY:",
+            _computeCreate2AddressViaFactory(_aaveV3FactorySalt, type(AaveV3StrategyFactory).creationCode)
+        );
         console.log("EXPECTED_ADDRESS_SET_FACTORY:", _addressSetFactoryAddress());
         console.log(
             "EXPECTED_CALC_FACTORY:",
@@ -323,7 +330,7 @@ contract DeployProtocol is Script, BatchScript {
     // ═════════════════════════════════════════════════════════════════════════
     //  PHASE A: Factory Deployment (3 Safe Transactions)
     //
-    //  All 10 contracts deployed via Nick's CREATE2 factory (0x4e59b44...56C).
+    //  All 11 contracts deployed via Nick's CREATE2 factory (0x4e59b44...56C).
     //  Split into 3 batches due to the EIP-7825 per-tx gas limit of ~16.78M.
     // ═════════════════════════════════════════════════════════════════════════
 
@@ -377,9 +384,10 @@ contract DeployProtocol is Script, BatchScript {
         executeBatch(_shouldSend());
     }
 
-    /// @notice Tx 2: 2 contracts
+    /// @notice Tx 2: 3 contracts
     ///         - SkyCompounderStrategyFactory
     ///         - YearnV3StrategyFactory
+    ///         - AaveV3StrategyFactory
     function phaseA_batch2() external isBatch(_initAndGetSafe()) {
         address deployed;
         address expected;
@@ -393,6 +401,11 @@ contract DeployProtocol is Script, BatchScript {
         expected = _computeCreate2AddressViaFactory(_yearnV3FactorySalt, type(YearnV3StrategyFactory).creationCode);
         require(deployed == expected, "YearnFactory address mismatch");
         console.log("YearnV3StrategyFactory:", deployed);
+
+        deployed = _addCreate2Deployment(_aaveV3FactorySalt, type(AaveV3StrategyFactory).creationCode);
+        expected = _computeCreate2AddressViaFactory(_aaveV3FactorySalt, type(AaveV3StrategyFactory).creationCode);
+        require(deployed == expected, "AaveV3Factory address mismatch");
+        console.log("AaveV3StrategyFactory:", deployed);
 
         executeBatch(_shouldSend());
     }
@@ -584,7 +597,7 @@ contract DeployProtocol is Script, BatchScript {
 // ═════════════════════════════════════════════════════════════════════════════
 
 /// @title VerifyProtocolSourceCode
-/// @notice Verifies all 15 Octant v2 protocol contracts on Etherscan and Sourcify.
+/// @notice Verifies all 16 Octant v2 protocol contracts on Etherscan and Sourcify.
 ///         Uses deterministic addresses computed at runtime from SAFE_ADDRESS and
 ///         SALT_TIMESTAMP env vars, reusing DeployProtocol address-computation helpers.
 ///
@@ -613,6 +626,7 @@ contract VerifyProtocolSourceCode is DeployProtocol {
     string constant SKY_FACTORY_PATH = "src/factories/SkyCompounderStrategyFactory.sol:SkyCompounderStrategyFactory";
     string constant YEARN_FACTORY_PATH =
         "src/factories/yieldDonating/YearnV3StrategyFactory.sol:YearnV3StrategyFactory";
+    string constant AAVE_FACTORY_PATH = "src/factories/AaveV3StrategyFactory.sol:AaveV3StrategyFactory";
     string constant ADDRESS_SET_FACTORY_PATH = "src/factories/AddressSetFactory.sol:AddressSetFactory";
     string constant CALC_FACTORY_PATH =
         "src/factories/RegenEarningPowerCalculatorFactory.sol:RegenEarningPowerCalculatorFactory";
@@ -626,13 +640,13 @@ contract VerifyProtocolSourceCode is DeployProtocol {
     //  ENTRY POINTS
     // ═════════════════════════════════════════════════════════════════════════
 
-    /// @notice Verify all 15 contracts on Etherscan. Requires ETHERSCAN_API_KEY env var.
+    /// @notice Verify all 16 contracts on Etherscan. Requires ETHERSCAN_API_KEY env var.
     function verifyEtherscan() external {
         _initialize();
         _verifyAll("etherscan");
     }
 
-    /// @notice Verify all 15 contracts on Sourcify. No API key needed.
+    /// @notice Verify all 16 contracts on Sourcify. No API key needed.
     function verifySourcify() external {
         _initialize();
         _verifyAll("sourcify");
@@ -643,7 +657,7 @@ contract VerifyProtocolSourceCode is DeployProtocol {
     // ═════════════════════════════════════════════════════════════════════════
 
     function _verifyAll(string memory verifier) internal {
-        console.log("=== VERIFYING ALL 15 PROTOCOL CONTRACTS ===");
+        console.log("=== VERIFYING ALL 16 PROTOCOL CONTRACTS ===");
         console.log("Verifier:", verifier);
         console.log("");
 
@@ -696,6 +710,12 @@ contract VerifyProtocolSourceCode is DeployProtocol {
             _computeCreate2AddressViaFactory(_yearnV3FactorySalt, type(YearnV3StrategyFactory).creationCode),
             YEARN_FACTORY_PATH,
             "YearnV3StrategyFactory",
+            verifier
+        );
+        _verifyNoArgs(
+            _computeCreate2AddressViaFactory(_aaveV3FactorySalt, type(AaveV3StrategyFactory).creationCode),
+            AAVE_FACTORY_PATH,
+            "AaveV3StrategyFactory",
             verifier
         );
         _verifyNoArgs(_addressSetFactoryAddress(), ADDRESS_SET_FACTORY_PATH, "AddressSetFactory", verifier);
@@ -861,8 +881,9 @@ contract VerifyProtocolSourceCode is DeployProtocol {
 
 /// @title VerifyProtocolDeployment
 /// @notice Fork test that validates all deployed mainnet contracts are correctly
-///         deployed and functionally operational. Covers all 10 Phase A
-///         factory/implementation contracts, all 5 Phase B instance contracts.
+///         deployed and functionally operational. Covers all Phase A
+///         factory/implementation contracts available via env/defaults and all
+///         5 Phase B instance contracts.
 ///
 ///         All addresses are read from env vars with production defaults, so the
 ///         test works both for production verification (run with no env vars) and
@@ -888,6 +909,7 @@ contract VerifyProtocolDeployment is Test {
     MorphoCompounderStrategyFactory internal morphoFactory;
     SkyCompounderStrategyFactory internal skyFactory;
     YearnV3StrategyFactory internal yearnFactory;
+    AaveV3StrategyFactory internal aaveFactory;
     AddressSetFactory internal addressSetFactory;
     RegenEarningPowerCalculatorFactory internal calculatorFactory;
     RegenStakerFactory internal regenStakerFactory;
@@ -941,6 +963,7 @@ contract VerifyProtocolDeployment is Test {
         yearnFactory = YearnV3StrategyFactory(
             vm.envOr("EXPECTED_YEARN_FACTORY", address(0xd5338eb7DFFE2e16cd217e8b0FA3d762024f614C))
         );
+        aaveFactory = AaveV3StrategyFactory(vm.envOr("EXPECTED_AAVE_FACTORY", address(0)));
         addressSetFactory = AddressSetFactory(
             vm.envOr("EXPECTED_ADDRESS_SET_FACTORY", address(0x94e05a2bEd3a6bD2809cF8Dcb7dc85b57019F714))
         );
@@ -973,6 +996,9 @@ contract VerifyProtocolDeployment is Test {
         allContracts.push(address(morphoFactory));
         allContracts.push(address(skyFactory));
         allContracts.push(address(yearnFactory));
+        if (address(aaveFactory) != address(0)) {
+            allContracts.push(address(aaveFactory));
+        }
         allContracts.push(address(addressSetFactory));
         allContracts.push(address(calculatorFactory));
         allContracts.push(address(regenStakerFactory));
@@ -984,7 +1010,7 @@ contract VerifyProtocolDeployment is Test {
     }
 
     // -----------------------------------------------------------------------
-    // Test 1: All 15 contracts have code on-chain
+    // Test 1: All configured contracts have code on-chain
     // -----------------------------------------------------------------------
 
     function test_allContractsHaveCode() public view {
@@ -1034,6 +1060,15 @@ contract VerifyProtocolDeployment is Test {
             _yieldDonating,
             address(7)
         );
+
+        if (address(aaveFactory) != address(0)) {
+            assertEq(
+                aaveFactory.AAVE_ADDRESSES_PROVIDER(),
+                0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e,
+                "AaveFactory: wrong AAVE_ADDRESSES_PROVIDER"
+            );
+            assertEq(aaveFactory.USDC(), 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48, "AaveFactory: wrong USDC");
+        }
 
         // AddressSetFactory: predictAddress returns non-zero
         address predicted = addressSetFactory.predictAddress(bytes32(uint256(1)), address(this));


### PR DESCRIPTION
## Summary
- add a standalone AaveV3StrategyFactory deploy script matching existing factory deployers
- include AaveV3StrategyFactory in Safe multisig deployment batches and production deployment verification
- wire Aave factory address tracking into staging deployment helpers and documentation

## Verification
- forge compile --skip test
- yarn format:check
- yarn lint (passes with existing solhint warnings)
- forge test --match-path test/unit/strategies/yieldDonating/AaveV3ApprovalHygiene.t.sol