### PR TITLE
docs: documentation cleanup (ProperQF @return docs + comment typo)

### DIFF
--- a/src/mechanisms/voting-strategy/ProperQF.sol
+++ b/src/mechanisms/voting-strategy/ProperQF.sol
@@ -80,31 +80,37 @@ abstract contract ProperQF {
 
     /// @notice Returns project aggregated sums
     /// @param projectId ID of the project to query
+    /// @return The aggregated quadratic-funding sums stored for the given project
     function projects(uint256 projectId) public view returns (Project memory) {
         return _getProperQFStorage().projects[projectId];
     }
 
     /// @notice Returns alpha numerator
+    /// @return The numerator of the alpha matching coefficient
     function alphaNumerator() public view returns (uint256) {
         return _getProperQFStorage().alphaNumerator;
     }
 
     /// @notice Returns alpha denominator
+    /// @return The denominator of the alpha matching coefficient
     function alphaDenominator() public view returns (uint256) {
         return _getProperQFStorage().alphaDenominator;
     }
 
     /// @notice Returns total quadratic sum across all projects
+    /// @return The total quadratic sum across all projects
     function totalQuadraticSum() public view returns (uint256) {
         return _getProperQFStorage().totalQuadraticSum;
     }
 
     /// @notice Returns total linear sum across all projects
+    /// @return The total linear sum across all projects
     function totalLinearSum() public view returns (uint256) {
         return _getProperQFStorage().totalLinearSum;
     }
 
     /// @notice Returns alpha-weighted total funding across all projects
+    /// @return The alpha-weighted total funding across all projects
     function totalFunding() public view returns (uint256) {
         return _getProperQFStorage().totalFunding;
     }

--- a/test/unit/strategies/yieldSkimming/Accounting.t.sol
+++ b/test/unit/strategies/yieldSkimming/Accounting.t.sol
@@ -1268,7 +1268,7 @@ contract AccountingTest is Setup {
         // User deposits
         mintAndDepositIntoStrategy(strategy, user1, depositAmount);
 
-        // make sure we dont burn dragon shares
+        // make sure we don't burn dragon shares
         vm.startPrank(management);
         strategy.setEnableBurning(false);
         vm.stopPrank();


### PR DESCRIPTION
Batched, comment-only documentation improvements. No bytecode or behavior change.

## Changes

### 1. `ProperQF.sol` — complete `@return` NatSpec on public getters
All six public view getters had a `@notice` but no `@return`, while the rest of the file documents `@return`. Added the missing lines (descriptions mirror each function's existing `@notice`):

| Function | Added `@return` |
|----------|-----------------|
| `projects(uint256)` | The aggregated quadratic-funding sums stored for the given project |
| `alphaNumerator()` | The numerator of the alpha matching coefficient |
| `alphaDenominator()` | The denominator of the alpha matching coefficient |
| `totalQuadraticSum()` | The total quadratic sum across all projects |
| `totalLinearSum()` | The total linear sum across all projects |
| `totalFunding()` | The alpha-weighted total funding across all projects |

### 2. `Accounting.t.sol` — comment typo
`// make sure we dont burn dragon shares` → `don't`.

## Safety
Comments only. `forge build --skip script` → `Compiler run successful!`; `solhint` reports no new issues (one pre-existing ordering warning, unrelated).