### PR TITLE
docs: add @return docs to factory getByDeployer getters

### DIFF
--- a/src/factories/AddressSetFactory.sol
+++ b/src/factories/AddressSetFactory.sol
@@ -57,6 +57,7 @@ contract AddressSetFactory {
 
     /// @notice Returns all AddressSets deployed by a specific address
     /// @param deployer Deployer address
+    /// @return Array of AddressSetInfo entries for every AddressSet deployed by the given deployer
     function getAddressSetsByDeployer(address deployer) external view returns (AddressSetInfo[] memory) {
         return addressSets[deployer];
     }

--- a/src/factories/RegenEarningPowerCalculatorFactory.sol
+++ b/src/factories/RegenEarningPowerCalculatorFactory.sol
@@ -91,6 +91,7 @@ contract RegenEarningPowerCalculatorFactory {
 
     /// @notice Returns all calculators deployed by a specific address
     /// @param deployer Deployer address
+    /// @return Array of CalculatorInfo entries for every calculator deployed by the given deployer
     function getCalculatorsByDeployer(address deployer) external view returns (CalculatorInfo[] memory) {
         return calculators[deployer];
     }

--- a/src/factories/RegenStakerFactory.sol
+++ b/src/factories/RegenStakerFactory.sol
@@ -159,6 +159,7 @@ contract RegenStakerFactory {
 
     /// @notice Returns all RegenStakers deployed by a specific address
     /// @param deployer Deployer address
+    /// @return Array of StakerInfo entries for every RegenStaker deployed by the given deployer
     function getStakersByDeployer(address deployer) external view returns (StakerInfo[] memory) {
         return stakers[deployer];
     }


### PR DESCRIPTION
Batched, comment-only documentation completeness fix across three factories. Each enumeration getter had `@notice` + `@param` but no `@return`, while its file documents `@return` elsewhere.

## Changes (one `@return` line each)

| File | Function | Added `@return` |
|------|----------|-----------------|
| `AddressSetFactory.sol` | `getAddressSetsByDeployer` | Array of `AddressSetInfo` entries for every AddressSet deployed by the given deployer |
| `RegenEarningPowerCalculatorFactory.sol` | `getCalculatorsByDeployer` | Array of `CalculatorInfo` entries for every calculator deployed by the given deployer |
| `RegenStakerFactory.sol` | `getStakersByDeployer` | Array of `StakerInfo` entries for every RegenStaker deployed by the given deployer |

Descriptions follow each function's existing `@notice` and return type.

## Safety
Comments only. No bytecode change. Verified `forge build --skip script` → `Compiler run successful!`; `solhint` reports no new issues (pre-existing struct-packing/ordering warnings only).