### PR TITLE
docs: fix garbled "to the that" phrasing in BaseStrategy NatSpec

### DIFF
--- a/src/core/BaseStrategy.sol
+++ b/src/core/BaseStrategy.sol
@@ -103,7 +103,7 @@ abstract contract BaseStrategy {
      * contract that will be used by all strategies to handle the
      * accounting, logic, storage etc.
      *
-     * Any external calls to the that don't hit one of the functions
+     * Any external calls to the strategy that don't hit one of the functions
      * defined in this base or the strategy will end up being forwarded
      * through the fallback function, which will delegateCall this address.
      *


### PR DESCRIPTION
The `@dev` comment on `TOKENIZED_STRATEGY_ADDRESS` reads "Any external calls **to the that** don't hit one of the functions" — the word `strategy` was dropped.

## Change
- `src/core/BaseStrategy.sol` — 1 NatSpec comment line

```
- Any external calls to the that don't hit one of the functions
+ Any external calls to the strategy that don't hit one of the functions
```

Restores the wording from the upstream Yearn `TokenizedStrategy` this is ported from.

## Safety
Comment only. No bytecode change. Verified `forge build --skip script` → `Compiler run successful!`.