### PR TITLE
docs: fix malformed @param NatSpec in DebtManagementLib.updateDebt

### DIFF
--- a/src/core/libs/DebtManagementLib.sol
+++ b/src/core/libs/DebtManagementLib.sol
@@ -135,7 +135,7 @@ library DebtManagementLib {
      * @param totalIdle Current vault idle assets
      * @param totalDebt Current total debt across all strategies
      * @param strategy Strategy address to rebalance
-     * @param targetDebt Target debt for strategy,  or type(uint256).max for max)
+     * @param targetDebt Target debt for strategy, or type(uint256).max for max
      * @param maxLoss Maximum acceptable loss in basis points (0-10000)
      * @param minimumTotalIdle Minimum idle to maintain in vault
      * @param asset Vault's asset token address


### PR DESCRIPTION
The `targetDebt` `@param` line in `DebtManagementLib.updateDebt` had a stray trailing `)` (no matching opening paren) and a double space.

## Change
- `src/core/libs/DebtManagementLib.sol` — 1 NatSpec comment line

\`\`\`
- @param targetDebt Target debt for strategy,  or type(uint256).max for max)
+ @param targetDebt Target debt for strategy, or type(uint256).max for max
\`\`\`

## Safety
Comment only. No bytecode change. Verified `forge build --skip script` compiles cleanly.