### PR TITLE
chore: small repo cleanups (docs, dead code, restored test)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,14 +21,15 @@ yarn coverage:summary     # forge coverage (summary table)
 | Directory | Contents |
 |-----------|----------|
 | `src/` | Production Solidity contracts |
-| `script/` | All scripts: Foundry `.s.sol` in subdirectories, bash `.sh` at root level |
+| `script/` | Foundry/bash scripts: `.s.sol` in subdirectories, bash `.sh` at root level |
+| `scripts/` | Node.js tooling (e.g. `sol-semver.mjs` for Solidity semver checks) |
 | `test/unit/` | Unit tests |
 | `test/integration/` | Integration tests (forked mainnet) |
 | `test/kontrol/` | Kontrol formal verification tests |
 | `verification/` | Formal verification support (Kontrol K definitions) |
 | `dependencies/` | Soldeer-managed dependencies |
 
-**There is no `scripts/` directory.** All scripts (Solidity and bash) live under `script/`.
+**Note the singular vs plural:** `script/` holds Foundry/bash scripts; `scripts/` holds Node.js tooling. They are distinct directories.
 
 ## Key references
 
@@ -40,7 +41,7 @@ yarn coverage:summary     # forge coverage (summary table)
 
 - Foundry toolchain (`forge`, `cast`, `anvil`); Soldeer for dependency management
 - Conventional commits: `type(scope): message`
-- Solidity `^0.8.24`; optimizer enabled
+- Solidity `^0.8.25`; compiled with solc `0.8.33` (pinned in `foundry.toml`); optimizer enabled
 - AGPL-3.0-or-later license for original code; preserve upstream licenses for ported/adapted code
 - NatSpec required on all public/external functions; use `@inheritdoc` for overrides
 - Tests follow Arrange-Act-Assert pattern

