### PR TITLE
docs: document owner/return on maxWithdraw & maxRedeem ABI-compat overloads

### DIFF
--- a/src/core/TokenizedStrategy.sol
+++ b/src/core/TokenizedStrategy.sol
@@ -932,6 +932,8 @@ abstract contract TokenizedStrategy {
      * @notice Variable `maxLoss` is ignored.
      * @dev Accepts a `maxLoss` variable in order to match the multi
      * strategy vaults ABI.
+     * @param owner Address that owns the shares
+     * @return Maximum assets that can be withdrawn (the `maxLoss` argument is ignored)
      */
     function maxWithdraw(address owner, uint256 /*maxLoss*/) external view returns (uint256) {
         return _maxWithdraw(_strategyStorage(), owner);
@@ -950,6 +952,8 @@ abstract contract TokenizedStrategy {
      * @notice Variable `maxLoss` is ignored.
      * @dev Accepts a `maxLoss` variable in order to match the multi
      * strategy vaults ABI.
+     * @param owner Address that owns the shares
+     * @return Maximum shares that can be redeemed (the `maxLoss` argument is ignored)
      */
     function maxRedeem(address owner, uint256 /*maxLoss*/) external view returns (uint256) {
         return _maxRedeem(_strategyStorage(), owner);


### PR DESCRIPTION
The two-argument `maxWithdraw`/`maxRedeem` overloads (which accept and ignore `maxLoss` for multistrategy-vault ABI compatibility) documented only that `maxLoss` is ignored — omitting `@param owner` and `@return`, which their primary single-argument versions document. Completes their NatSpec for consistency.

## Changes (`src/core/TokenizedStrategy.sol`)

| Function | Added |
|----------|-------|
| `maxWithdraw(address owner, uint256 /*maxLoss*/)` | `@param owner` + `@return` (Maximum assets withdrawable; `maxLoss` ignored) |
| `maxRedeem(address owner, uint256 /*maxLoss*/)` | `@param owner` + `@return` (Maximum shares redeemable; `maxLoss` ignored) |

Descriptions mirror the primary single-arg `maxWithdraw`/`maxRedeem` docs in the same file.

## Safety
Comments only. No bytecode change. Verified `forge build --skip script` → `Compiler run successful!`; `solhint` reports 0 errors and no new warnings.