### PR TITLE
docs: document @return for rage-quit cooldown getters in IMultistrategyLockedVault

### DIFF
--- a/src/core/interfaces/IMultistrategyLockedVault.sol
+++ b/src/core/interfaces/IMultistrategyLockedVault.sol
@@ -108,9 +108,11 @@ interface IMultistrategyLockedVault is IMultistrategyVault {
      */
     function cancelRageQuitCooldownPeriodChange() external;
     /// @notice Get the pending rage quit cooldown period awaiting governance timelock
+    /// @return The pending rage quit cooldown period, in seconds, awaiting finalization after the timelock
     function getPendingRageQuitCooldownPeriod() external view returns (uint256);
 
     /// @notice Get the timestamp when the rage quit cooldown period change was initiated
+    /// @return The block timestamp at which the pending cooldown period change was initiated
     function getRageQuitCooldownPeriodChangeTimestamp() external view returns (uint256);
 
     /**


### PR DESCRIPTION
Two view getters in `IMultistrategyLockedVault` were missing `@return` docs, while the interface's other view getters (`getTransferableShares`, `getRageQuitableShares`) document theirs — an inconsistency.

## Change
- `src/core/interfaces/IMultistrategyLockedVault.sol` — adds 2 `@return` lines

```
  /// @notice Get the pending rage quit cooldown period awaiting governance timelock
+ /// @return The pending rage quit cooldown period, in seconds, awaiting finalization after the timelock
  function getPendingRageQuitCooldownPeriod() external view returns (uint256);

  /// @notice Get the timestamp when the rage quit cooldown period change was initiated
+ /// @return The block timestamp at which the pending cooldown period change was initiated
  function getRageQuitCooldownPeriodChangeTimestamp() external view returns (uint256);
```

The "seconds" unit matches the existing `@param _rageQuitCooldownPeriod Cooldown period in seconds` doc in the same interface.

## Safety
Comment only. No bytecode change. Verified `forge build --skip script` → `Compiler run successful!`.