### PR TITLE
docs: document params and returns on MultistrategyLockedVault withdraw/redeem

### DIFF
--- a/src/core/MultistrategyLockedVault.sol
+++ b/src/core/MultistrategyLockedVault.sol
@@ -361,6 +361,12 @@ contract MultistrategyLockedVault is MultistrategyVault, IMultistrategyLockedVau
 
     /**
      * @notice Override withdrawal functions to handle custodied shares
+     * @param assets Amount of assets to withdraw
+     * @param receiver Address to receive the withdrawn assets
+     * @param owner Address whose shares will be burned
+     * @param maxLoss Maximum acceptable loss in basis points (0-10000, default 0 = no loss)
+     * @param strategiesArray Optional custom withdrawal queue (empty = use default)
+     * @return Amount of shares actually burned from owner
      */
     function withdraw(
         uint256 assets,
@@ -377,6 +383,12 @@ contract MultistrategyLockedVault is MultistrategyVault, IMultistrategyLockedVau
 
     /**
      * @notice Override redeem function to handle custodied shares
+     * @param shares Exact amount of shares to burn
+     * @param receiver Address to receive the withdrawn assets
+     * @param owner Address whose shares will be burned
+     * @param maxLoss Maximum acceptable loss in basis points (0-10000, default 10000 = accept all)
+     * @param strategiesArray Optional custom withdrawal queue (empty = use default)
+     * @return Amount of assets actually withdrawn and sent to receiver
      */
     function redeem(
         uint256 shares,


### PR DESCRIPTION
The `withdraw()` and `redeem()` overrides in `MultistrategyLockedVault` carried only a one-line `@notice` and documented none of their five parameters or their return value. This adds full `@param`/`@return` NatSpec.

## Change
- `src/core/MultistrategyLockedVault.sol` — `withdraw` (+6 doc lines) and `redeem` (+6 doc lines)

Descriptions mirror the canonical wording on the base `MultistrategyVault.withdraw`/`redeem` functions these override (including the differing `maxLoss` defaults: `withdraw` 0 = no loss, `redeem` 10000 = accept all).

## Safety
Comments only. No bytecode change. Verified `forge build --skip script` → `Compiler run successful!`; `solhint` reports 0 errors and no new warnings.