### PR TITLE
docs: fix "Cant" -> "Can't" in code comments

### DIFF
--- a/src/core/libs/DebtManagementLib.sol
+++ b/src/core/libs/DebtManagementLib.sol
@@ -187,7 +187,7 @@ library DebtManagementLib {
             // Respect minimum total idle in vault
             if (vars.totalIdle + vars.assetsToWithdraw < vars.minimumTotalIdle) {
                 vars.assetsToWithdraw = vars.minimumTotalIdle - vars.totalIdle;
-                // Cant withdraw more than the strategy has.
+                // Can't withdraw more than the strategy has.
                 if (vars.assetsToWithdraw > vars.currentDebt) {
                     vars.assetsToWithdraw = vars.currentDebt;
                 }

--- a/test/integration/strategies/YieldSkimming/LidoStrategy.t.sol
+++ b/test/integration/strategies/YieldSkimming/LidoStrategy.t.sol
@@ -1358,7 +1358,7 @@ contract LidoStrategyTest is Test {
     }
 
     /// @notice Test dragon router withdrawal followed by rate recovery - user should have no loss
-    /// @dev Sequence: d1 -> r1.5 -> report (mint DR) -> wDR -> r1.0 -> report (cant burn shares) -> r1.5 -> report -> w1 (no loss)
+    /// @dev Sequence: d1 -> r1.5 -> report (mint DR) -> wDR -> r1.0 -> report (can't burn shares) -> r1.5 -> report -> w1 (no loss)
     function test_dragonRouterWithdrawal_rateRecovery_userNoLoss() public {
         DragonWithdrawalTestData memory data;
 
@@ -1429,7 +1429,7 @@ contract LidoStrategyTest is Test {
         // Step 5: r1.0 - Rate drops back to 1.0
         vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.decreasedRate));
 
-        // Step 6: report (cant burn shares) - Report with no dragon shares to burn
+        // Step 6: report (can't burn shares) - Report with no dragon shares to burn
         vm.startPrank(keeper);
         (data.profit2, data.loss2) = vault.report();
         vm.stopPrank();
@@ -1491,7 +1491,7 @@ contract LidoStrategyTest is Test {
     }
 
     /// @notice Test dragon router withdrawal followed by rate decline - user should experience loss
-    /// @dev Sequence: d1 -> r1.5 -> report (mint DR) -> wDR -> r1.0 -> report (cant burn shares) -> r0.9 -> w1 (loss)
+    /// @dev Sequence: d1 -> r1.5 -> report (mint DR) -> wDR -> r1.0 -> report (can't burn shares) -> r0.9 -> w1 (loss)
     function test_dragonRouterWithdrawal_rateDecline_userLoss() public {
         DragonWithdrawalTestData memory data;
 
@@ -1563,7 +1563,7 @@ contract LidoStrategyTest is Test {
         // Step 5: r1.0 - Rate drops back to 1.0
         vm.mockCall(WSTETH, abi.encodeWithSignature("stEthPerToken()"), abi.encode(data.decreasedRate));
 
-        // Step 6: report (cant burn shares) - Report with no dragon shares to burn
+        // Step 6: report (can't burn shares) - Report with no dragon shares to burn
         vm.startPrank(keeper);
         (data.profit2, data.loss2) = vault.report();
         vm.stopPrank();


### PR DESCRIPTION
Corrects a missing apostrophe in the "can't" contraction across code comments.

## Changes
- `src/core/libs/DebtManagementLib.sol` — 1 comment
- `test/integration/strategies/YieldSkimming/LidoStrategy.t.sol` — 4 comments

## Safety
Comments only. No bytecode change, no test behavior change. Verified `forge build --skip script` compiles cleanly (only pre-existing Kontrol AST warnings).