### PR TITLE
docs: fix "wont" -> "won't" in BaseStrategy fallback NatSpec

### DIFF
--- a/src/core/BaseStrategy.sol
+++ b/src/core/BaseStrategy.sol
@@ -519,7 +519,7 @@ abstract contract BaseStrategy {
      * @dev Execute a function on the TokenizedStrategy and return any value.
      *
      * This fallback function will be executed when any of the standard functions
-     * defined in the TokenizedStrategy are called since they wont be defined in
+     * defined in the TokenizedStrategy are called since they won't be defined in
      * this contract.
      *
      * It will delegatecall the TokenizedStrategy implementation with the exact


### PR DESCRIPTION
Adds the missing apostrophe in the `@dev` comment on `BaseStrategy`'s fallback function.

## Change
- `src/core/BaseStrategy.sol` — 1 NatSpec comment line (`wont` → `won't`)

## Safety
Comment only. No bytecode change. Verified `forge build --skip script` → `Compiler run successful!`.