### PR TITLE
docs: document report() return values in YieldDonatingTokenizedStrategy

### DIFF
--- a/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
+++ b/src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol
@@ -181,6 +181,9 @@ contract YieldDonatingTokenizedStrategy is TokenizedStrategy {
      *      happen, but it does not block tend() or report(). No on-chain cap on reporting cadence
      *      is enforced — that would constrain legitimate operation for a threat the trust model
      *      already accepts.
+     *
+     * @return profit Notional amount of gain since last report, in terms of `asset`
+     * @return loss Notional loss in terms of `asset`, subject to override-specific semantics
      */
     function report()
         public


### PR DESCRIPTION
The `report()` override declares named returns `(uint256 profit, uint256 loss)` and has a detailed `@notice`/`@dev` block, but was missing `@return` docs — an inconsistency, since the file documents `@return` elsewhere.

## Change
- `src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol` — adds 2 `@return` lines

```
+ @return profit Notional amount of gain since last report, in terms of `asset`
+ @return loss Notional loss in terms of `asset`, subject to override-specific semantics
```

Wording mirrors the canonical `@return` docs on `TokenizedStrategy.report()`.

## Safety
Comment only. No bytecode change. Verified `forge build --skip script` → `Compiler run successful!`; solhint reports no new issues (one pre-existing ordering warning unrelated to this change).