--- a/src/core/interfaces/IMultistrategyVault.sol
+++ b/src/core/interfaces/IMultistrategyVault.sol
@@ -415,7 +415,7 @@ interface IMultistrategyVault {
 
     // ERC20 & ERC4626 Functions
     function deposit(uint256 assets, address receiver) external returns (uint256);
-    // function mint(uint256 shares, address receiver) external returns (uint256);
+    function mint(uint256 shares, address receiver) external returns (uint256);
     function withdraw(
         uint256 assets,
         address receiver,

--- a/src/mechanisms/AllocationMechanismFactory.sol
+++ b/src/mechanisms/AllocationMechanismFactory.sol
@@ -7,7 +7,6 @@ import { OctantQFMechanism } from "./mechanism/OctantQFMechanism.sol";
 import { AllocationConfig } from "./BaseAllocationMechanism.sol";
 import { IAddressSet } from "src/utils/IAddressSet.sol";
 import { AccessMode } from "src/constants.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import { Create2 } from "@openzeppelin/contracts/utils/Create2.sol";
 
 /**

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingTimelockEnforcementTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingTimelockEnforcementTest.t.sol
@@ -354,71 +354,78 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
         assertEq(bobAssets, expectedAssetsPerRecipient);
     }
 
-    /// @notice Test edge cases in timelock enforcement
-    // function testTimelockEnforcement_EdgeCases() public {
-    //     uint256 startBlock = _tokenized(address(mechanism)).startBlock();
-    //     vm.roll(startBlock - 1);
+    /// @notice Test edge cases in timelock enforcement: inclusive window boundaries,
+    ///         share transfer to a new owner, and approved (allowance-based) redemption.
+    function testTimelockEnforcement_EdgeCases() public {
+        // Start with clean timestamp
+        vm.warp(40);
 
-    //     // Start with clean timestamp
-    //     vm.warp(400000); // Different timestamp to avoid interference
+        // Get absolute timeline from contract
+        uint256 deploymentTime = block.timestamp;
+        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
+        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingStartTime = deploymentTime + votingDelay;
+        uint256 votingEndTime = votingStartTime + votingPeriod;
 
-    //     // Setup
-    //     vm.startPrank(alice);
-    //     token.approve(address(mechanism), LARGE_DEPOSIT);
-    //     _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-    //     uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Charlie's Edge Case Project");
-    //     vm.stopPrank();
+        // Setup successful proposal for charlie
+        vm.startPrank(alice);
+        token.approve(address(mechanism), LARGE_DEPOSIT);
+        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Charlie's Edge Case Project");
+        vm.stopPrank();
 
-    //     vm.roll(startBlock + VOTING_DELAY + 1);
+        vm.warp(votingStartTime + 1);
 
-    //     vm.prank(alice);
-    //     _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30); // 30^2 = 900 > 500 quorum
+        vm.prank(alice);
+        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
 
-    //     vm.roll(startBlock + VOTING_DELAY + VOTING_PERIOD + 1);
-    //     (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
-    //     require(success, "Finalization failed");
+        vm.warp(votingEndTime + 1);
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        require(success, "Finalization failed");
 
-    //     uint256 queueTime = block.timestamp;
-    //     (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
-    //     require(success2, "Queue failed");
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        require(success2, "Queue failed");
 
-    //     // Test 1: Exactly at boundary moments
+        uint256 redeemableTime = _tokenized(address(mechanism)).globalRedemptionStart();
 
-    //     // Exactly at timelock expiry
-    //     vm.warp(queueTime + TIMELOCK_DELAY);
-    //     assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 900);
+        // Test 1: Inclusive window boundaries [start, start + gracePeriod]
+        // Exactly at redemption start - full balance redeemable
+        vm.warp(redeemableTime);
+        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 900);
 
-    //     // Exactly at grace period expiry
-    //     vm.warp(queueTime + TIMELOCK_DELAY + GRACE_PERIOD);
-    //     assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0);
+        // Exactly at grace period expiry - still redeemable (window end is inclusive)
+        vm.warp(redeemableTime + GRACE_PERIOD);
+        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 900);
 
-    //     // Test 2: Transfer shares and check timelock enforcement for new owner
-    //     vm.warp(queueTime + TIMELOCK_DELAY + GRACE_PERIOD / 2); // Valid window
+        // One second past grace period expiry - no longer redeemable
+        vm.warp(redeemableTime + GRACE_PERIOD + 1);
+        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0);
 
-    //     address newOwner = address(0x999);
-    //     vm.prank(charlie);
-    //     _tokenized(address(mechanism)).transfer(newOwner, 300);
+        // Test 2: Transfer shares and check the new owner can redeem within the window
+        vm.warp(redeemableTime + GRACE_PERIOD / 2); // Valid window
 
-    //     // New owner should also respect charlie's original timelock
-    //     assertEq(_tokenized(address(mechanism)).maxRedeem(newOwner), 300);
+        address newOwner = address(0x999);
+        vm.prank(charlie);
+        _tokenized(address(mechanism)).transfer(newOwner, 300);
 
-    //     vm.prank(newOwner);
-    //     uint256 newOwnerAssets = _tokenized(address(mechanism)).redeem(300, newOwner, newOwner);
+        // Redemption is gated by the global window, so the new owner can redeem their balance
+        assertEq(_tokenized(address(mechanism)).maxRedeem(newOwner), 300);
 
-    //     // With matching pool: total assets = 1000 (alice) + 2000 (matching pool) = 3000 ether
-    //     // 300 shares out of 900 total = (300/900) × 3000 = 1000 ether
-    //     uint256 expectedAssets = 1000 ether;
-    //     assertEq(newOwnerAssets, expectedAssets);
+        vm.prank(newOwner);
+        uint256 newOwnerAssets = _tokenized(address(mechanism)).redeem(300, newOwner, newOwner);
 
-    //     // Test 3: Approved redemption
-    //     vm.prank(charlie);
-    //     _tokenized(address(mechanism)).approve(newOwner, 300); // Approve 300 of the 600 remaining shares
+        // total assets = 1000 (alice) + 2000 (matching pool) = 3000 ether
+        // 300 shares out of 900 total = (300/900) × 3000 = 1000 ether
+        assertEq(newOwnerAssets, 1000 ether);
 
-    //     vm.prank(newOwner);
-    //     uint256 approvedAssets = _tokenized(address(mechanism)).redeem(300, newOwner, charlie);
+        // Test 3: Approved (allowance-based) redemption on behalf of charlie
+        vm.prank(charlie);
+        _tokenized(address(mechanism)).approve(newOwner, 300);
 
-    //     // Same calculation: 300 shares out of 900 total = (300/900) × 3000 = 1000 ether
-    //     uint256 expectedApprovedAssets = 1000 ether;
-    //     assertEq(approvedAssets, expectedApprovedAssets);
-    // }
+        vm.prank(newOwner);
+        uint256 approvedAssets = _tokenized(address(mechanism)).redeem(300, newOwner, charlie);
+
+        // 300 shares out of the remaining 600 total = (300/600) × 2000 = 1000 ether
+        assertEq(approvedAssets, 1000 ether);
+    }
 }


### PR DESCRIPTION
Small, low-risk housekeeping found while surveying the repo. Each change is its own commit.

### Changes
- **docs(agents):** `AGENTS.md` correctly described the directory layout and toolchain — fixed the now-false "there is no `scripts/` directory" claim (`scripts/sol-semver.mjs` exists and is referenced by `package.json`), and corrected the Solidity version (`^0.8.24` → `^0.8.25`, compiled with pinned solc `0.8.33`).
- **fix(interfaces):** `IMultistrategyVault` had `mint(uint256,address)` commented out even though `MultistrategyVault` implements it (`MultistrategyVault.sol:1346`). Restored the declaration so the interface matches the implementation. The interface is standalone (no inheritance conflict) and nothing relied on the omission.
- **refactor(mechanisms):** removed an unused `IERC20` import in `AllocationMechanismFactory.sol`.
- **test(allocation):** restored the previously commented-out `testTimelockEnforcement_EdgeCases` in `QuadraticVotingTimelockEnforcementTest`, ported from the old block-based API to the current timestamp-based API. It now covers the **inclusive** redemption-window boundaries (`start` and `start + gracePeriod`), share transfer to a new owner, and allowance-based redemption — coverage no other test had.

### Verification
- `forge build` — compiles clean.
- `forge test --match-contract QuadraticVotingTimelockEnforcementTest` — 5/5 pass.
- `prettier --check` clean; `solhint` 0 errors on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)