### PR TITLE
test(allocation): modularize quadratic voting fixtures

### DIFF
--- a/test/unit/mechanisms/allocation/DecimalConversionTest.t.sol
+++ b/test/unit/mechanisms/allocation/DecimalConversionTest.t.sol
@@ -1,13 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {AllocationTestHelpers} from "./utils/AllocationTestHelpers.sol";
 
 /// @title Mock ERC20 token with configurable decimals
 contract MockTokenWithDecimals is ERC20 {
@@ -27,17 +25,13 @@ contract MockTokenWithDecimals is ERC20 {
 }
 
 /// @title Test decimal conversion in voting power calculation
-contract DecimalConversionTest is Test {
+contract DecimalConversionTest is AllocationTestHelpers {
     AllocationMechanismFactory factory;
     MockTokenWithDecimals token6; // 6 decimals (USDC-like)
     MockTokenWithDecimals token8; // 8 decimals (Bitcoin-like)
     MockTokenWithDecimals token18; // 18 decimals (ETH-like)
 
     address alice = address(0x1);
-
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
 
     function setUp() public {
         factory = new AllocationMechanismFactory();
@@ -53,20 +47,22 @@ contract DecimalConversionTest is Test {
     }
 
     function deployQuadraticMechanismWithToken(IERC20 asset) internal returns (QuadraticVotingMechanism) {
-        AllocationConfig memory config = AllocationConfig({
-            asset: asset,
-            name: "Test Quadratic Mechanism",
-            symbol: "TESTQ",
-            votingDelay: 100,
-            votingPeriod: 1000,
-            quorumShares: 500,
-            timelockDelay: 1 days,
-            gracePeriod: 7 days,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100);
-        return QuadraticVotingMechanism(payable(mechanismAddr));
+        return _deployQuadraticVoting(
+            factory,
+            _config({
+                asset: asset,
+                name: "Test Quadratic Mechanism",
+                symbol: "TESTQ",
+                votingDelay: 100,
+                votingPeriod: 1000,
+                quorumShares: 500,
+                timelockDelay: 1 days,
+                gracePeriod: 7 days,
+                owner: address(0)
+            }),
+            50,
+            100
+        );
     }
 
     /// @notice Test that 6-decimal tokens are properly scaled to 18 decimals (Quadratic)

--- a/test/unit/mechanisms/allocation/DecimalConversionTest.t.sol
+++ b/test/unit/mechanisms/allocation/DecimalConversionTest.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {AllocationTestHelpers} from "./utils/AllocationTestHelpers.sol";
+import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { AllocationTestHelpers } from "./utils/AllocationTestHelpers.sol";
 
 /// @title Mock ERC20 token with configurable decimals
 contract MockTokenWithDecimals is ERC20 {
@@ -47,22 +47,23 @@ contract DecimalConversionTest is AllocationTestHelpers {
     }
 
     function deployQuadraticMechanismWithToken(IERC20 asset) internal returns (QuadraticVotingMechanism) {
-        return _deployQuadraticVoting(
-            factory,
-            _config({
-                asset: asset,
-                name: "Test Quadratic Mechanism",
-                symbol: "TESTQ",
-                votingDelay: 100,
-                votingPeriod: 1000,
-                quorumShares: 500,
-                timelockDelay: 1 days,
-                gracePeriod: 7 days,
-                owner: address(0)
-            }),
-            50,
-            100
-        );
+        return
+            _deployQuadraticVoting(
+                factory,
+                _config({
+                    asset: asset,
+                    name: "Test Quadratic Mechanism",
+                    symbol: "TESTQ",
+                    votingDelay: 100,
+                    votingPeriod: 1000,
+                    quorumShares: 500,
+                    timelockDelay: 1 days,
+                    gracePeriod: 7 days,
+                    owner: address(0)
+                }),
+                50,
+                100
+            );
     }
 
     /// @notice Test that 6-decimal tokens are properly scaled to 18 decimals (Quadratic)

--- a/test/unit/mechanisms/allocation/DuplicatePreventionTest.t.sol
+++ b/test/unit/mechanisms/allocation/DuplicatePreventionTest.t.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {AllocationConfig} from "src/mechanisms/BaseAllocationMechanism.sol";
+import {AllocationTestHelpers} from "./utils/AllocationTestHelpers.sol";
 
-contract DuplicatePreventionTest is Test {
+contract DuplicatePreventionTest is AllocationTestHelpers {
     AllocationMechanismFactory factory;
     ERC20Mock token;
 
@@ -17,7 +17,7 @@ contract DuplicatePreventionTest is Test {
     }
 
     function testDuplicatePrevention() public {
-        AllocationConfig memory config = AllocationConfig({
+        AllocationConfig memory config = _config({
             asset: IERC20(address(token)),
             name: "Test Mechanism",
             symbol: "TEST",
@@ -47,7 +47,7 @@ contract DuplicatePreventionTest is Test {
     }
 
     function testPredictMechanismAddress() public {
-        AllocationConfig memory config = AllocationConfig({
+        AllocationConfig memory config = _config({
             asset: IERC20(address(token)),
             name: "Predictable Mechanism",
             symbol: "PRED",

--- a/test/unit/mechanisms/allocation/DuplicatePreventionTest.t.sol
+++ b/test/unit/mechanisms/allocation/DuplicatePreventionTest.t.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
-import {AllocationConfig} from "src/mechanisms/BaseAllocationMechanism.sol";
-import {AllocationTestHelpers} from "./utils/AllocationTestHelpers.sol";
+import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
+import { AllocationTestHelpers } from "./utils/AllocationTestHelpers.sol";
 
 contract DuplicatePreventionTest is AllocationTestHelpers {
     AllocationMechanismFactory factory;

--- a/test/unit/mechanisms/allocation/EIP712SignatureTest.t.sol
+++ b/test/unit/mechanisms/allocation/EIP712SignatureTest.t.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
-import {AllocationTestHelpers} from "./utils/AllocationTestHelpers.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { AllocationTestHelpers } from "./utils/AllocationTestHelpers.sol";
 
 /// @title EIP712 Signature Tests
 /// @notice Comprehensive tests for EIP-2612 style signature functionality
@@ -18,9 +18,10 @@ contract EIP712SignatureTest is AllocationTestHelpers {
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     bytes32 private constant SIGNUP_TYPEHASH =
         keccak256("Signup(address user,address payer,uint256 deposit,uint256 nonce,uint256 deadline)");
-    bytes32 private constant CAST_VOTE_TYPEHASH = keccak256(
-        "CastVote(address voter,uint256 proposalId,uint8 choice,uint256 weight,address expectedRecipient,uint256 nonce,uint256 deadline)"
-    );
+    bytes32 private constant CAST_VOTE_TYPEHASH =
+        keccak256(
+            "CastVote(address voter,uint256 proposalId,uint8 choice,uint256 weight,address expectedRecipient,uint256 nonce,uint256 deadline)"
+        );
     string private constant EIP712_VERSION = "1";
 
     // Test contracts
@@ -81,17 +82,24 @@ contract EIP712SignatureTest is AllocationTestHelpers {
     // ============ EIP712 Helper Functions ============
 
     function _computeDomainSeparator(string memory name, address verifyingContract) internal view returns (bytes32) {
-        return keccak256(
-            abi.encode(
-                TYPE_HASH, keccak256(bytes(name)), keccak256(bytes(EIP712_VERSION)), block.chainid, verifyingContract
-            )
-        );
+        return
+            keccak256(
+                abi.encode(
+                    TYPE_HASH,
+                    keccak256(bytes(name)),
+                    keccak256(bytes(EIP712_VERSION)),
+                    block.chainid,
+                    verifyingContract
+                )
+            );
     }
 
-    function _getSignupDigest(address user, uint256 deposit, uint256 nonce, uint256 deadline)
-        internal
-        returns (bytes32)
-    {
+    function _getSignupDigest(
+        address user,
+        uint256 deposit,
+        uint256 nonce,
+        uint256 deadline
+    ) internal returns (bytes32) {
         bytes32 structHash = keccak256(abi.encode(SIGNUP_TYPEHASH, user, user, deposit, nonce, deadline));
         bytes32 domainSeparator = _tokenized(address(mechanism)).DOMAIN_SEPARATOR();
         return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
@@ -308,10 +316,17 @@ contract EIP712SignatureTest is AllocationTestHelpers {
         (uint8 v, bytes32 r, bytes32 s) = _signDigest(digest, ALICE_PRIVATE_KEY);
 
         // Cast vote with signature
-        _tokenized(address(mechanism))
-            .castVoteWithSignature(
-                alice, pid, TokenizedAllocationMechanism.VoteType.For, weight, address(0x123), deadline, v, r, s
-            );
+        _tokenized(address(mechanism)).castVoteWithSignature(
+            alice,
+            pid,
+            TokenizedAllocationMechanism.VoteType.For,
+            weight,
+            address(0x123),
+            deadline,
+            v,
+            r,
+            s
+        );
 
         // Verify vote was recorded
         assertEq(
@@ -361,14 +376,28 @@ contract EIP712SignatureTest is AllocationTestHelpers {
                 uint8 choice = uint8(voteTypes[i]);
                 uint256 weight = 50;
 
-                bytes32 digest =
-                    _getCastVoteDigest(users[i], pids[i], choice, weight, address(uint160(0x100 + i)), nonce, deadline);
+                bytes32 digest = _getCastVoteDigest(
+                    users[i],
+                    pids[i],
+                    choice,
+                    weight,
+                    address(uint160(0x100 + i)),
+                    nonce,
+                    deadline
+                );
                 (uint8 v, bytes32 r, bytes32 s) = _signDigest(digest, privateKeys[i]);
 
-                _tokenized(address(mechanism))
-                    .castVoteWithSignature(
-                        users[i], pids[i], voteTypes[i], weight, address(uint160(0x100 + i)), deadline, v, r, s
-                    );
+                _tokenized(address(mechanism)).castVoteWithSignature(
+                    users[i],
+                    pids[i],
+                    voteTypes[i],
+                    weight,
+                    address(uint160(0x100 + i)),
+                    deadline,
+                    v,
+                    r,
+                    s
+                );
             }
 
             // Verify votes were recorded - each user voted with weight 50, so cost is 50*50 = 2500
@@ -403,10 +432,17 @@ contract EIP712SignatureTest is AllocationTestHelpers {
         s = bytes32(0);
 
         vm.expectRevert(abi.encodeWithSelector(TokenizedAllocationMechanism.InvalidSigner.selector, address(0), alice));
-        _tokenized(address(mechanism))
-            .castVoteWithSignature(
-                alice, pid, TokenizedAllocationMechanism.VoteType.For, 100, address(0x123), deadline, v, r, s
-            );
+        _tokenized(address(mechanism)).castVoteWithSignature(
+            alice,
+            pid,
+            TokenizedAllocationMechanism.VoteType.For,
+            100,
+            address(0x123),
+            deadline,
+            v,
+            r,
+            s
+        );
     }
 
     function test_CastVoteWithSignature_ExpiredDeadline() public {
@@ -429,10 +465,17 @@ contract EIP712SignatureTest is AllocationTestHelpers {
         vm.expectRevert(
             abi.encodeWithSelector(TokenizedAllocationMechanism.ExpiredSignature.selector, deadline, block.timestamp)
         );
-        _tokenized(address(mechanism))
-            .castVoteWithSignature(
-                alice, pid, TokenizedAllocationMechanism.VoteType.For, 100, address(0x123), deadline, v, r, s
-            );
+        _tokenized(address(mechanism)).castVoteWithSignature(
+            alice,
+            pid,
+            TokenizedAllocationMechanism.VoteType.For,
+            100,
+            address(0x123),
+            deadline,
+            v,
+            r,
+            s
+        );
     }
 
     function test_CastVoteWithSignature_ReplayAttack() public {
@@ -454,17 +497,31 @@ contract EIP712SignatureTest is AllocationTestHelpers {
         (uint8 v, bytes32 r, bytes32 s) = _signDigest(digest, ALICE_PRIVATE_KEY);
 
         // First vote succeeds
-        _tokenized(address(mechanism))
-            .castVoteWithSignature(
-                alice, pid1, TokenizedAllocationMechanism.VoteType.For, 100, address(0x123), deadline, v, r, s
-            );
+        _tokenized(address(mechanism)).castVoteWithSignature(
+            alice,
+            pid1,
+            TokenizedAllocationMechanism.VoteType.For,
+            100,
+            address(0x123),
+            deadline,
+            v,
+            r,
+            s
+        );
 
         // Try to replay - should fail due to nonce mismatch
         vm.expectRevert();
-        _tokenized(address(mechanism))
-            .castVoteWithSignature(
-                alice, pid1, TokenizedAllocationMechanism.VoteType.For, 100, address(0x123), deadline, v, r, s
-            );
+        _tokenized(address(mechanism)).castVoteWithSignature(
+            alice,
+            pid1,
+            TokenizedAllocationMechanism.VoteType.For,
+            100,
+            address(0x123),
+            deadline,
+            v,
+            r,
+            s
+        );
     }
 
     // ============ Integration Tests ============
@@ -497,14 +554,23 @@ contract EIP712SignatureTest is AllocationTestHelpers {
         (uint8 vv, bytes32 vr, bytes32 vs) = _signDigest(voteDigest, ALICE_PRIVATE_KEY);
 
         vm.prank(relayer);
-        _tokenized(address(mechanism))
-            .castVoteWithSignature(
-                alice, pid, TokenizedAllocationMechanism.VoteType.For, 200, address(0x123), voteDeadline, vv, vr, vs
-            );
+        _tokenized(address(mechanism)).castVoteWithSignature(
+            alice,
+            pid,
+            TokenizedAllocationMechanism.VoteType.For,
+            200,
+            address(0x123),
+            voteDeadline,
+            vv,
+            vr,
+            vs
+        );
 
         // Verify final state
         assertEq(
-            _tokenized(address(mechanism)).votingPower(alice), DEPOSIT_AMOUNT - 200 * 200, "Voting power incorrect"
+            _tokenized(address(mechanism)).votingPower(alice),
+            DEPOSIT_AMOUNT - 200 * 200,
+            "Voting power incorrect"
         );
         assertEq(_tokenized(address(mechanism)).nonces(alice), signupNonce + 2, "Nonce should increment twice");
     }
@@ -545,10 +611,17 @@ contract EIP712SignatureTest is AllocationTestHelpers {
         bytes32 bobVoteDigest = _getCastVoteDigest(bob, pid, 1, 150, address(0x123), bobVoteNonce, bobVoteDeadline);
         (uint8 vv, bytes32 vr, bytes32 vs) = _signDigest(bobVoteDigest, BOB_PRIVATE_KEY);
 
-        _tokenized(address(mechanism))
-            .castVoteWithSignature(
-                bob, pid, TokenizedAllocationMechanism.VoteType.For, 150, address(0x123), bobVoteDeadline, vv, vr, vs
-            );
+        _tokenized(address(mechanism)).castVoteWithSignature(
+            bob,
+            pid,
+            TokenizedAllocationMechanism.VoteType.For,
+            150,
+            address(0x123),
+            bobVoteDeadline,
+            vv,
+            vr,
+            vs
+        );
 
         // Verify both votes recorded - Alice voted 100 (cost 100^2=10000), Bob voted 150 (cost 150^2=22500)
         assertEq(
@@ -593,10 +666,17 @@ contract EIP712SignatureTest is AllocationTestHelpers {
         bytes32 voteDigest = _getCastVoteDigest(alice, pid, 1, 50, address(0x123), voteNonce, voteDeadline);
         (uint8 vv, bytes32 vr, bytes32 vs) = _signDigest(voteDigest, ALICE_PRIVATE_KEY);
 
-        _tokenized(address(mechanism))
-            .castVoteWithSignature(
-                alice, pid, TokenizedAllocationMechanism.VoteType.For, 50, address(0x123), voteDeadline, vv, vr, vs
-            );
+        _tokenized(address(mechanism)).castVoteWithSignature(
+            alice,
+            pid,
+            TokenizedAllocationMechanism.VoteType.For,
+            50,
+            address(0x123),
+            voteDeadline,
+            vv,
+            vr,
+            vs
+        );
 
         assertEq(_tokenized(address(mechanism)).nonces(alice), initialNonce + 2, "Nonce should increment after vote");
     }

--- a/test/unit/mechanisms/allocation/EIP712SignatureTest.t.sol
+++ b/test/unit/mechanisms/allocation/EIP712SignatureTest.t.sol
@@ -1,28 +1,26 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {AllocationTestHelpers} from "./utils/AllocationTestHelpers.sol";
 
 /// @title EIP712 Signature Tests
 /// @notice Comprehensive tests for EIP-2612 style signature functionality
 /// @dev Tests signup and voting with signatures following EIP712 standard
-contract EIP712SignatureTest is Test {
+contract EIP712SignatureTest is AllocationTestHelpers {
     // Constants
     bytes32 private constant TYPE_HASH =
         keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)");
     bytes32 private constant SIGNUP_TYPEHASH =
         keccak256("Signup(address user,address payer,uint256 deposit,uint256 nonce,uint256 deadline)");
-    bytes32 private constant CAST_VOTE_TYPEHASH =
-        keccak256(
-            "CastVote(address voter,uint256 proposalId,uint8 choice,uint256 weight,address expectedRecipient,uint256 nonce,uint256 deadline)"
-        );
+    bytes32 private constant CAST_VOTE_TYPEHASH = keccak256(
+        "CastVote(address voter,uint256 proposalId,uint8 choice,uint256 weight,address expectedRecipient,uint256 nonce,uint256 deadline)"
+    );
     string private constant EIP712_VERSION = "1";
 
     // Test contracts
@@ -62,48 +60,38 @@ contract EIP712SignatureTest is Test {
         token.mint(charlie, INITIAL_BALANCE);
         vm.deal(relayer, 10 ether);
 
-        // Deploy mechanism
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Test Voting",
-            symbol: "TEST",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_SHARES,
-            timelockDelay: 1 days,
-            gracePeriod: 7 days,
-            owner: address(this)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 1, 1);
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-    }
-
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
+        mechanism = _deployQuadraticVoting(
+            factory,
+            _config({
+                asset: IERC20(address(token)),
+                name: "Test Voting",
+                symbol: "TEST",
+                votingDelay: VOTING_DELAY,
+                votingPeriod: VOTING_PERIOD,
+                quorumShares: QUORUM_SHARES,
+                timelockDelay: 1 days,
+                gracePeriod: 7 days,
+                owner: address(this)
+            }),
+            1,
+            1
+        );
     }
 
     // ============ EIP712 Helper Functions ============
 
     function _computeDomainSeparator(string memory name, address verifyingContract) internal view returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    TYPE_HASH,
-                    keccak256(bytes(name)),
-                    keccak256(bytes(EIP712_VERSION)),
-                    block.chainid,
-                    verifyingContract
-                )
-            );
+        return keccak256(
+            abi.encode(
+                TYPE_HASH, keccak256(bytes(name)), keccak256(bytes(EIP712_VERSION)), block.chainid, verifyingContract
+            )
+        );
     }
 
-    function _getSignupDigest(
-        address user,
-        uint256 deposit,
-        uint256 nonce,
-        uint256 deadline
-    ) internal returns (bytes32) {
+    function _getSignupDigest(address user, uint256 deposit, uint256 nonce, uint256 deadline)
+        internal
+        returns (bytes32)
+    {
         bytes32 structHash = keccak256(abi.encode(SIGNUP_TYPEHASH, user, user, deposit, nonce, deadline));
         bytes32 domainSeparator = _tokenized(address(mechanism)).DOMAIN_SEPARATOR();
         return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
@@ -320,17 +308,10 @@ contract EIP712SignatureTest is Test {
         (uint8 v, bytes32 r, bytes32 s) = _signDigest(digest, ALICE_PRIVATE_KEY);
 
         // Cast vote with signature
-        _tokenized(address(mechanism)).castVoteWithSignature(
-            alice,
-            pid,
-            TokenizedAllocationMechanism.VoteType.For,
-            weight,
-            address(0x123),
-            deadline,
-            v,
-            r,
-            s
-        );
+        _tokenized(address(mechanism))
+            .castVoteWithSignature(
+                alice, pid, TokenizedAllocationMechanism.VoteType.For, weight, address(0x123), deadline, v, r, s
+            );
 
         // Verify vote was recorded
         assertEq(
@@ -349,7 +330,7 @@ contract EIP712SignatureTest is Test {
         address[3] memory users = [alice, bob, charlie];
         uint256[3] memory privateKeys = [ALICE_PRIVATE_KEY, BOB_PRIVATE_KEY, CHARLIE_PRIVATE_KEY];
 
-        for (uint i = 0; i < users.length; i++) {
+        for (uint256 i = 0; i < users.length; i++) {
             vm.startPrank(users[i]);
             token.approve(address(mechanism), DEPOSIT_AMOUNT);
             _tokenized(address(mechanism)).signup(DEPOSIT_AMOUNT);
@@ -358,7 +339,7 @@ contract EIP712SignatureTest is Test {
 
         // Create proposals
         uint256[3] memory pids;
-        for (uint i = 0; i < 3; i++) {
+        for (uint256 i = 0; i < 3; i++) {
             pids[i] = _tokenized(address(mechanism)).propose(address(uint160(0x100 + i)), "Proposal");
         }
 
@@ -372,7 +353,7 @@ contract EIP712SignatureTest is Test {
             TokenizedAllocationMechanism.VoteType.For
         ];
 
-        for (uint i = 0; i < 3; i++) {
+        for (uint256 i = 0; i < 3; i++) {
             // Scope variables to reduce stack pressure
             {
                 uint256 nonce = _tokenized(address(mechanism)).nonces(users[i]);
@@ -380,28 +361,14 @@ contract EIP712SignatureTest is Test {
                 uint8 choice = uint8(voteTypes[i]);
                 uint256 weight = 50;
 
-                bytes32 digest = _getCastVoteDigest(
-                    users[i],
-                    pids[i],
-                    choice,
-                    weight,
-                    address(uint160(0x100 + i)),
-                    nonce,
-                    deadline
-                );
+                bytes32 digest =
+                    _getCastVoteDigest(users[i], pids[i], choice, weight, address(uint160(0x100 + i)), nonce, deadline);
                 (uint8 v, bytes32 r, bytes32 s) = _signDigest(digest, privateKeys[i]);
 
-                _tokenized(address(mechanism)).castVoteWithSignature(
-                    users[i],
-                    pids[i],
-                    voteTypes[i],
-                    weight,
-                    address(uint160(0x100 + i)),
-                    deadline,
-                    v,
-                    r,
-                    s
-                );
+                _tokenized(address(mechanism))
+                    .castVoteWithSignature(
+                        users[i], pids[i], voteTypes[i], weight, address(uint160(0x100 + i)), deadline, v, r, s
+                    );
             }
 
             // Verify votes were recorded - each user voted with weight 50, so cost is 50*50 = 2500
@@ -436,17 +403,10 @@ contract EIP712SignatureTest is Test {
         s = bytes32(0);
 
         vm.expectRevert(abi.encodeWithSelector(TokenizedAllocationMechanism.InvalidSigner.selector, address(0), alice));
-        _tokenized(address(mechanism)).castVoteWithSignature(
-            alice,
-            pid,
-            TokenizedAllocationMechanism.VoteType.For,
-            100,
-            address(0x123),
-            deadline,
-            v,
-            r,
-            s
-        );
+        _tokenized(address(mechanism))
+            .castVoteWithSignature(
+                alice, pid, TokenizedAllocationMechanism.VoteType.For, 100, address(0x123), deadline, v, r, s
+            );
     }
 
     function test_CastVoteWithSignature_ExpiredDeadline() public {
@@ -469,17 +429,10 @@ contract EIP712SignatureTest is Test {
         vm.expectRevert(
             abi.encodeWithSelector(TokenizedAllocationMechanism.ExpiredSignature.selector, deadline, block.timestamp)
         );
-        _tokenized(address(mechanism)).castVoteWithSignature(
-            alice,
-            pid,
-            TokenizedAllocationMechanism.VoteType.For,
-            100,
-            address(0x123),
-            deadline,
-            v,
-            r,
-            s
-        );
+        _tokenized(address(mechanism))
+            .castVoteWithSignature(
+                alice, pid, TokenizedAllocationMechanism.VoteType.For, 100, address(0x123), deadline, v, r, s
+            );
     }
 
     function test_CastVoteWithSignature_ReplayAttack() public {
@@ -501,31 +454,17 @@ contract EIP712SignatureTest is Test {
         (uint8 v, bytes32 r, bytes32 s) = _signDigest(digest, ALICE_PRIVATE_KEY);
 
         // First vote succeeds
-        _tokenized(address(mechanism)).castVoteWithSignature(
-            alice,
-            pid1,
-            TokenizedAllocationMechanism.VoteType.For,
-            100,
-            address(0x123),
-            deadline,
-            v,
-            r,
-            s
-        );
+        _tokenized(address(mechanism))
+            .castVoteWithSignature(
+                alice, pid1, TokenizedAllocationMechanism.VoteType.For, 100, address(0x123), deadline, v, r, s
+            );
 
         // Try to replay - should fail due to nonce mismatch
         vm.expectRevert();
-        _tokenized(address(mechanism)).castVoteWithSignature(
-            alice,
-            pid1,
-            TokenizedAllocationMechanism.VoteType.For,
-            100,
-            address(0x123),
-            deadline,
-            v,
-            r,
-            s
-        );
+        _tokenized(address(mechanism))
+            .castVoteWithSignature(
+                alice, pid1, TokenizedAllocationMechanism.VoteType.For, 100, address(0x123), deadline, v, r, s
+            );
     }
 
     // ============ Integration Tests ============
@@ -558,23 +497,14 @@ contract EIP712SignatureTest is Test {
         (uint8 vv, bytes32 vr, bytes32 vs) = _signDigest(voteDigest, ALICE_PRIVATE_KEY);
 
         vm.prank(relayer);
-        _tokenized(address(mechanism)).castVoteWithSignature(
-            alice,
-            pid,
-            TokenizedAllocationMechanism.VoteType.For,
-            200,
-            address(0x123),
-            voteDeadline,
-            vv,
-            vr,
-            vs
-        );
+        _tokenized(address(mechanism))
+            .castVoteWithSignature(
+                alice, pid, TokenizedAllocationMechanism.VoteType.For, 200, address(0x123), voteDeadline, vv, vr, vs
+            );
 
         // Verify final state
         assertEq(
-            _tokenized(address(mechanism)).votingPower(alice),
-            DEPOSIT_AMOUNT - 200 * 200,
-            "Voting power incorrect"
+            _tokenized(address(mechanism)).votingPower(alice), DEPOSIT_AMOUNT - 200 * 200, "Voting power incorrect"
         );
         assertEq(_tokenized(address(mechanism)).nonces(alice), signupNonce + 2, "Nonce should increment twice");
     }
@@ -615,17 +545,10 @@ contract EIP712SignatureTest is Test {
         bytes32 bobVoteDigest = _getCastVoteDigest(bob, pid, 1, 150, address(0x123), bobVoteNonce, bobVoteDeadline);
         (uint8 vv, bytes32 vr, bytes32 vs) = _signDigest(bobVoteDigest, BOB_PRIVATE_KEY);
 
-        _tokenized(address(mechanism)).castVoteWithSignature(
-            bob,
-            pid,
-            TokenizedAllocationMechanism.VoteType.For,
-            150,
-            address(0x123),
-            bobVoteDeadline,
-            vv,
-            vr,
-            vs
-        );
+        _tokenized(address(mechanism))
+            .castVoteWithSignature(
+                bob, pid, TokenizedAllocationMechanism.VoteType.For, 150, address(0x123), bobVoteDeadline, vv, vr, vs
+            );
 
         // Verify both votes recorded - Alice voted 100 (cost 100^2=10000), Bob voted 150 (cost 150^2=22500)
         assertEq(
@@ -670,17 +593,10 @@ contract EIP712SignatureTest is Test {
         bytes32 voteDigest = _getCastVoteDigest(alice, pid, 1, 50, address(0x123), voteNonce, voteDeadline);
         (uint8 vv, bytes32 vr, bytes32 vs) = _signDigest(voteDigest, ALICE_PRIVATE_KEY);
 
-        _tokenized(address(mechanism)).castVoteWithSignature(
-            alice,
-            pid,
-            TokenizedAllocationMechanism.VoteType.For,
-            50,
-            address(0x123),
-            voteDeadline,
-            vv,
-            vr,
-            vs
-        );
+        _tokenized(address(mechanism))
+            .castVoteWithSignature(
+                alice, pid, TokenizedAllocationMechanism.VoteType.For, 50, address(0x123), voteDeadline, vv, vr, vs
+            );
 
         assertEq(_tokenized(address(mechanism)).nonces(alice), initialNonce + 2, "Nonce should increment after vote");
     }

--- a/test/unit/mechanisms/allocation/MultipleSignupTest.t.sol
+++ b/test/unit/mechanisms/allocation/MultipleSignupTest.t.sol
@@ -1,50 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {QuadraticVotingTestBase} from "./utils/QuadraticVotingTestBase.sol";
 
 /// @title Multiple Signup Test
 /// @notice Tests that QuadraticVotingMechanism allows multiple signups while OctantQFMechanism prevents them
-contract MultipleSignupTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism quadraticMechanism;
-
-    address alice = address(0x1);
-
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
+contract MultipleSignupTest is QuadraticVotingTestBase {
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting("Multiple Signup Test", "MST", 100, 1000, 100 ether, 1 days, 7 days, 1, 2);
 
         // Fund alice
         token.mint(alice, 10000 ether);
-
-        // Deploy QuadraticVotingMechanism
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Multiple Signup Test",
-            symbol: "MST",
-            votingDelay: 100,
-            votingPeriod: 1000,
-            quorumShares: 100 ether,
-            timelockDelay: 1 days,
-            gracePeriod: 7 days,
-            owner: address(this)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 1, 2); // Alpha = 0.5
-        quadraticMechanism = QuadraticVotingMechanism(payable(mechanismAddr));
     }
 
     /// @notice Test that QuadraticVotingMechanism allows multiple signups
@@ -53,7 +20,7 @@ contract MultipleSignupTest is Test {
 
         // Get timeline info
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(quadraticMechanism)).votingDelay();
+        uint256 votingDelay = _tokenized().votingDelay();
         uint256 votingStartTime = deploymentTime + votingDelay;
 
         // Stay before voting starts for registration
@@ -61,25 +28,25 @@ contract MultipleSignupTest is Test {
 
         // First signup - should work
         vm.startPrank(alice);
-        token.approve(address(quadraticMechanism), 1000 ether);
-        _tokenized(address(quadraticMechanism)).signup(1000 ether);
+        token.approve(address(mechanism), 1000 ether);
+        _tokenized().signup(1000 ether);
 
-        uint256 powerAfterFirst = _tokenized(address(quadraticMechanism)).votingPower(alice);
+        uint256 powerAfterFirst = _tokenized().votingPower(alice);
         console.log("Power after first signup:", powerAfterFirst);
         assertEq(powerAfterFirst, 1000 ether, "First signup should give voting power");
 
         // Second signup - should also work and add to existing power
-        token.approve(address(quadraticMechanism), 500 ether);
-        _tokenized(address(quadraticMechanism)).signup(500 ether);
+        token.approve(address(mechanism), 500 ether);
+        _tokenized().signup(500 ether);
 
-        uint256 powerAfterSecond = _tokenized(address(quadraticMechanism)).votingPower(alice);
+        uint256 powerAfterSecond = _tokenized().votingPower(alice);
         console.log("Power after second signup:", powerAfterSecond);
         assertEq(powerAfterSecond, 1500 ether, "Second signup should add to existing power");
 
         // Third signup with zero deposit - should work
-        _tokenized(address(quadraticMechanism)).signup(0);
+        _tokenized().signup(0);
 
-        uint256 powerAfterThird = _tokenized(address(quadraticMechanism)).votingPower(alice);
+        uint256 powerAfterThird = _tokenized().votingPower(alice);
         console.log("Power after third signup (zero deposit):", powerAfterThird);
         assertEq(powerAfterThird, 1500 ether, "Zero deposit signup should not change power");
 

--- a/test/unit/mechanisms/allocation/MultipleSignupTest.t.sol
+++ b/test/unit/mechanisms/allocation/MultipleSignupTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {QuadraticVotingTestBase} from "./utils/QuadraticVotingTestBase.sol";
+import { QuadraticVotingTestBase } from "./utils/QuadraticVotingTestBase.sol";
 
 /// @title Multiple Signup Test
 /// @notice Tests that QuadraticVotingMechanism allows multiple signups while OctantQFMechanism prevents them

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/DebugQuorum.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/DebugQuorum.t.sol
@@ -1,74 +1,35 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
-contract DebugQuorum is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1);
-    address charlie = address(0x3);
-
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
+contract DebugQuorum is QuadraticVotingTestBase {
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting("Debug Test", "DEBUG", 10, 100, 500, 1000, 5000, 50, 100);
         token.mint(alice, 2000 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Debug Test",
-            symbol: "DEBUG",
-            votingDelay: 10,
-            votingPeriod: 100,
-            quorumShares: 500, // Adjusted for quadratic funding
-            timelockDelay: 1000,
-            gracePeriod: 5000,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-
-        // Set alice as keeper so she can create proposals
-        _tokenized(address(mechanism)).setKeeper(alice);
+        _tokenized().setKeeper(alice);
     }
 
     function testDebugQuorum() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup
-        vm.startPrank(alice);
-        token.approve(address(mechanism), 1000 ether);
-        _tokenized(address(mechanism)).signup(1000 ether);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Test");
-        vm.stopPrank();
+        _signup(alice, 1000 ether);
+        uint256 pid = _propose(alice, charlie, "Test");
 
         console.log("=== SETUP COMPLETE ===");
-        console.log("Alice voting power:", _tokenized(address(mechanism)).votingPower(alice));
-        console.log("Quorum requirement:", _tokenized(address(mechanism)).quorumShares());
+        console.log("Alice voting power:", _tokenized().votingPower(alice));
+        console.log("Quorum requirement:", _tokenized().quorumShares());
 
         // Try different vote weights to find minimum for quorum
         vm.warp(votingStartTime + 1);
-        vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 31, charlie); // 31^2 = 961 > 200 ether quorum
+        _vote(alice, pid, 31, charlie); // 31^2 = 961 > 200 ether quorum
 
         console.log("=== AFTER VOTING ===");
         console.log("Vote weight used: 31");
@@ -81,10 +42,7 @@ contract DebugQuorum is Test {
         uint256 linearFunding;
 
         try mechanism.getProposalFunding(pid) returns (
-            uint256 _sumContributions,
-            uint256 _sumSquareRoots,
-            uint256 _quadraticFunding,
-            uint256 _linearFunding
+            uint256 _sumContributions, uint256 _sumSquareRoots, uint256 _quadraticFunding, uint256 _linearFunding
         ) {
             sumContributions = _sumContributions;
             sumSquareRoots = _sumSquareRoots;
@@ -101,28 +59,25 @@ contract DebugQuorum is Test {
         // Calculate weighted funding (what quorum check uses - WRONG VERSION)
         uint256 alphaNumerator = 50;
         uint256 alphaDenominator = 100;
-        uint256 projectWeightedFunding = (quadraticFunding * alphaNumerator) /
-            alphaDenominator +
-            (linearFunding * (alphaDenominator - alphaNumerator)) /
-            alphaDenominator;
+        uint256 projectWeightedFunding = (quadraticFunding * alphaNumerator) / alphaDenominator
+            + (linearFunding * (alphaDenominator - alphaNumerator)) / alphaDenominator;
         console.log("Project weighted funding (WRONG - double alpha):", projectWeightedFunding);
         console.log("Meets quorum (wrong calc)?", projectWeightedFunding >= 200 ether);
 
         // Correct calculation: getTally already returns alpha-weighted quadratic
-        uint256 correctWeightedFunding = quadraticFunding +
-            (linearFunding * (alphaDenominator - alphaNumerator)) /
-            alphaDenominator;
+        uint256 correctWeightedFunding =
+            quadraticFunding + (linearFunding * (alphaDenominator - alphaNumerator)) / alphaDenominator;
         console.log("Project weighted funding (CORRECT):", correctWeightedFunding);
         console.log("Meets quorum (correct calc)?", correctWeightedFunding >= 200 ether);
 
         // Try to finalize
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check if we can queue
         console.log("=== FINALIZATION COMPLETE ===");
-        console.log("Proposal state:", uint(_tokenized(address(mechanism)).state(pid)));
+        console.log("Proposal state:", uint256(_tokenized().state(pid)));
         // 0=Pending, 1=Active, 2=Canceled, 3=Defeated, 4=Succeeded, 5=Queued, 6=Expired, 7=Executed
 
         try this.tryQueue(pid) {
@@ -133,7 +88,7 @@ contract DebugQuorum is Test {
     }
 
     function tryQueue(uint256 pid) external {
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success, "Queue failed");
     }
 }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/DebugQuorum.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/DebugQuorum.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 contract DebugQuorum is QuadraticVotingTestBase {
     function setUp() public {
@@ -42,7 +42,10 @@ contract DebugQuorum is QuadraticVotingTestBase {
         uint256 linearFunding;
 
         try mechanism.getProposalFunding(pid) returns (
-            uint256 _sumContributions, uint256 _sumSquareRoots, uint256 _quadraticFunding, uint256 _linearFunding
+            uint256 _sumContributions,
+            uint256 _sumSquareRoots,
+            uint256 _quadraticFunding,
+            uint256 _linearFunding
         ) {
             sumContributions = _sumContributions;
             sumSquareRoots = _sumSquareRoots;
@@ -59,20 +62,23 @@ contract DebugQuorum is QuadraticVotingTestBase {
         // Calculate weighted funding (what quorum check uses - WRONG VERSION)
         uint256 alphaNumerator = 50;
         uint256 alphaDenominator = 100;
-        uint256 projectWeightedFunding = (quadraticFunding * alphaNumerator) / alphaDenominator
-            + (linearFunding * (alphaDenominator - alphaNumerator)) / alphaDenominator;
+        uint256 projectWeightedFunding = (quadraticFunding * alphaNumerator) /
+            alphaDenominator +
+            (linearFunding * (alphaDenominator - alphaNumerator)) /
+            alphaDenominator;
         console.log("Project weighted funding (WRONG - double alpha):", projectWeightedFunding);
         console.log("Meets quorum (wrong calc)?", projectWeightedFunding >= 200 ether);
 
         // Correct calculation: getTally already returns alpha-weighted quadratic
-        uint256 correctWeightedFunding =
-            quadraticFunding + (linearFunding * (alphaDenominator - alphaNumerator)) / alphaDenominator;
+        uint256 correctWeightedFunding = quadraticFunding +
+            (linearFunding * (alphaDenominator - alphaNumerator)) /
+            alphaDenominator;
         console.log("Project weighted funding (CORRECT):", correctWeightedFunding);
         console.log("Meets quorum (correct calc)?", correctWeightedFunding >= 200 ether);
 
         // Try to finalize
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check if we can queue
@@ -88,7 +94,7 @@ contract DebugQuorum is QuadraticVotingTestBase {
     }
 
     function tryQueue(uint256 pid) external {
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success, "Queue failed");
     }
 }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingAccountingAuditTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingAccountingAuditTest.t.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
-import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
-import {AllocationTestHelpers} from "../utils/AllocationTestHelpers.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { AllocationTestHelpers } from "../utils/AllocationTestHelpers.sol";
 
 /// @title Quadratic Voting Accounting Audit Test
 /// @notice Comprehensive end-to-end test tracking every state change for auditor verification
@@ -232,11 +232,11 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
 
         // Proposal funding (if proposals exist) - use getTally() from ProperQF
         if (pid1 != 0) {
-            (,, uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(pid1);
+            (, , uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(pid1);
             state.proposal1Funding = p1QuadraticFunding + p1LinearFunding;
         }
         if (pid2 != 0) {
-            (,, uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(pid2);
+            (, , uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(pid2);
             state.proposal2Funding = p2QuadraticFunding + p2LinearFunding;
         }
 
@@ -266,7 +266,8 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         if (keccak256(bytes(phase)) == keccak256(bytes("FINAL"))) {
             // After all redemptions, mechanism should have minimal dust (<=2 wei)
             assertTrue(
-                state.totalMechanismAssets <= 2, string(abi.encodePacked("Final asset cleanup failed in ", phase))
+                state.totalMechanismAssets <= 2,
+                string(abi.encodePacked("Final asset cleanup failed in ", phase))
             );
         } else if (keccak256(bytes(phase)) == keccak256(bytes("POST_REDEMPTION_1"))) {
             // After first redemption, mechanism should have ~half the assets
@@ -380,27 +381,51 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
 
         // Alice votes
         vm.prank(alice);
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid1, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient1);
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid1,
+            TokenizedAllocationMechanism.VoteType.For,
+            VOTE_WEIGHT,
+            recipient1
+        );
         vm.prank(alice);
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid2, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient2);
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid2,
+            TokenizedAllocationMechanism.VoteType.For,
+            VOTE_WEIGHT,
+            recipient2
+        );
 
         // Bob votes
         vm.prank(bob);
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid1, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient1);
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid1,
+            TokenizedAllocationMechanism.VoteType.For,
+            VOTE_WEIGHT,
+            recipient1
+        );
         vm.prank(bob);
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid2, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient2);
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid2,
+            TokenizedAllocationMechanism.VoteType.For,
+            VOTE_WEIGHT,
+            recipient2
+        );
 
         // Charlie votes
         vm.prank(charlie);
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid1, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient1);
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid1,
+            TokenizedAllocationMechanism.VoteType.For,
+            VOTE_WEIGHT,
+            recipient1
+        );
         vm.prank(charlie);
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid2, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient2);
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid2,
+            TokenizedAllocationMechanism.VoteType.For,
+            VOTE_WEIGHT,
+            recipient2
+        );
 
         AccountingState memory postVotingState = _captureAccountingState(currentTestCtx.pid1, currentTestCtx.pid2);
         _logAccountingState("POST_VOTING", postVotingState);
@@ -448,7 +473,9 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         uint256 currentAssets = postVotingState.totalMechanismAssets; // User deposits = totalLinearSum
 
         // For alpha = 1: matching pool = totalQuadraticSum - totalLinearSum
-        currentTestCtx.matchingPoolNeeded = (currentTestCtx.totalQuadraticSum - currentTestCtx.totalLinearSum) * 1 ether;
+        currentTestCtx.matchingPoolNeeded =
+            (currentTestCtx.totalQuadraticSum - currentTestCtx.totalLinearSum) *
+            1 ether;
         currentTestCtx.totalAssetsNeeded = currentTestCtx.totalQuadraticSum * 1 ether; // For 1:1 ratio
 
         console.log("Total quadratic sum:", currentTestCtx.totalQuadraticSum);
@@ -465,10 +492,13 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         console.log("=== PHASE 5: FINALIZATION ===");
         vm.warp(currentTestCtx.startTime + VOTING_DELAY + VOTING_PERIOD + 1);
 
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
-        AccountingState memory postFinalizationState = _captureAccountingState(currentTestCtx.pid1, currentTestCtx.pid2);
+        AccountingState memory postFinalizationState = _captureAccountingState(
+            currentTestCtx.pid1,
+            currentTestCtx.pid2
+        );
         _logAccountingState("POST_FINALIZATION", postFinalizationState);
         _verifyAccountingInvariants(postFinalizationState, "POST_FINALIZATION");
 
@@ -484,12 +514,14 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
 
         currentTestCtx.queueTimestamp = block.timestamp;
 
-        (bool success1,) =
-            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1));
+        (bool success1, ) = address(mechanism).call(
+            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1)
+        );
         require(success1, "Queue proposal 1 failed");
 
-        (bool success2,) =
-            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2));
+        (bool success2, ) = address(mechanism).call(
+            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2)
+        );
         require(success2, "Queue proposal 2 failed");
 
         AccountingState memory postQueueingState = _captureAccountingState(currentTestCtx.pid1, currentTestCtx.pid2);
@@ -499,13 +531,19 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         // Verify share minting - should be exact with alpha = 1
         uint256 expectedSharesPerRecipient = currentTestCtx.expectedFundingPerProposal; // 3600 shares per recipient
         assertEq(
-            postQueueingState.recipient1Shares, expectedSharesPerRecipient, "Recipient1 should get exactly 3600 shares"
+            postQueueingState.recipient1Shares,
+            expectedSharesPerRecipient,
+            "Recipient1 should get exactly 3600 shares"
         );
         assertEq(
-            postQueueingState.recipient2Shares, expectedSharesPerRecipient, "Recipient2 should get exactly 3600 shares"
+            postQueueingState.recipient2Shares,
+            expectedSharesPerRecipient,
+            "Recipient2 should get exactly 3600 shares"
         );
         assertEq(
-            postQueueingState.totalSharesSupply, expectedSharesPerRecipient * 2, "Total shares should be exactly 7200"
+            postQueueingState.totalSharesSupply,
+            expectedSharesPerRecipient * 2,
+            "Total shares should be exactly 7200"
         );
 
         // Verify timelock setup
@@ -531,7 +569,8 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         currentTestCtx.totalAssets = postQueueingState.totalMechanismAssets;
         currentTestCtx.totalShares = postQueueingState.totalSharesSupply;
         currentTestCtx.expectedAssetsPerRecipient =
-            (expectedSharesPerRecipient * currentTestCtx.totalAssets) / currentTestCtx.totalShares;
+            (expectedSharesPerRecipient * currentTestCtx.totalAssets) /
+            currentTestCtx.totalShares;
 
         console.log("Post-queuing total assets:", currentTestCtx.totalAssets);
         console.log("Post-queuing total shares:", currentTestCtx.totalShares);
@@ -552,15 +591,18 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         currentTestCtx.recipient1ActualShares = postQueueingState.recipient1Shares;
 
         vm.prank(recipient1);
-        currentTestCtx.recipient1Assets =
-            _tokenized(address(mechanism)).redeem(currentTestCtx.recipient1ActualShares, recipient1, recipient1);
+        currentTestCtx.recipient1Assets = _tokenized(address(mechanism)).redeem(
+            currentTestCtx.recipient1ActualShares,
+            recipient1,
+            recipient1
+        );
 
         AccountingState memory postRedemption1State = _captureAccountingState(currentTestCtx.pid1, currentTestCtx.pid2);
         _logAccountingState("POST_REDEMPTION_1", postRedemption1State);
 
         // Verify recipient1 redemption accounting - exact proportional calculation
-        uint256 expectedRecipient1Assets =
-            (currentTestCtx.recipient1ActualShares * currentTestCtx.totalAssets) / currentTestCtx.totalShares;
+        uint256 expectedRecipient1Assets = (currentTestCtx.recipient1ActualShares * currentTestCtx.totalAssets) /
+            currentTestCtx.totalShares;
         assertEq(
             currentTestCtx.recipient1Assets,
             expectedRecipient1Assets,
@@ -584,16 +626,19 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         currentTestCtx.recipient2ActualShares = postRedemption1State.recipient2Shares;
 
         vm.prank(recipient2);
-        currentTestCtx.recipient2Assets =
-            _tokenized(address(mechanism)).redeem(currentTestCtx.recipient2ActualShares, recipient2, recipient2);
+        currentTestCtx.recipient2Assets = _tokenized(address(mechanism)).redeem(
+            currentTestCtx.recipient2ActualShares,
+            recipient2,
+            recipient2
+        );
 
         AccountingState memory finalState = _captureAccountingState(currentTestCtx.pid1, currentTestCtx.pid2);
         _logAccountingState("FINAL", finalState);
         _verifyAccountingInvariants(finalState, "FINAL");
 
         // Verify recipient2 redemption accounting - exact proportional calculation
-        uint256 expectedRecipient2Assets =
-            (currentTestCtx.recipient2ActualShares * currentTestCtx.totalAssets) / currentTestCtx.totalShares;
+        uint256 expectedRecipient2Assets = (currentTestCtx.recipient2ActualShares * currentTestCtx.totalAssets) /
+            currentTestCtx.totalShares;
         assertEq(
             currentTestCtx.recipient2Assets,
             expectedRecipient2Assets,
@@ -613,7 +658,8 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         // Verify good shares:asset ratio achieved using test context
         currentTestCtx.totalAssetsDistributed = currentTestCtx.recipient1Assets + currentTestCtx.recipient2Assets;
         currentTestCtx.totalSharesRedeemed =
-            currentTestCtx.recipient1ActualShares + currentTestCtx.recipient2ActualShares;
+            currentTestCtx.recipient1ActualShares +
+            currentTestCtx.recipient2ActualShares;
 
         console.log("Total assets distributed:", currentTestCtx.totalAssetsDistributed);
         console.log("Total shares redeemed:", currentTestCtx.totalSharesRedeemed);
@@ -621,7 +667,9 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
 
         // Verify exact asset conservation - all assets distributed, none lost
         assertEq(
-            currentTestCtx.totalAssetsDistributed, currentTestCtx.totalAssets, "All assets must be distributed exactly"
+            currentTestCtx.totalAssetsDistributed,
+            currentTestCtx.totalAssets,
+            "All assets must be distributed exactly"
         );
         assertEq(currentTestCtx.totalSharesRedeemed, currentTestCtx.totalShares, "All shares must be redeemed exactly");
 
@@ -724,7 +772,7 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         // Note: This requires the mechanism to be deployed with the correct alpha initially
         // For this test, we'll verify the calculation instead
 
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // ==================== VERIFY OPTIMAL FUNDING ====================
@@ -734,10 +782,10 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         _verifyConstrainedFunding(currentTestCtx);
 
         // Queue proposals
-        (bool success1,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
+        (bool success1, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
         require(success1, "Queue project 1 failed");
 
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
         require(success2, "Queue project 2 failed");
 
         // ==================== VERIFY EXACT ACCOUNTING ====================
@@ -779,8 +827,11 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         uint256 recipient1MaxRedeem = _tokenized(address(mechanism)).maxRedeem(recipient1);
         if (recipient1MaxRedeem > 0) {
             vm.prank(recipient1);
-            currentTestCtx.recipient1Assets += _tokenized(address(mechanism))
-                .redeem(recipient1MaxRedeem, recipient1, recipient1);
+            currentTestCtx.recipient1Assets += _tokenized(address(mechanism)).redeem(
+                recipient1MaxRedeem,
+                recipient1,
+                recipient1
+            );
         }
 
         // Handle any remaining shares due to rounding
@@ -789,8 +840,11 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
             uint256 recipient1MaxRedeem2 = _tokenized(address(mechanism)).maxRedeem(recipient1);
             if (recipient1MaxRedeem2 > 0) {
                 vm.prank(recipient1);
-                currentTestCtx.recipient1Assets += _tokenized(address(mechanism))
-                    .redeem(recipient1MaxRedeem2, recipient1, recipient1);
+                currentTestCtx.recipient1Assets += _tokenized(address(mechanism)).redeem(
+                    recipient1MaxRedeem2,
+                    recipient1,
+                    recipient1
+                );
             }
         }
 
@@ -798,8 +852,11 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         uint256 recipient2MaxRedeem = _tokenized(address(mechanism)).maxRedeem(recipient2);
         if (recipient2MaxRedeem > 0) {
             vm.prank(recipient2);
-            currentTestCtx.recipient2Assets += _tokenized(address(mechanism))
-                .redeem(recipient2MaxRedeem, recipient2, recipient2);
+            currentTestCtx.recipient2Assets += _tokenized(address(mechanism)).redeem(
+                recipient2MaxRedeem,
+                recipient2,
+                recipient2
+            );
         }
 
         // Handle any remaining shares due to rounding
@@ -808,22 +865,29 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
             uint256 recipient2MaxRedeem2 = _tokenized(address(mechanism)).maxRedeem(recipient2);
             if (recipient2MaxRedeem2 > 0) {
                 vm.prank(recipient2);
-                currentTestCtx.recipient2Assets += _tokenized(address(mechanism))
-                    .redeem(recipient2MaxRedeem2, recipient2, recipient2);
+                currentTestCtx.recipient2Assets += _tokenized(address(mechanism)).redeem(
+                    recipient2MaxRedeem2,
+                    recipient2,
+                    recipient2
+                );
             }
         }
 
         // Verify exact proportional distribution based on actual shares redeemed
-        uint256 totalActualSharesRedeemed = currentTestCtx.recipient1Shares
-            - _tokenized(address(mechanism)).balanceOf(recipient1) + currentTestCtx.recipient2Shares
-            - _tokenized(address(mechanism)).balanceOf(recipient2);
+        uint256 totalActualSharesRedeemed = currentTestCtx.recipient1Shares -
+            _tokenized(address(mechanism)).balanceOf(recipient1) +
+            currentTestCtx.recipient2Shares -
+            _tokenized(address(mechanism)).balanceOf(recipient2);
         currentTestCtx.expectedTotalAssets =
-            (totalActualSharesRedeemed * currentTestCtx.totalAssets) / currentTestCtx.totalShares;
+            (totalActualSharesRedeemed * currentTestCtx.totalAssets) /
+            currentTestCtx.totalShares;
 
         // Verify complete asset distribution - should be exact with proper redemption
         uint256 totalAssetsRedeemed = currentTestCtx.recipient1Assets + currentTestCtx.recipient2Assets;
         assertEq(
-            totalAssetsRedeemed, currentTestCtx.expectedTotalAssets, "All redeemable assets must be distributed exactly"
+            totalAssetsRedeemed,
+            currentTestCtx.expectedTotalAssets,
+            "All redeemable assets must be distributed exactly"
         );
 
         // Both recipients should have redeemed all or nearly all their shares
@@ -899,22 +963,46 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
 
         // Alice votes the same amount (20) for each project
         vm.startPrank(alice);
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid1, TokenizedAllocationMechanism.VoteType.For, 20, recipient1); // Cost: 400
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid2, TokenizedAllocationMechanism.VoteType.For, 20, recipient2); // Cost: 400
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid3, TokenizedAllocationMechanism.VoteType.For, 20, recipient3); // Cost: 400
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid1,
+            TokenizedAllocationMechanism.VoteType.For,
+            20,
+            recipient1
+        ); // Cost: 400
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid2,
+            TokenizedAllocationMechanism.VoteType.For,
+            20,
+            recipient2
+        ); // Cost: 400
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid3,
+            TokenizedAllocationMechanism.VoteType.For,
+            20,
+            recipient3
+        ); // Cost: 400
         vm.stopPrank();
 
         // Bob votes the same amount (15) for each project
         vm.startPrank(bob);
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid1, TokenizedAllocationMechanism.VoteType.For, 15, recipient1); // Cost: 225
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid2, TokenizedAllocationMechanism.VoteType.For, 15, recipient2); // Cost: 225
-        _tokenized(address(mechanism))
-            .castVote(currentTestCtx.pid3, TokenizedAllocationMechanism.VoteType.For, 15, recipient3); // Cost: 225
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid1,
+            TokenizedAllocationMechanism.VoteType.For,
+            15,
+            recipient1
+        ); // Cost: 225
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid2,
+            TokenizedAllocationMechanism.VoteType.For,
+            15,
+            recipient2
+        ); // Cost: 225
+        _tokenized(address(mechanism)).castVote(
+            currentTestCtx.pid3,
+            TokenizedAllocationMechanism.VoteType.For,
+            15,
+            recipient3
+        ); // Cost: 225
         vm.stopPrank();
 
         vm.warp(currentTestCtx.startTime + VOTING_DELAY + VOTING_PERIOD + 1);
@@ -923,9 +1011,9 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         console.log("=== VERIFYING QUADRATIC FUNDING ===");
 
         // Get funding for each project using getTally()
-        (,, uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(currentTestCtx.pid1);
-        (,, uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(currentTestCtx.pid2);
-        (,, uint256 p3QuadraticFunding, uint256 p3LinearFunding) = mechanism.getTally(currentTestCtx.pid3);
+        (, , uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(currentTestCtx.pid1);
+        (, , uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(currentTestCtx.pid2);
+        (, , uint256 p3QuadraticFunding, uint256 p3LinearFunding) = mechanism.getTally(currentTestCtx.pid3);
 
         currentTestCtx.expectedProject1Funding = p1QuadraticFunding + p1LinearFunding;
         currentTestCtx.expectedProject2Funding = p2QuadraticFunding + p2LinearFunding;
@@ -963,20 +1051,23 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         token.transfer(address(mechanism), currentTestCtx.matchingPoolNeeded);
 
         // Finalize voting
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue all proposals
-        (bool success1,) =
-            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1));
+        (bool success1, ) = address(mechanism).call(
+            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1)
+        );
         require(success1, "Queue project 1 failed");
 
-        (bool success2,) =
-            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2));
+        (bool success2, ) = address(mechanism).call(
+            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2)
+        );
         require(success2, "Queue project 2 failed");
 
-        (bool success3,) =
-            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid3));
+        (bool success3, ) = address(mechanism).call(
+            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid3)
+        );
         require(success3, "Queue project 3 failed");
 
         // === VERIFICATION ===
@@ -1021,7 +1112,9 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         );
 
         currentTestCtx.totalSharesRedeemed =
-            currentTestCtx.recipient1Shares + currentTestCtx.recipient2Shares + currentTestCtx.recipient3Shares;
+            currentTestCtx.recipient1Shares +
+            currentTestCtx.recipient2Shares +
+            currentTestCtx.recipient3Shares;
         currentTestCtx.expectedTotalAssets = 3 * 1225; // 3 projects × 1225 funding each
         assertEq(
             currentTestCtx.totalSharesRedeemed,
@@ -1048,7 +1141,8 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         ctx.constrainedAlphaNumerator = smallerBudget;
 
         ctx.requiredMatchingPool =
-            (ctx.totalQuadraticSum * ctx.constrainedAlphaNumerator) / ctx.constrainedAlphaDenominator;
+            (ctx.totalQuadraticSum * ctx.constrainedAlphaNumerator) /
+            ctx.constrainedAlphaDenominator;
 
         console.log("Total quadratic sum:", ctx.totalQuadraticSum);
         console.log("Total linear sum:", totalLinearSum);
@@ -1056,7 +1150,9 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
         console.log("Example: If budget was", smallerBudget, "shares");
         console.log("Then alpha would be:", ctx.constrainedAlphaNumerator, "/", ctx.constrainedAlphaDenominator);
         console.log(
-            "Alpha percentage:", (ctx.constrainedAlphaNumerator * 10000) / ctx.constrainedAlphaDenominator, "/ 10000"
+            "Alpha percentage:",
+            (ctx.constrainedAlphaNumerator * 10000) / ctx.constrainedAlphaDenominator,
+            "/ 10000"
         );
     }
 
@@ -1064,8 +1160,8 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
     /// @param ctx Test context containing alpha parameters and storing results
     function _verifyConstrainedFunding(TestContext storage ctx) internal {
         // Get actual funding from mechanism
-        (,, uint256 project1QuadraticFunding, uint256 project1LinearFunding) = mechanism.getTally(ctx.pid1);
-        (,, uint256 project2QuadraticFunding, uint256 project2LinearFunding) = mechanism.getTally(ctx.pid2);
+        (, , uint256 project1QuadraticFunding, uint256 project1LinearFunding) = mechanism.getTally(ctx.pid1);
+        (, , uint256 project2QuadraticFunding, uint256 project2LinearFunding) = mechanism.getTally(ctx.pid2);
 
         uint256 project1Funding = project1QuadraticFunding + project1LinearFunding;
         uint256 project2Funding = project2QuadraticFunding + project2LinearFunding;
@@ -1075,26 +1171,30 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
 
         // Calculate expected funding in scoped block to limit stack usage
         {
-            uint256 project1QuadraticComponent =
-                (60 * 60 * ctx.constrainedAlphaNumerator) / ctx.constrainedAlphaDenominator;
-            uint256 project1LinearComponent = (1250 * (ctx.constrainedAlphaDenominator - ctx.constrainedAlphaNumerator))
-                / ctx.constrainedAlphaDenominator;
+            uint256 project1QuadraticComponent = (60 * 60 * ctx.constrainedAlphaNumerator) /
+                ctx.constrainedAlphaDenominator;
+            uint256 project1LinearComponent = (1250 *
+                (ctx.constrainedAlphaDenominator - ctx.constrainedAlphaNumerator)) / ctx.constrainedAlphaDenominator;
             ctx.expectedProject1Funding = project1QuadraticComponent + project1LinearComponent;
 
             assertEq(
-                project1Funding, ctx.expectedProject1Funding, "Project 1 funding should match quadratic calculation"
+                project1Funding,
+                ctx.expectedProject1Funding,
+                "Project 1 funding should match quadratic calculation"
             );
         }
 
         {
-            uint256 project2QuadraticComponent =
-                (27 * 27 * ctx.constrainedAlphaNumerator) / ctx.constrainedAlphaDenominator;
-            uint256 project2LinearComponent = (369 * (ctx.constrainedAlphaDenominator - ctx.constrainedAlphaNumerator))
-                / ctx.constrainedAlphaDenominator;
+            uint256 project2QuadraticComponent = (27 * 27 * ctx.constrainedAlphaNumerator) /
+                ctx.constrainedAlphaDenominator;
+            uint256 project2LinearComponent = (369 *
+                (ctx.constrainedAlphaDenominator - ctx.constrainedAlphaNumerator)) / ctx.constrainedAlphaDenominator;
             ctx.expectedProject2Funding = project2QuadraticComponent + project2LinearComponent;
 
             assertEq(
-                project2Funding, ctx.expectedProject2Funding, "Project 2 funding should match quadratic calculation"
+                project2Funding,
+                ctx.expectedProject2Funding,
+                "Project 2 funding should match quadratic calculation"
             );
         }
     }
@@ -1122,11 +1222,17 @@ contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
             console.log("- Amount trapped:", remainingAssets);
             console.log("- Percentage of total:", (remainingAssets * 10000) / ctx.totalAssets, "basis points");
             console.log(
-                "- Exchange rate at time of issue: totalAssets/totalShares =", ctx.totalAssets, "/", ctx.totalShares
+                "- Exchange rate at time of issue: totalAssets/totalShares =",
+                ctx.totalAssets,
+                "/",
+                ctx.totalShares
             );
             if (remainingShares > 0) {
                 console.log(
-                    "- Current exchange rate: remainingAssets/remainingShares =", remainingAssets, "/", remainingShares
+                    "- Current exchange rate: remainingAssets/remainingShares =",
+                    remainingAssets,
+                    "/",
+                    remainingShares
                 );
             }
         }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingAccountingAuditTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingAccountingAuditTest.t.sol
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {AllocationTestHelpers} from "../utils/AllocationTestHelpers.sol";
 
 /// @title Quadratic Voting Accounting Audit Test
 /// @notice Comprehensive end-to-end test tracking every state change for auditor verification
@@ -48,7 +46,7 @@ import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 /// 4. Share-to-asset conversion approaching 1:1 ratio
 /// 5. Timelock enforcement
 /// 6. Complete asset redemption with minimal dust remaining
-contract QuadraticVotingAccountingAuditTest is Test {
+contract QuadraticVotingAccountingAuditTest is AllocationTestHelpers {
     AllocationMechanismFactory factory;
     ERC20Mock token;
     QuadraticVotingMechanism mechanism;
@@ -136,10 +134,6 @@ contract QuadraticVotingAccountingAuditTest is Test {
     // Storage-based test context for stack optimization
     TestContext internal currentTestCtx;
 
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
     /// @notice Clear test context for fresh initialization
     function _clearTestContext() internal {
         delete currentTestCtx.constrainedAlphaNumerator;
@@ -188,20 +182,22 @@ contract QuadraticVotingAccountingAuditTest is Test {
         token.mint(bob, 2000 ether);
         token.mint(charlie, 2000 ether);
 
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Accounting Audit Test",
-            symbol: "AUDIT",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_REQUIREMENT,
-            timelockDelay: TIMELOCK_DELAY,
-            gracePeriod: 7 days,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, ALPHA_NUMERATOR, ALPHA_DENOMINATOR);
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
+        mechanism = _deployQuadraticVoting(
+            factory,
+            _config({
+                asset: token,
+                name: "Accounting Audit Test",
+                symbol: "AUDIT",
+                votingDelay: VOTING_DELAY,
+                votingPeriod: VOTING_PERIOD,
+                quorumShares: QUORUM_REQUIREMENT,
+                timelockDelay: TIMELOCK_DELAY,
+                gracePeriod: 7 days,
+                owner: address(0)
+            }),
+            ALPHA_NUMERATOR,
+            ALPHA_DENOMINATOR
+        );
 
         // Set alice as keeper and management for proposers
         _tokenized(address(mechanism)).setKeeper(alice);
@@ -236,11 +232,11 @@ contract QuadraticVotingAccountingAuditTest is Test {
 
         // Proposal funding (if proposals exist) - use getTally() from ProperQF
         if (pid1 != 0) {
-            (, , uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(pid1);
+            (,, uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(pid1);
             state.proposal1Funding = p1QuadraticFunding + p1LinearFunding;
         }
         if (pid2 != 0) {
-            (, , uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(pid2);
+            (,, uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(pid2);
             state.proposal2Funding = p2QuadraticFunding + p2LinearFunding;
         }
 
@@ -270,8 +266,7 @@ contract QuadraticVotingAccountingAuditTest is Test {
         if (keccak256(bytes(phase)) == keccak256(bytes("FINAL"))) {
             // After all redemptions, mechanism should have minimal dust (<=2 wei)
             assertTrue(
-                state.totalMechanismAssets <= 2,
-                string(abi.encodePacked("Final asset cleanup failed in ", phase))
+                state.totalMechanismAssets <= 2, string(abi.encodePacked("Final asset cleanup failed in ", phase))
             );
         } else if (keccak256(bytes(phase)) == keccak256(bytes("POST_REDEMPTION_1"))) {
             // After first redemption, mechanism should have ~half the assets
@@ -385,51 +380,27 @@ contract QuadraticVotingAccountingAuditTest is Test {
 
         // Alice votes
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid1,
-            TokenizedAllocationMechanism.VoteType.For,
-            VOTE_WEIGHT,
-            recipient1
-        );
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid1, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient1);
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid2,
-            TokenizedAllocationMechanism.VoteType.For,
-            VOTE_WEIGHT,
-            recipient2
-        );
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid2, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient2);
 
         // Bob votes
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid1,
-            TokenizedAllocationMechanism.VoteType.For,
-            VOTE_WEIGHT,
-            recipient1
-        );
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid1, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient1);
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid2,
-            TokenizedAllocationMechanism.VoteType.For,
-            VOTE_WEIGHT,
-            recipient2
-        );
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid2, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient2);
 
         // Charlie votes
         vm.prank(charlie);
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid1,
-            TokenizedAllocationMechanism.VoteType.For,
-            VOTE_WEIGHT,
-            recipient1
-        );
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid1, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient1);
         vm.prank(charlie);
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid2,
-            TokenizedAllocationMechanism.VoteType.For,
-            VOTE_WEIGHT,
-            recipient2
-        );
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid2, TokenizedAllocationMechanism.VoteType.For, VOTE_WEIGHT, recipient2);
 
         AccountingState memory postVotingState = _captureAccountingState(currentTestCtx.pid1, currentTestCtx.pid2);
         _logAccountingState("POST_VOTING", postVotingState);
@@ -477,9 +448,7 @@ contract QuadraticVotingAccountingAuditTest is Test {
         uint256 currentAssets = postVotingState.totalMechanismAssets; // User deposits = totalLinearSum
 
         // For alpha = 1: matching pool = totalQuadraticSum - totalLinearSum
-        currentTestCtx.matchingPoolNeeded =
-            (currentTestCtx.totalQuadraticSum - currentTestCtx.totalLinearSum) *
-            1 ether;
+        currentTestCtx.matchingPoolNeeded = (currentTestCtx.totalQuadraticSum - currentTestCtx.totalLinearSum) * 1 ether;
         currentTestCtx.totalAssetsNeeded = currentTestCtx.totalQuadraticSum * 1 ether; // For 1:1 ratio
 
         console.log("Total quadratic sum:", currentTestCtx.totalQuadraticSum);
@@ -496,13 +465,10 @@ contract QuadraticVotingAccountingAuditTest is Test {
         console.log("=== PHASE 5: FINALIZATION ===");
         vm.warp(currentTestCtx.startTime + VOTING_DELAY + VOTING_PERIOD + 1);
 
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
-        AccountingState memory postFinalizationState = _captureAccountingState(
-            currentTestCtx.pid1,
-            currentTestCtx.pid2
-        );
+        AccountingState memory postFinalizationState = _captureAccountingState(currentTestCtx.pid1, currentTestCtx.pid2);
         _logAccountingState("POST_FINALIZATION", postFinalizationState);
         _verifyAccountingInvariants(postFinalizationState, "POST_FINALIZATION");
 
@@ -518,14 +484,12 @@ contract QuadraticVotingAccountingAuditTest is Test {
 
         currentTestCtx.queueTimestamp = block.timestamp;
 
-        (bool success1, ) = address(mechanism).call(
-            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1)
-        );
+        (bool success1,) =
+            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1));
         require(success1, "Queue proposal 1 failed");
 
-        (bool success2, ) = address(mechanism).call(
-            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2)
-        );
+        (bool success2,) =
+            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2));
         require(success2, "Queue proposal 2 failed");
 
         AccountingState memory postQueueingState = _captureAccountingState(currentTestCtx.pid1, currentTestCtx.pid2);
@@ -535,19 +499,13 @@ contract QuadraticVotingAccountingAuditTest is Test {
         // Verify share minting - should be exact with alpha = 1
         uint256 expectedSharesPerRecipient = currentTestCtx.expectedFundingPerProposal; // 3600 shares per recipient
         assertEq(
-            postQueueingState.recipient1Shares,
-            expectedSharesPerRecipient,
-            "Recipient1 should get exactly 3600 shares"
+            postQueueingState.recipient1Shares, expectedSharesPerRecipient, "Recipient1 should get exactly 3600 shares"
         );
         assertEq(
-            postQueueingState.recipient2Shares,
-            expectedSharesPerRecipient,
-            "Recipient2 should get exactly 3600 shares"
+            postQueueingState.recipient2Shares, expectedSharesPerRecipient, "Recipient2 should get exactly 3600 shares"
         );
         assertEq(
-            postQueueingState.totalSharesSupply,
-            expectedSharesPerRecipient * 2,
-            "Total shares should be exactly 7200"
+            postQueueingState.totalSharesSupply, expectedSharesPerRecipient * 2, "Total shares should be exactly 7200"
         );
 
         // Verify timelock setup
@@ -573,8 +531,7 @@ contract QuadraticVotingAccountingAuditTest is Test {
         currentTestCtx.totalAssets = postQueueingState.totalMechanismAssets;
         currentTestCtx.totalShares = postQueueingState.totalSharesSupply;
         currentTestCtx.expectedAssetsPerRecipient =
-            (expectedSharesPerRecipient * currentTestCtx.totalAssets) /
-            currentTestCtx.totalShares;
+            (expectedSharesPerRecipient * currentTestCtx.totalAssets) / currentTestCtx.totalShares;
 
         console.log("Post-queuing total assets:", currentTestCtx.totalAssets);
         console.log("Post-queuing total shares:", currentTestCtx.totalShares);
@@ -595,18 +552,15 @@ contract QuadraticVotingAccountingAuditTest is Test {
         currentTestCtx.recipient1ActualShares = postQueueingState.recipient1Shares;
 
         vm.prank(recipient1);
-        currentTestCtx.recipient1Assets = _tokenized(address(mechanism)).redeem(
-            currentTestCtx.recipient1ActualShares,
-            recipient1,
-            recipient1
-        );
+        currentTestCtx.recipient1Assets =
+            _tokenized(address(mechanism)).redeem(currentTestCtx.recipient1ActualShares, recipient1, recipient1);
 
         AccountingState memory postRedemption1State = _captureAccountingState(currentTestCtx.pid1, currentTestCtx.pid2);
         _logAccountingState("POST_REDEMPTION_1", postRedemption1State);
 
         // Verify recipient1 redemption accounting - exact proportional calculation
-        uint256 expectedRecipient1Assets = (currentTestCtx.recipient1ActualShares * currentTestCtx.totalAssets) /
-            currentTestCtx.totalShares;
+        uint256 expectedRecipient1Assets =
+            (currentTestCtx.recipient1ActualShares * currentTestCtx.totalAssets) / currentTestCtx.totalShares;
         assertEq(
             currentTestCtx.recipient1Assets,
             expectedRecipient1Assets,
@@ -630,19 +584,16 @@ contract QuadraticVotingAccountingAuditTest is Test {
         currentTestCtx.recipient2ActualShares = postRedemption1State.recipient2Shares;
 
         vm.prank(recipient2);
-        currentTestCtx.recipient2Assets = _tokenized(address(mechanism)).redeem(
-            currentTestCtx.recipient2ActualShares,
-            recipient2,
-            recipient2
-        );
+        currentTestCtx.recipient2Assets =
+            _tokenized(address(mechanism)).redeem(currentTestCtx.recipient2ActualShares, recipient2, recipient2);
 
         AccountingState memory finalState = _captureAccountingState(currentTestCtx.pid1, currentTestCtx.pid2);
         _logAccountingState("FINAL", finalState);
         _verifyAccountingInvariants(finalState, "FINAL");
 
         // Verify recipient2 redemption accounting - exact proportional calculation
-        uint256 expectedRecipient2Assets = (currentTestCtx.recipient2ActualShares * currentTestCtx.totalAssets) /
-            currentTestCtx.totalShares;
+        uint256 expectedRecipient2Assets =
+            (currentTestCtx.recipient2ActualShares * currentTestCtx.totalAssets) / currentTestCtx.totalShares;
         assertEq(
             currentTestCtx.recipient2Assets,
             expectedRecipient2Assets,
@@ -662,8 +613,7 @@ contract QuadraticVotingAccountingAuditTest is Test {
         // Verify good shares:asset ratio achieved using test context
         currentTestCtx.totalAssetsDistributed = currentTestCtx.recipient1Assets + currentTestCtx.recipient2Assets;
         currentTestCtx.totalSharesRedeemed =
-            currentTestCtx.recipient1ActualShares +
-            currentTestCtx.recipient2ActualShares;
+            currentTestCtx.recipient1ActualShares + currentTestCtx.recipient2ActualShares;
 
         console.log("Total assets distributed:", currentTestCtx.totalAssetsDistributed);
         console.log("Total shares redeemed:", currentTestCtx.totalSharesRedeemed);
@@ -671,9 +621,7 @@ contract QuadraticVotingAccountingAuditTest is Test {
 
         // Verify exact asset conservation - all assets distributed, none lost
         assertEq(
-            currentTestCtx.totalAssetsDistributed,
-            currentTestCtx.totalAssets,
-            "All assets must be distributed exactly"
+            currentTestCtx.totalAssetsDistributed, currentTestCtx.totalAssets, "All assets must be distributed exactly"
         );
         assertEq(currentTestCtx.totalSharesRedeemed, currentTestCtx.totalShares, "All shares must be redeemed exactly");
 
@@ -776,7 +724,7 @@ contract QuadraticVotingAccountingAuditTest is Test {
         // Note: This requires the mechanism to be deployed with the correct alpha initially
         // For this test, we'll verify the calculation instead
 
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // ==================== VERIFY OPTIMAL FUNDING ====================
@@ -786,10 +734,10 @@ contract QuadraticVotingAccountingAuditTest is Test {
         _verifyConstrainedFunding(currentTestCtx);
 
         // Queue proposals
-        (bool success1, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
+        (bool success1,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
         require(success1, "Queue project 1 failed");
 
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
         require(success2, "Queue project 2 failed");
 
         // ==================== VERIFY EXACT ACCOUNTING ====================
@@ -831,11 +779,8 @@ contract QuadraticVotingAccountingAuditTest is Test {
         uint256 recipient1MaxRedeem = _tokenized(address(mechanism)).maxRedeem(recipient1);
         if (recipient1MaxRedeem > 0) {
             vm.prank(recipient1);
-            currentTestCtx.recipient1Assets += _tokenized(address(mechanism)).redeem(
-                recipient1MaxRedeem,
-                recipient1,
-                recipient1
-            );
+            currentTestCtx.recipient1Assets += _tokenized(address(mechanism))
+                .redeem(recipient1MaxRedeem, recipient1, recipient1);
         }
 
         // Handle any remaining shares due to rounding
@@ -844,11 +789,8 @@ contract QuadraticVotingAccountingAuditTest is Test {
             uint256 recipient1MaxRedeem2 = _tokenized(address(mechanism)).maxRedeem(recipient1);
             if (recipient1MaxRedeem2 > 0) {
                 vm.prank(recipient1);
-                currentTestCtx.recipient1Assets += _tokenized(address(mechanism)).redeem(
-                    recipient1MaxRedeem2,
-                    recipient1,
-                    recipient1
-                );
+                currentTestCtx.recipient1Assets += _tokenized(address(mechanism))
+                    .redeem(recipient1MaxRedeem2, recipient1, recipient1);
             }
         }
 
@@ -856,11 +798,8 @@ contract QuadraticVotingAccountingAuditTest is Test {
         uint256 recipient2MaxRedeem = _tokenized(address(mechanism)).maxRedeem(recipient2);
         if (recipient2MaxRedeem > 0) {
             vm.prank(recipient2);
-            currentTestCtx.recipient2Assets += _tokenized(address(mechanism)).redeem(
-                recipient2MaxRedeem,
-                recipient2,
-                recipient2
-            );
+            currentTestCtx.recipient2Assets += _tokenized(address(mechanism))
+                .redeem(recipient2MaxRedeem, recipient2, recipient2);
         }
 
         // Handle any remaining shares due to rounding
@@ -869,29 +808,22 @@ contract QuadraticVotingAccountingAuditTest is Test {
             uint256 recipient2MaxRedeem2 = _tokenized(address(mechanism)).maxRedeem(recipient2);
             if (recipient2MaxRedeem2 > 0) {
                 vm.prank(recipient2);
-                currentTestCtx.recipient2Assets += _tokenized(address(mechanism)).redeem(
-                    recipient2MaxRedeem2,
-                    recipient2,
-                    recipient2
-                );
+                currentTestCtx.recipient2Assets += _tokenized(address(mechanism))
+                    .redeem(recipient2MaxRedeem2, recipient2, recipient2);
             }
         }
 
         // Verify exact proportional distribution based on actual shares redeemed
-        uint256 totalActualSharesRedeemed = currentTestCtx.recipient1Shares -
-            _tokenized(address(mechanism)).balanceOf(recipient1) +
-            currentTestCtx.recipient2Shares -
-            _tokenized(address(mechanism)).balanceOf(recipient2);
+        uint256 totalActualSharesRedeemed = currentTestCtx.recipient1Shares
+            - _tokenized(address(mechanism)).balanceOf(recipient1) + currentTestCtx.recipient2Shares
+            - _tokenized(address(mechanism)).balanceOf(recipient2);
         currentTestCtx.expectedTotalAssets =
-            (totalActualSharesRedeemed * currentTestCtx.totalAssets) /
-            currentTestCtx.totalShares;
+            (totalActualSharesRedeemed * currentTestCtx.totalAssets) / currentTestCtx.totalShares;
 
         // Verify complete asset distribution - should be exact with proper redemption
         uint256 totalAssetsRedeemed = currentTestCtx.recipient1Assets + currentTestCtx.recipient2Assets;
         assertEq(
-            totalAssetsRedeemed,
-            currentTestCtx.expectedTotalAssets,
-            "All redeemable assets must be distributed exactly"
+            totalAssetsRedeemed, currentTestCtx.expectedTotalAssets, "All redeemable assets must be distributed exactly"
         );
 
         // Both recipients should have redeemed all or nearly all their shares
@@ -967,46 +899,22 @@ contract QuadraticVotingAccountingAuditTest is Test {
 
         // Alice votes the same amount (20) for each project
         vm.startPrank(alice);
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid1,
-            TokenizedAllocationMechanism.VoteType.For,
-            20,
-            recipient1
-        ); // Cost: 400
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid2,
-            TokenizedAllocationMechanism.VoteType.For,
-            20,
-            recipient2
-        ); // Cost: 400
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid3,
-            TokenizedAllocationMechanism.VoteType.For,
-            20,
-            recipient3
-        ); // Cost: 400
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid1, TokenizedAllocationMechanism.VoteType.For, 20, recipient1); // Cost: 400
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid2, TokenizedAllocationMechanism.VoteType.For, 20, recipient2); // Cost: 400
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid3, TokenizedAllocationMechanism.VoteType.For, 20, recipient3); // Cost: 400
         vm.stopPrank();
 
         // Bob votes the same amount (15) for each project
         vm.startPrank(bob);
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid1,
-            TokenizedAllocationMechanism.VoteType.For,
-            15,
-            recipient1
-        ); // Cost: 225
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid2,
-            TokenizedAllocationMechanism.VoteType.For,
-            15,
-            recipient2
-        ); // Cost: 225
-        _tokenized(address(mechanism)).castVote(
-            currentTestCtx.pid3,
-            TokenizedAllocationMechanism.VoteType.For,
-            15,
-            recipient3
-        ); // Cost: 225
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid1, TokenizedAllocationMechanism.VoteType.For, 15, recipient1); // Cost: 225
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid2, TokenizedAllocationMechanism.VoteType.For, 15, recipient2); // Cost: 225
+        _tokenized(address(mechanism))
+            .castVote(currentTestCtx.pid3, TokenizedAllocationMechanism.VoteType.For, 15, recipient3); // Cost: 225
         vm.stopPrank();
 
         vm.warp(currentTestCtx.startTime + VOTING_DELAY + VOTING_PERIOD + 1);
@@ -1015,9 +923,9 @@ contract QuadraticVotingAccountingAuditTest is Test {
         console.log("=== VERIFYING QUADRATIC FUNDING ===");
 
         // Get funding for each project using getTally()
-        (, , uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(currentTestCtx.pid1);
-        (, , uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(currentTestCtx.pid2);
-        (, , uint256 p3QuadraticFunding, uint256 p3LinearFunding) = mechanism.getTally(currentTestCtx.pid3);
+        (,, uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(currentTestCtx.pid1);
+        (,, uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(currentTestCtx.pid2);
+        (,, uint256 p3QuadraticFunding, uint256 p3LinearFunding) = mechanism.getTally(currentTestCtx.pid3);
 
         currentTestCtx.expectedProject1Funding = p1QuadraticFunding + p1LinearFunding;
         currentTestCtx.expectedProject2Funding = p2QuadraticFunding + p2LinearFunding;
@@ -1055,23 +963,20 @@ contract QuadraticVotingAccountingAuditTest is Test {
         token.transfer(address(mechanism), currentTestCtx.matchingPoolNeeded);
 
         // Finalize voting
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue all proposals
-        (bool success1, ) = address(mechanism).call(
-            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1)
-        );
+        (bool success1,) =
+            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1));
         require(success1, "Queue project 1 failed");
 
-        (bool success2, ) = address(mechanism).call(
-            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2)
-        );
+        (bool success2,) =
+            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2));
         require(success2, "Queue project 2 failed");
 
-        (bool success3, ) = address(mechanism).call(
-            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid3)
-        );
+        (bool success3,) =
+            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid3));
         require(success3, "Queue project 3 failed");
 
         // === VERIFICATION ===
@@ -1116,9 +1021,7 @@ contract QuadraticVotingAccountingAuditTest is Test {
         );
 
         currentTestCtx.totalSharesRedeemed =
-            currentTestCtx.recipient1Shares +
-            currentTestCtx.recipient2Shares +
-            currentTestCtx.recipient3Shares;
+            currentTestCtx.recipient1Shares + currentTestCtx.recipient2Shares + currentTestCtx.recipient3Shares;
         currentTestCtx.expectedTotalAssets = 3 * 1225; // 3 projects × 1225 funding each
         assertEq(
             currentTestCtx.totalSharesRedeemed,
@@ -1145,8 +1048,7 @@ contract QuadraticVotingAccountingAuditTest is Test {
         ctx.constrainedAlphaNumerator = smallerBudget;
 
         ctx.requiredMatchingPool =
-            (ctx.totalQuadraticSum * ctx.constrainedAlphaNumerator) /
-            ctx.constrainedAlphaDenominator;
+            (ctx.totalQuadraticSum * ctx.constrainedAlphaNumerator) / ctx.constrainedAlphaDenominator;
 
         console.log("Total quadratic sum:", ctx.totalQuadraticSum);
         console.log("Total linear sum:", totalLinearSum);
@@ -1154,9 +1056,7 @@ contract QuadraticVotingAccountingAuditTest is Test {
         console.log("Example: If budget was", smallerBudget, "shares");
         console.log("Then alpha would be:", ctx.constrainedAlphaNumerator, "/", ctx.constrainedAlphaDenominator);
         console.log(
-            "Alpha percentage:",
-            (ctx.constrainedAlphaNumerator * 10000) / ctx.constrainedAlphaDenominator,
-            "/ 10000"
+            "Alpha percentage:", (ctx.constrainedAlphaNumerator * 10000) / ctx.constrainedAlphaDenominator, "/ 10000"
         );
     }
 
@@ -1164,8 +1064,8 @@ contract QuadraticVotingAccountingAuditTest is Test {
     /// @param ctx Test context containing alpha parameters and storing results
     function _verifyConstrainedFunding(TestContext storage ctx) internal {
         // Get actual funding from mechanism
-        (, , uint256 project1QuadraticFunding, uint256 project1LinearFunding) = mechanism.getTally(ctx.pid1);
-        (, , uint256 project2QuadraticFunding, uint256 project2LinearFunding) = mechanism.getTally(ctx.pid2);
+        (,, uint256 project1QuadraticFunding, uint256 project1LinearFunding) = mechanism.getTally(ctx.pid1);
+        (,, uint256 project2QuadraticFunding, uint256 project2LinearFunding) = mechanism.getTally(ctx.pid2);
 
         uint256 project1Funding = project1QuadraticFunding + project1LinearFunding;
         uint256 project2Funding = project2QuadraticFunding + project2LinearFunding;
@@ -1175,30 +1075,26 @@ contract QuadraticVotingAccountingAuditTest is Test {
 
         // Calculate expected funding in scoped block to limit stack usage
         {
-            uint256 project1QuadraticComponent = (60 * 60 * ctx.constrainedAlphaNumerator) /
-                ctx.constrainedAlphaDenominator;
-            uint256 project1LinearComponent = (1250 *
-                (ctx.constrainedAlphaDenominator - ctx.constrainedAlphaNumerator)) / ctx.constrainedAlphaDenominator;
+            uint256 project1QuadraticComponent =
+                (60 * 60 * ctx.constrainedAlphaNumerator) / ctx.constrainedAlphaDenominator;
+            uint256 project1LinearComponent = (1250 * (ctx.constrainedAlphaDenominator - ctx.constrainedAlphaNumerator))
+                / ctx.constrainedAlphaDenominator;
             ctx.expectedProject1Funding = project1QuadraticComponent + project1LinearComponent;
 
             assertEq(
-                project1Funding,
-                ctx.expectedProject1Funding,
-                "Project 1 funding should match quadratic calculation"
+                project1Funding, ctx.expectedProject1Funding, "Project 1 funding should match quadratic calculation"
             );
         }
 
         {
-            uint256 project2QuadraticComponent = (27 * 27 * ctx.constrainedAlphaNumerator) /
-                ctx.constrainedAlphaDenominator;
-            uint256 project2LinearComponent = (369 *
-                (ctx.constrainedAlphaDenominator - ctx.constrainedAlphaNumerator)) / ctx.constrainedAlphaDenominator;
+            uint256 project2QuadraticComponent =
+                (27 * 27 * ctx.constrainedAlphaNumerator) / ctx.constrainedAlphaDenominator;
+            uint256 project2LinearComponent = (369 * (ctx.constrainedAlphaDenominator - ctx.constrainedAlphaNumerator))
+                / ctx.constrainedAlphaDenominator;
             ctx.expectedProject2Funding = project2QuadraticComponent + project2LinearComponent;
 
             assertEq(
-                project2Funding,
-                ctx.expectedProject2Funding,
-                "Project 2 funding should match quadratic calculation"
+                project2Funding, ctx.expectedProject2Funding, "Project 2 funding should match quadratic calculation"
             );
         }
     }
@@ -1226,17 +1122,11 @@ contract QuadraticVotingAccountingAuditTest is Test {
             console.log("- Amount trapped:", remainingAssets);
             console.log("- Percentage of total:", (remainingAssets * 10000) / ctx.totalAssets, "basis points");
             console.log(
-                "- Exchange rate at time of issue: totalAssets/totalShares =",
-                ctx.totalAssets,
-                "/",
-                ctx.totalShares
+                "- Exchange rate at time of issue: totalAssets/totalShares =", ctx.totalAssets, "/", ctx.totalShares
             );
             if (remainingShares > 0) {
                 console.log(
-                    "- Current exchange rate: remainingAssets/remainingShares =",
-                    remainingAssets,
-                    "/",
-                    remainingShares
+                    "- Current exchange rate: remainingAssets/remainingShares =", remainingAssets, "/", remainingShares
                 );
             }
         }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingAdminJourneyTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingAdminJourneyTest.t.sol
@@ -1,26 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Admin Journey Integration Tests
 /// @notice Comprehensive tests for admin user journey covering deployment, monitoring, and execution
-contract QuadraticVotingAdminJourneyTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1);
-    address bob = address(0x2);
-    address charlie = address(0x3);
-    address dave = address(0x4);
+contract QuadraticVotingAdminJourneyTest is QuadraticVotingTestBase {
     address newOwner = address(0xa);
 
     uint256 constant LARGE_DEPOSIT = 1000 ether;
@@ -30,69 +17,22 @@ contract QuadraticVotingAdminJourneyTest is Test {
     uint256 constant VOTING_PERIOD = 1000;
     uint256 constant TIMELOCK_DELAY = 1 days;
 
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
-    /// @notice Helper function to sign up a user with specified deposit
-    /// @param user Address of user to sign up
-    /// @param depositAmount Amount of tokens to deposit
-    function _signupUser(address user, uint256 depositAmount) internal {
-        vm.startPrank(user);
-        token.approve(address(mechanism), depositAmount);
-        _tokenized(address(mechanism)).signup(depositAmount);
-        vm.stopPrank();
-    }
-
-    /// @notice Helper function to create a proposal
-    /// @param proposer Address creating the proposal
-    /// @param recipient Address that will receive funds if proposal passes
-    /// @param description Description of the proposal
-    /// @return pid The proposal ID
-    function _createProposal(
-        address proposer,
-        address recipient,
-        string memory description
-    ) internal returns (uint256 pid) {
-        vm.prank(proposer);
-        pid = _tokenized(address(mechanism)).propose(recipient, description);
-    }
-
-    /// @notice Helper function to cast a vote on a proposal
-    /// @param voter Address casting the vote
-    /// @param pid Proposal ID to vote on
-    /// @param weight Vote weight (quadratic cost = weight^2)
-    /// @param recipient Expected recipient address for the proposal
-    function _castVote(address voter, uint256 pid, uint256 weight, address recipient) internal {
-        vm.prank(voter);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, weight, recipient);
-    }
-
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting(
+            "Admin Journey Test",
+            "AJTEST",
+            VOTING_DELAY,
+            VOTING_PERIOD,
+            QUORUM_REQUIREMENT,
+            TIMELOCK_DELAY,
+            7 days,
+            50,
+            100
+        );
 
         token.mint(alice, 2000 ether);
         token.mint(bob, 1500 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Admin Journey Test",
-            symbol: "AJTEST",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_REQUIREMENT,
-            timelockDelay: TIMELOCK_DELAY,
-            gracePeriod: 7 days,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-
-        // Set alice as keeper and bob as management so they can create proposals
-        _tokenized(address(mechanism)).setKeeper(alice);
-        _tokenized(address(mechanism)).setManagement(bob);
+        _setRoles(alice, bob);
     }
 
     /// @notice Test admin deployment and configuration verification
@@ -103,37 +43,42 @@ contract QuadraticVotingAdminJourneyTest is Test {
         assertNotEq(factory.tokenizedAllocationImplementation(), address(0));
 
         // Verify mechanism configuration
-        assertEq(_tokenized(address(mechanism)).name(), "Admin Journey Test");
-        assertEq(_tokenized(address(mechanism)).symbol(), "AJTEST");
-        assertEq(address(_tokenized(address(mechanism)).asset()), address(token));
-        assertEq(_tokenized(address(mechanism)).votingDelay(), VOTING_DELAY);
-        assertEq(_tokenized(address(mechanism)).votingPeriod(), VOTING_PERIOD);
-        assertEq(_tokenized(address(mechanism)).quorumShares(), QUORUM_REQUIREMENT);
-        assertEq(_tokenized(address(mechanism)).timelockDelay(), TIMELOCK_DELAY);
+        assertEq(_tokenized().name(), "Admin Journey Test");
+        assertEq(_tokenized().symbol(), "AJTEST");
+        assertEq(address(_tokenized().asset()), address(token));
+        assertEq(_tokenized().votingDelay(), VOTING_DELAY);
+        assertEq(_tokenized().votingPeriod(), VOTING_PERIOD);
+        assertEq(_tokenized().quorumShares(), QUORUM_REQUIREMENT);
+        assertEq(_tokenized().timelockDelay(), TIMELOCK_DELAY);
 
         // Verify owner context (deployer becomes owner)
-        assertEq(_tokenized(address(mechanism)).owner(), address(this));
+        assertEq(_tokenized().owner(), address(this));
 
         // Deploy second mechanism to test isolation
-        AllocationConfig memory config2 = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Second Mechanism",
-            symbol: "SECOND",
-            votingDelay: 50,
-            votingPeriod: 500,
-            quorumShares: 300,
-            timelockDelay: 2 days,
-            gracePeriod: 14 days,
-            owner: address(0)
-        });
-
-        address mechanism2Addr = factory.deployQuadraticVotingMechanism(config2, 50, 100);
+        address mechanism2Addr = address(
+            _deployQuadraticVoting(
+                factory,
+                _config({
+                    asset: token,
+                    name: "Second Mechanism",
+                    symbol: "SECOND",
+                    votingDelay: 50,
+                    votingPeriod: 500,
+                    quorumShares: 300,
+                    timelockDelay: 2 days,
+                    gracePeriod: 14 days,
+                    owner: address(0)
+                }),
+                50,
+                100
+            )
+        );
 
         // Verify isolation between mechanisms
         assertEq(factory.getDeployedCount(), 2);
-        assertEq(_tokenized(address(mechanism)).name(), "Admin Journey Test");
+        assertEq(_tokenized().name(), "Admin Journey Test");
         assertEq(_tokenized(mechanism2Addr).name(), "Second Mechanism");
-        assertEq(_tokenized(address(mechanism)).votingDelay(), VOTING_DELAY);
+        assertEq(_tokenized().votingDelay(), VOTING_DELAY);
         assertEq(_tokenized(mechanism2Addr).votingDelay(), 50);
     }
 
@@ -147,7 +92,7 @@ contract QuadraticVotingAdminJourneyTest is Test {
         uint256 pid1 = _createProposal(alice, charlie, "Infrastructure Project");
         uint256 pid2 = _createProposal(bob, dave, "Community Initiative");
 
-        assertEq(_tokenized(address(mechanism)).getProposalCount(), 2);
+        assertEq(_tokenized().getProposalCount(), 2);
 
         // Admin monitors voting progress - advance to voting period
         vm.warp(block.timestamp + VOTING_DELAY + 1);
@@ -158,23 +103,17 @@ contract QuadraticVotingAdminJourneyTest is Test {
         _castVote(bob, pid2, 18, dave);
 
         // Admin checks real-time vote tallies using getTally() from ProperQF
-        (, , uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(pid1);
+        (,, uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(pid1);
         uint256 p1For = p1QuadraticFunding + p1LinearFunding;
         assertEq(p1For, 724); // QuadraticFunding: (22+8)² × 0.5 + linear portion = 724
 
-        (, , uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(pid2);
+        (,, uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(pid2);
         uint256 p2For = p2QuadraticFunding + p2LinearFunding;
         assertEq(p2For, 972); // QuadraticFunding: (18+18)² × 0.5 + linear portion = 972
 
         // Admin monitors proposal states during voting
-        assertEq(
-            uint256(_tokenized(address(mechanism)).state(pid1)),
-            uint256(TokenizedAllocationMechanism.ProposalState.Active)
-        );
-        assertEq(
-            uint256(_tokenized(address(mechanism)).state(pid2)),
-            uint256(TokenizedAllocationMechanism.ProposalState.Active)
-        );
+        assertEq(uint256(_tokenized().state(pid1)), uint256(TokenizedAllocationMechanism.ProposalState.Active));
+        assertEq(uint256(_tokenized().state(pid2)), uint256(TokenizedAllocationMechanism.ProposalState.Active));
     }
 
     /// @notice Test admin finalization process
@@ -190,18 +129,18 @@ contract QuadraticVotingAdminJourneyTest is Test {
 
         // Cannot finalize before voting period ends
         vm.expectRevert();
-        _tokenized(address(mechanism)).finalizeVoteTally();
+        _tokenized().finalizeVoteTally();
 
         // Successful finalization after voting period
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
-        assertFalse(_tokenized(address(mechanism)).tallyFinalized());
+        assertFalse(_tokenized().tallyFinalized());
 
-        _tokenized(address(mechanism)).finalizeVoteTally();
-        assertTrue(_tokenized(address(mechanism)).tallyFinalized());
+        _tokenized().finalizeVoteTally();
+        assertTrue(_tokenized().tallyFinalized());
 
         // Cannot finalize twice
         vm.expectRevert(TokenizedAllocationMechanism.TallyAlreadyFinalized.selector);
-        _tokenized(address(mechanism)).finalizeVoteTally();
+        _tokenized().finalizeVoteTally();
     }
 
     /// @notice Test admin proposal queuing and execution
@@ -225,84 +164,77 @@ contract QuadraticVotingAdminJourneyTest is Test {
 
         // Advance past voting period
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue successful proposal
         assertEq(
-            uint256(_tokenized(address(mechanism)).state(pidSuccessful)),
-            uint256(TokenizedAllocationMechanism.ProposalState.Succeeded)
+            uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded)
         );
 
         uint256 timestampBefore = block.timestamp;
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidSuccessful));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidSuccessful));
         require(success2, "Queue successful proposal failed");
 
         // Verify queuing effects
-        assertEq(
-            uint256(_tokenized(address(mechanism)).state(pidSuccessful)),
-            uint256(TokenizedAllocationMechanism.ProposalState.Queued)
-        );
+        assertEq(uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Queued));
         // QuadraticFunding calculation: pidSuccessful gets proportional shares based on weighted funding
         // Alice(25) + Bob(15) = (40)² × 0.5 + contributions × 0.5 = approx 1225 weighted funding
         // Exact shares depend on total funding across all proposals
-        uint256 actualShares = _tokenized(address(mechanism)).proposalShares(pidSuccessful);
+        uint256 actualShares = _tokenized().proposalShares(pidSuccessful);
         assertTrue(actualShares > 0, "Successful proposal should receive shares");
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), actualShares);
-        assertEq(_tokenized(address(mechanism)).globalRedemptionStart(), timestampBefore + TIMELOCK_DELAY);
+        assertEq(_tokenized().balanceOf(charlie), actualShares);
+        assertEq(_tokenized().globalRedemptionStart(), timestampBefore + TIMELOCK_DELAY);
 
         // Cannot queue failed proposal
-        assertEq(
-            uint256(_tokenized(address(mechanism)).state(pidFailed)),
-            uint256(TokenizedAllocationMechanism.ProposalState.Defeated)
-        );
+        assertEq(uint256(_tokenized().state(pidFailed)), uint256(TokenizedAllocationMechanism.ProposalState.Defeated));
 
         vm.expectRevert(); // Should revert with NoQuorum or similar for defeated proposal
-        _tokenized(address(mechanism)).queueProposal(pidFailed);
+        _tokenized().queueProposal(pidFailed);
 
         // Cannot queue already queued proposal
         vm.expectRevert(abi.encodeWithSelector(TokenizedAllocationMechanism.AlreadyQueued.selector, pidSuccessful));
-        _tokenized(address(mechanism)).queueProposal(pidSuccessful);
+        _tokenized().queueProposal(pidSuccessful);
     }
 
     /// @notice Test admin emergency functions
     function testAdminEmergency_Functions() public {
         // Test pause mechanism
-        assertFalse(_tokenized(address(mechanism)).paused());
+        assertFalse(_tokenized().paused());
 
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success, "Pause failed");
-        assertTrue(_tokenized(address(mechanism)).paused());
+        assertTrue(_tokenized().paused());
 
         // Paused mechanism blocks operations
         vm.expectRevert(TokenizedAllocationMechanism.PausedError.selector);
         vm.prank(alice);
-        _tokenized(address(mechanism)).signup(100 ether);
+        _tokenized().signup(100 ether);
 
         // Unpause mechanism
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
         require(success2, "Unpause failed");
-        assertFalse(_tokenized(address(mechanism)).paused());
+        assertFalse(_tokenized().paused());
 
         // Transfer ownership
-        (bool success3, ) = address(mechanism).call(abi.encodeWithSignature("transferOwnership(address)", newOwner));
+        (bool success3,) = address(mechanism).call(abi.encodeWithSignature("transferOwnership(address)", newOwner));
         require(success3, "Transfer ownership failed");
 
         // New owner accepts ownership
         vm.prank(newOwner);
-        (bool success3b, ) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
+        (bool success3b,) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
         require(success3b, "Accept ownership failed");
-        assertEq(_tokenized(address(mechanism)).owner(), newOwner);
+        assertEq(_tokenized().owner(), newOwner);
 
         // Old owner cannot perform owner functions
         vm.expectRevert(TokenizedAllocationMechanism.Unauthorized.selector);
-        _tokenized(address(mechanism)).pause();
+        _tokenized().pause();
 
         // New owner can perform owner functions
         vm.startPrank(newOwner);
-        (bool success5, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success5,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success5, "New owner pause failed");
-        assertTrue(_tokenized(address(mechanism)).paused());
+        assertTrue(_tokenized().paused());
         vm.stopPrank();
     }
 
@@ -320,16 +252,16 @@ contract QuadraticVotingAdminJourneyTest is Test {
         _castVote(alice, pid, 20, charlie);
 
         // Emergency pause during voting
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success, "Pause failed");
 
         // All operations blocked
         vm.expectRevert(TokenizedAllocationMechanism.PausedError.selector);
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, charlie);
 
         // Resume operations
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
         require(success2, "Unpause failed");
 
         // Operations work again - use bob since alice already voted
@@ -337,25 +269,24 @@ contract QuadraticVotingAdminJourneyTest is Test {
 
         // Ownership transfer during crisis
         address emergencyAdmin = newOwner;
-        (bool success3, ) = address(mechanism).call(
-            abi.encodeWithSignature("transferOwnership(address)", emergencyAdmin)
-        );
+        (bool success3,) =
+            address(mechanism).call(abi.encodeWithSignature("transferOwnership(address)", emergencyAdmin));
         require(success3, "Transfer ownership failed");
 
         // New owner accepts ownership
         vm.prank(emergencyAdmin);
-        (bool success3b, ) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
+        (bool success3b,) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
         require(success3b, "Accept ownership failed");
 
         // New owner manages crisis
         vm.startPrank(emergencyAdmin);
-        (bool success4, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success4,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success4, "Emergency admin pause failed");
         vm.stopPrank();
 
         // System recovery after crisis
         vm.startPrank(emergencyAdmin);
-        (bool success5, ) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
+        (bool success5,) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
         require(success5, "Recovery unpause failed");
         vm.stopPrank();
 
@@ -363,20 +294,17 @@ contract QuadraticVotingAdminJourneyTest is Test {
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
 
         vm.startPrank(emergencyAdmin);
-        (bool success6, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success6,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success6, "Emergency finalization failed");
 
-        (bool success7, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success7,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success7, "Emergency queuing failed");
         vm.stopPrank();
 
         // System functions normally - alice (20) + bob (8) votes in QuadraticFunding
         // Total weighted funding = quadratic + linear components, shares allocated proportionally
-        uint256 actualShares = _tokenized(address(mechanism)).balanceOf(charlie);
+        uint256 actualShares = _tokenized().balanceOf(charlie);
         assertTrue(actualShares > 0, "Successful proposal should receive shares after crisis recovery");
-        assertEq(
-            uint256(_tokenized(address(mechanism)).state(pid)),
-            uint256(TokenizedAllocationMechanism.ProposalState.Queued)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Queued));
     }
 }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingAdminJourneyTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingAdminJourneyTest.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Admin Journey Integration Tests
 /// @notice Comprehensive tests for admin user journey covering deployment, monitoring, and execution
@@ -103,11 +103,11 @@ contract QuadraticVotingAdminJourneyTest is QuadraticVotingTestBase {
         _castVote(bob, pid2, 18, dave);
 
         // Admin checks real-time vote tallies using getTally() from ProperQF
-        (,, uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(pid1);
+        (, , uint256 p1QuadraticFunding, uint256 p1LinearFunding) = mechanism.getTally(pid1);
         uint256 p1For = p1QuadraticFunding + p1LinearFunding;
         assertEq(p1For, 724); // QuadraticFunding: (22+8)² × 0.5 + linear portion = 724
 
-        (,, uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(pid2);
+        (, , uint256 p2QuadraticFunding, uint256 p2LinearFunding) = mechanism.getTally(pid2);
         uint256 p2For = p2QuadraticFunding + p2LinearFunding;
         assertEq(p2For, 972); // QuadraticFunding: (18+18)² × 0.5 + linear portion = 972
 
@@ -164,20 +164,24 @@ contract QuadraticVotingAdminJourneyTest is QuadraticVotingTestBase {
 
         // Advance past voting period
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue successful proposal
         assertEq(
-            uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded)
+            uint256(_tokenized().state(pidSuccessful)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Succeeded)
         );
 
         uint256 timestampBefore = block.timestamp;
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidSuccessful));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidSuccessful));
         require(success2, "Queue successful proposal failed");
 
         // Verify queuing effects
-        assertEq(uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Queued));
+        assertEq(
+            uint256(_tokenized().state(pidSuccessful)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Queued)
+        );
         // QuadraticFunding calculation: pidSuccessful gets proportional shares based on weighted funding
         // Alice(25) + Bob(15) = (40)² × 0.5 + contributions × 0.5 = approx 1225 weighted funding
         // Exact shares depend on total funding across all proposals
@@ -202,7 +206,7 @@ contract QuadraticVotingAdminJourneyTest is QuadraticVotingTestBase {
         // Test pause mechanism
         assertFalse(_tokenized().paused());
 
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success, "Pause failed");
         assertTrue(_tokenized().paused());
 
@@ -212,17 +216,17 @@ contract QuadraticVotingAdminJourneyTest is QuadraticVotingTestBase {
         _tokenized().signup(100 ether);
 
         // Unpause mechanism
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
         require(success2, "Unpause failed");
         assertFalse(_tokenized().paused());
 
         // Transfer ownership
-        (bool success3,) = address(mechanism).call(abi.encodeWithSignature("transferOwnership(address)", newOwner));
+        (bool success3, ) = address(mechanism).call(abi.encodeWithSignature("transferOwnership(address)", newOwner));
         require(success3, "Transfer ownership failed");
 
         // New owner accepts ownership
         vm.prank(newOwner);
-        (bool success3b,) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
+        (bool success3b, ) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
         require(success3b, "Accept ownership failed");
         assertEq(_tokenized().owner(), newOwner);
 
@@ -232,7 +236,7 @@ contract QuadraticVotingAdminJourneyTest is QuadraticVotingTestBase {
 
         // New owner can perform owner functions
         vm.startPrank(newOwner);
-        (bool success5,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success5, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success5, "New owner pause failed");
         assertTrue(_tokenized().paused());
         vm.stopPrank();
@@ -252,7 +256,7 @@ contract QuadraticVotingAdminJourneyTest is QuadraticVotingTestBase {
         _castVote(alice, pid, 20, charlie);
 
         // Emergency pause during voting
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success, "Pause failed");
 
         // All operations blocked
@@ -261,7 +265,7 @@ contract QuadraticVotingAdminJourneyTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, charlie);
 
         // Resume operations
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
         require(success2, "Unpause failed");
 
         // Operations work again - use bob since alice already voted
@@ -269,24 +273,25 @@ contract QuadraticVotingAdminJourneyTest is QuadraticVotingTestBase {
 
         // Ownership transfer during crisis
         address emergencyAdmin = newOwner;
-        (bool success3,) =
-            address(mechanism).call(abi.encodeWithSignature("transferOwnership(address)", emergencyAdmin));
+        (bool success3, ) = address(mechanism).call(
+            abi.encodeWithSignature("transferOwnership(address)", emergencyAdmin)
+        );
         require(success3, "Transfer ownership failed");
 
         // New owner accepts ownership
         vm.prank(emergencyAdmin);
-        (bool success3b,) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
+        (bool success3b, ) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
         require(success3b, "Accept ownership failed");
 
         // New owner manages crisis
         vm.startPrank(emergencyAdmin);
-        (bool success4,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success4, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success4, "Emergency admin pause failed");
         vm.stopPrank();
 
         // System recovery after crisis
         vm.startPrank(emergencyAdmin);
-        (bool success5,) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
+        (bool success5, ) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
         require(success5, "Recovery unpause failed");
         vm.stopPrank();
 
@@ -294,10 +299,10 @@ contract QuadraticVotingAdminJourneyTest is QuadraticVotingTestBase {
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
 
         vm.startPrank(emergencyAdmin);
-        (bool success6,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success6, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success6, "Emergency finalization failed");
 
-        (bool success7,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success7, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success7, "Emergency queuing failed");
         vm.stopPrank();
 

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingBasicTimelockTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingBasicTimelockTest.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 contract QuadraticVotingBasicTimelockTest is QuadraticVotingTestBase {
     function setUp() public {
@@ -31,7 +31,7 @@ contract QuadraticVotingBasicTimelockTest is QuadraticVotingTestBase {
         // Finalize - advance past voting period
         vm.warp(votingEndTime + 1);
         uint256 finalizeTime = block.timestamp; // Should be 112
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check that global redemption start was set during finalization
@@ -45,7 +45,7 @@ contract QuadraticVotingBasicTimelockTest is QuadraticVotingTestBase {
 
         // Queue proposal
         assertEq(block.timestamp, finalizeTime, "Should be at finalize timestamp");
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         // Verify shares were minted

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingBasicTimelockTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingBasicTimelockTest.t.sol
@@ -1,52 +1,19 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
-contract QuadraticVotingBasicTimelockTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1);
-    address charlie = address(0x3);
-
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
+contract QuadraticVotingBasicTimelockTest is QuadraticVotingTestBase {
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting("Basic Test", "BASIC", 10, 100, 500, 1000, 5000, 50, 100);
         token.mint(alice, 2000 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Basic Test",
-            symbol: "BASIC",
-            votingDelay: 10,
-            votingPeriod: 100,
-            quorumShares: 500, // Adjusted for quadratic funding
-            timelockDelay: 1000, // 1000 seconds
-            gracePeriod: 5000, // 5000 seconds
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-        _tokenized(address(mechanism)).setKeeper(alice);
+        _tokenized().setKeeper(alice);
     }
 
     function testBasicTimelock() public {
         // Get the voting delay and period from the mechanism
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
 
         // Calculate timeline based on deployment time (setUp runs at timestamp 1)
         uint256 deploymentTime = 1; // Default foundry timestamp
@@ -54,64 +21,60 @@ contract QuadraticVotingBasicTimelockTest is Test {
         uint256 votingEndTime = votingStartTime + votingPeriod; // 11 + 100 = 111
 
         // Setup - register and create proposal (before voting starts)
-        vm.startPrank(alice);
-        token.approve(address(mechanism), 1000 ether);
-        _tokenized(address(mechanism)).signup(1000 ether);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Test");
-        vm.stopPrank();
+        _signup(alice, 1000 ether);
+        uint256 pid = _propose(alice, charlie, "Test");
 
         // Vote - advance to voting period
         vm.warp(votingStartTime);
-        vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 31, charlie); // 31^2 = 961 > 500 quorum
+        _vote(alice, pid, 31, charlie); // 31^2 = 961 > 500 quorum
 
         // Finalize - advance past voting period
         vm.warp(votingEndTime + 1);
         uint256 finalizeTime = block.timestamp; // Should be 112
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check that global redemption start was set during finalization
-        uint256 timelockDelay = _tokenized(address(mechanism)).timelockDelay();
+        uint256 timelockDelay = _tokenized().timelockDelay();
         assertEq(
-            _tokenized(address(mechanism)).globalRedemptionStart(),
+            _tokenized().globalRedemptionStart(),
             finalizeTime + timelockDelay,
             "Should have globalRedemptionStart set after finalize"
         );
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), 0, "Should have no shares before queue");
+        assertEq(_tokenized().balanceOf(charlie), 0, "Should have no shares before queue");
 
         // Queue proposal
         assertEq(block.timestamp, finalizeTime, "Should be at finalize timestamp");
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         // Verify shares were minted
-        assertGt(_tokenized(address(mechanism)).balanceOf(charlie), 0, "Should have shares after queue");
+        assertGt(_tokenized().balanceOf(charlie), 0, "Should have shares after queue");
         // Global redemption start remains the same (set during finalize)
         assertEq(
-            _tokenized(address(mechanism)).globalRedemptionStart(),
+            _tokenized().globalRedemptionStart(),
             finalizeTime + timelockDelay,
             "globalRedemptionStart should not change after queue"
         );
 
         // Should be blocked immediately at queue time
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0, "Should be blocked at queue time");
+        assertEq(_tokenized().maxRedeem(charlie), 0, "Should be blocked at queue time");
 
         // Should be blocked during timelock period (1 second before expiry)
         vm.warp(finalizeTime + timelockDelay - 1);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0, "Should be blocked 1 second before expiry");
+        assertEq(_tokenized().maxRedeem(charlie), 0, "Should be blocked 1 second before expiry");
 
         // Should be allowed at timelock expiry
         vm.warp(finalizeTime + timelockDelay);
-        assertGt(_tokenized(address(mechanism)).maxRedeem(charlie), 0, "Should be allowed at timelock expiry");
+        assertGt(_tokenized().maxRedeem(charlie), 0, "Should be allowed at timelock expiry");
 
         // Should still be allowed after timelock expiry
         vm.warp(finalizeTime + timelockDelay + 1);
-        assertGt(_tokenized(address(mechanism)).maxRedeem(charlie), 0, "Should be allowed after timelock expiry");
+        assertGt(_tokenized().maxRedeem(charlie), 0, "Should be allowed after timelock expiry");
 
         // Should be blocked after grace period expires
-        uint256 gracePeriod = _tokenized(address(mechanism)).gracePeriod();
+        uint256 gracePeriod = _tokenized().gracePeriod();
         vm.warp(finalizeTime + timelockDelay + gracePeriod + 1);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0, "Should be blocked after grace period");
+        assertEq(_tokenized().maxRedeem(charlie), 0, "Should be blocked after grace period");
     }
 }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingCrossJourneyTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingCrossJourneyTest.t.sol
@@ -1,30 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
-import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Cross-Journey Integration Tests
 /// @notice Tests complete end-to-end workflows across voter, admin, and recipient journeys
-contract QuadraticVotingCrossJourneyTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1); // Primary voter
-    address bob = address(0x2); // Secondary voter
-    address charlie = address(0x3); // Recipient 1
-    address dave = address(0x4); // Recipient 2
-    address eve = address(0x5); // Recipient 3
-    address frank = address(0x6); // Small voter
-    address emergencyAdmin = address(0xa);
-
+contract QuadraticVotingCrossJourneyTest is QuadraticVotingTestBase {
     uint256 constant LARGE_DEPOSIT = 1000 ether;
     uint256 constant MEDIUM_DEPOSIT = 500 ether;
     uint256 constant SMALL_DEPOSIT = 100 ether;
@@ -33,35 +15,24 @@ contract QuadraticVotingCrossJourneyTest is Test {
     uint256 constant VOTING_PERIOD = 1000;
     uint256 constant TIMELOCK_DELAY = 1 days;
 
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting(
+            "Cross Journey Integration Test",
+            "CJITEST",
+            VOTING_DELAY,
+            VOTING_PERIOD,
+            QUORUM_REQUIREMENT,
+            TIMELOCK_DELAY,
+            7 days,
+            50,
+            100
+        );
 
         // Mint tokens to all actors (including large amount for edge case testing)
         token.mint(alice, type(uint128).max);
         token.mint(bob, 1500 ether);
         token.mint(frank, 200 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Cross Journey Integration Test",
-            symbol: "CJITEST",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_REQUIREMENT,
-            timelockDelay: TIMELOCK_DELAY,
-            gracePeriod: 7 days,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-        _tokenized(address(mechanism)).setKeeper(alice);
-        _tokenized(address(mechanism)).setManagement(bob);
+        _setRoles(alice, bob);
 
         // Pre-fund matching pool - this will be included in total assets during finalize
         uint256 matchingPoolAmount = 2000 ether;
@@ -78,30 +49,30 @@ contract QuadraticVotingCrossJourneyTest is Test {
         // Admin monitors community joining
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
+        _tokenized().signup(LARGE_DEPOSIT);
         vm.stopPrank();
 
         vm.startPrank(bob);
         token.approve(address(mechanism), MEDIUM_DEPOSIT);
-        _tokenized(address(mechanism)).signup(MEDIUM_DEPOSIT);
+        _tokenized().signup(MEDIUM_DEPOSIT);
         vm.stopPrank();
 
         vm.startPrank(frank);
         token.approve(address(mechanism), SMALL_DEPOSIT);
-        _tokenized(address(mechanism)).signup(SMALL_DEPOSIT);
+        _tokenized().signup(SMALL_DEPOSIT);
         vm.stopPrank();
 
         // PHASE 2: RECIPIENT ADVOCACY AND PROPOSAL CREATION
 
         // Recipients work with proposers
         vm.prank(alice);
-        uint256 pidCharlie = _tokenized(address(mechanism)).propose(charlie, "Charlie's Renewable Energy Grid");
+        uint256 pidCharlie = _tokenized().propose(charlie, "Charlie's Renewable Energy Grid");
 
         vm.prank(bob);
-        uint256 pidDave = _tokenized(address(mechanism)).propose(dave, "Dave's Digital Literacy Program");
+        uint256 pidDave = _tokenized().propose(dave, "Dave's Digital Literacy Program");
 
         vm.prank(alice);
-        uint256 pidEve = _tokenized(address(mechanism)).propose(eve, "Eve's Community Health Clinic");
+        uint256 pidEve = _tokenized().propose(eve, "Eve's Community Health Clinic");
 
         // PHASE 3: DEMOCRATIC VOTING PROCESS
 
@@ -111,21 +82,21 @@ contract QuadraticVotingCrossJourneyTest is Test {
         // Complex voting patterns
         // Alice: Strategic voter supporting energy and education (deposit: 1000 ether)
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pidCharlie, TokenizedAllocationMechanism.VoteType.For, 30, charlie);
+        _tokenized().castVote(pidCharlie, TokenizedAllocationMechanism.VoteType.For, 30, charlie);
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pidDave, TokenizedAllocationMechanism.VoteType.For, 10, dave);
+        _tokenized().castVote(pidDave, TokenizedAllocationMechanism.VoteType.For, 10, dave);
 
         // Bob: Focused on education with opposition to energy (deposit: 500 ether)
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pidDave, TokenizedAllocationMechanism.VoteType.For, 20, dave);
+        _tokenized().castVote(pidDave, TokenizedAllocationMechanism.VoteType.For, 20, dave);
 
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pidCharlie, TokenizedAllocationMechanism.VoteType.For, 10, charlie);
+        _tokenized().castVote(pidCharlie, TokenizedAllocationMechanism.VoteType.For, 10, charlie);
 
         // Frank: Supporting healthcare (deposit: 100 ether)
         vm.prank(frank);
-        _tokenized(address(mechanism)).castVote(pidEve, TokenizedAllocationMechanism.VoteType.For, 10, eve);
+        _tokenized().castVote(pidEve, TokenizedAllocationMechanism.VoteType.For, 10, eve);
 
         // PHASE 4: ADMIN FINALIZATION AND EXECUTION
 
@@ -133,45 +104,36 @@ contract QuadraticVotingCrossJourneyTest is Test {
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
 
         // Admin finalizes voting
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check final outcomes using QuadraticFunding algorithm
         // Charlie: Alice(30) + Bob(10) = (40)² × 0.5 + contributions × 0.5 = weighted funding meets quorum ✓
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidCharlie)),
-            uint(TokenizedAllocationMechanism.ProposalState.Succeeded)
-        );
+        assertEq(uint256(_tokenized().state(pidCharlie)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded));
 
         // Dave: Alice(10) + Bob(20) = (30)² × 0.5 + contributions × 0.5 = weighted funding meets quorum ✓
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidDave)),
-            uint(TokenizedAllocationMechanism.ProposalState.Succeeded)
-        );
+        assertEq(uint256(_tokenized().state(pidDave)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded));
 
         // Eve: Frank(10) = (10)² × 0.5 + contributions × 0.5 = weighted funding below quorum ✗
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidEve)),
-            uint(TokenizedAllocationMechanism.ProposalState.Defeated)
-        );
+        assertEq(uint256(_tokenized().state(pidEve)), uint256(TokenizedAllocationMechanism.ProposalState.Defeated));
 
         // Admin queues successful proposals
-        (bool success1, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidCharlie));
+        (bool success1,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidCharlie));
         require(success1, "Queue Charlie failed");
 
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidDave));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidDave));
         require(success2, "Queue Dave failed");
 
         // PHASE 5: RECIPIENT REDEMPTION AND ASSET UTILIZATION
 
         // Verify share distribution - shares are allocated proportionally based on QuadraticFunding
-        uint256 charlieShares = _tokenized(address(mechanism)).balanceOf(charlie);
-        uint256 daveShares = _tokenized(address(mechanism)).balanceOf(dave);
-        uint256 totalSupply = _tokenized(address(mechanism)).totalSupply();
+        uint256 charlieShares = _tokenized().balanceOf(charlie);
+        uint256 daveShares = _tokenized().balanceOf(dave);
+        uint256 totalSupply = _tokenized().totalSupply();
 
         assertTrue(charlieShares > 0, "Charlie should receive shares");
         assertTrue(daveShares > 0, "Dave should receive shares");
-        assertEq(_tokenized(address(mechanism)).balanceOf(eve), 0);
+        assertEq(_tokenized().balanceOf(eve), 0);
         assertEq(totalSupply, charlieShares + daveShares);
 
         // Fast forward past timelock
@@ -182,15 +144,15 @@ contract QuadraticVotingCrossJourneyTest is Test {
         uint256 daveTokensBefore = token.balanceOf(dave);
 
         vm.prank(charlie);
-        uint256 charlieAssets = _tokenized(address(mechanism)).redeem(charlieShares, charlie, charlie);
+        uint256 charlieAssets = _tokenized().redeem(charlieShares, charlie, charlie);
 
         vm.prank(dave);
-        uint256 daveAssets = _tokenized(address(mechanism)).redeem(daveShares, dave, dave);
+        uint256 daveAssets = _tokenized().redeem(daveShares, dave, dave);
 
         // Verify final state
         assertEq(token.balanceOf(charlie), charlieTokensBefore + charlieAssets);
         assertEq(token.balanceOf(dave), daveTokensBefore + daveAssets);
-        assertEq(_tokenized(address(mechanism)).totalSupply(), 0);
+        assertEq(_tokenized().totalSupply(), 0);
         assertTrue(charlieAssets > 0, "Charlie should receive assets");
         assertTrue(daveAssets > 0, "Dave should receive assets");
 
@@ -202,23 +164,14 @@ contract QuadraticVotingCrossJourneyTest is Test {
         // PHASE 6: SYSTEM INTEGRITY VERIFICATION
 
         // Verify clean state
-        assertEq(_tokenized(address(mechanism)).totalSupply(), 0);
-        assertTrue(_tokenized(address(mechanism)).tallyFinalized());
-        assertEq(_tokenized(address(mechanism)).getProposalCount(), 3);
+        assertEq(_tokenized().totalSupply(), 0);
+        assertTrue(_tokenized().tallyFinalized());
+        assertEq(_tokenized().getProposalCount(), 3);
 
         // Verify voter power consumption (QuadraticVoting consumes voting power in discrete units)
-        assertTrue(
-            _tokenized(address(mechanism)).votingPower(alice) < 1000 ether,
-            "Alice should have consumed most voting power"
-        );
-        assertTrue(
-            _tokenized(address(mechanism)).votingPower(bob) < 1000 ether,
-            "Bob should have consumed most voting power"
-        );
-        assertTrue(
-            _tokenized(address(mechanism)).votingPower(frank) < 1000 ether,
-            "Frank should have consumed most voting power"
-        );
+        assertTrue(_tokenized().votingPower(alice) < 1000 ether, "Alice should have consumed most voting power");
+        assertTrue(_tokenized().votingPower(bob) < 1000 ether, "Bob should have consumed most voting power");
+        assertTrue(_tokenized().votingPower(frank) < 1000 ether, "Frank should have consumed most voting power");
     }
 
     /// @notice Test crisis recovery and system resilience
@@ -228,60 +181,59 @@ contract QuadraticVotingCrossJourneyTest is Test {
         // Setup scenario with potential failures
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
+        _tokenized().signup(LARGE_DEPOSIT);
         vm.stopPrank();
 
         vm.startPrank(bob);
         token.approve(address(mechanism), MEDIUM_DEPOSIT);
-        _tokenized(address(mechanism)).signup(MEDIUM_DEPOSIT);
+        _tokenized().signup(MEDIUM_DEPOSIT);
         vm.stopPrank();
 
         vm.prank(alice);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Test proposal");
+        uint256 pid = _tokenized().propose(charlie, "Test proposal");
 
         // Advance to voting period
         vm.warp(block.timestamp + VOTING_DELAY + 1);
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie);
 
         // Emergency pause during voting
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success, "Pause failed");
 
         // All operations blocked
         vm.expectRevert(TokenizedAllocationMechanism.PausedError.selector);
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, charlie);
 
         // Resume operations
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
         require(success2, "Unpause failed");
 
         // Operations work again - use bob since alice already voted
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 15, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 15, charlie);
 
         // Ownership transfer during crisis
-        (bool success3, ) = address(mechanism).call(
-            abi.encodeWithSignature("transferOwnership(address)", emergencyAdmin)
-        );
+        (bool success3,) =
+            address(mechanism).call(abi.encodeWithSignature("transferOwnership(address)", emergencyAdmin));
         require(success3, "Transfer ownership failed");
 
         // New owner accepts ownership
         vm.prank(emergencyAdmin);
-        (bool success3b, ) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
+        (bool success3b,) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
         require(success3b, "Accept ownership failed");
 
         // New owner manages crisis
         vm.startPrank(emergencyAdmin);
-        (bool success4, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success4,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success4, "Emergency admin pause failed");
         vm.stopPrank();
 
         // System recovery
         vm.startPrank(emergencyAdmin);
-        (bool success5, ) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
+        (bool success5,) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
         require(success5, "Recovery unpause failed");
         vm.stopPrank();
 
@@ -289,20 +241,17 @@ contract QuadraticVotingCrossJourneyTest is Test {
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
 
         vm.startPrank(emergencyAdmin);
-        (bool success6, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success6,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success6, "Emergency finalization failed");
 
-        (bool success7, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success7,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success7, "Emergency queuing failed");
         vm.stopPrank();
 
         // System functions normally - alice (30) + bob (15) votes with QuadraticFunding calculation
-        uint256 actualShares = _tokenized(address(mechanism)).balanceOf(charlie);
+        uint256 actualShares = _tokenized().balanceOf(charlie);
         assertTrue(actualShares > 0, "Charlie should receive shares after crisis recovery");
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Queued)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Queued));
     }
 
     /// @notice Test edge cases and boundary conditions across journeys
@@ -312,97 +261,88 @@ contract QuadraticVotingCrossJourneyTest is Test {
         // Maximum safe values
         vm.startPrank(alice);
         token.approve(address(mechanism), type(uint128).max);
-        _tokenized(address(mechanism)).signup(type(uint128).max);
+        _tokenized().signup(type(uint128).max);
         vm.stopPrank();
 
-        assertEq(_tokenized(address(mechanism)).votingPower(alice), type(uint128).max);
+        assertEq(_tokenized().votingPower(alice), type(uint128).max);
 
         // Zero voting power operations
         vm.prank(frank);
-        _tokenized(address(mechanism)).signup(0);
+        _tokenized().signup(0);
 
         // Cannot propose with zero power
         vm.expectRevert(abi.encodeWithSelector(TokenizedAllocationMechanism.ProposeNotAllowed.selector, frank));
         vm.prank(frank);
-        _tokenized(address(mechanism)).propose(eve, "Should fail");
+        _tokenized().propose(eve, "Should fail");
 
         // Boundary voting timing - ensure bob has registered before voting starts
         vm.startPrank(bob);
         token.approve(address(mechanism), MEDIUM_DEPOSIT);
-        _tokenized(address(mechanism)).signup(MEDIUM_DEPOSIT);
+        _tokenized().signup(MEDIUM_DEPOSIT);
         vm.stopPrank();
 
         vm.prank(alice);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Boundary test");
+        uint256 pid = _tokenized().propose(charlie, "Boundary test");
 
         // Exactly at voting start
         vm.warp(block.timestamp + VOTING_DELAY);
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 25, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 25, charlie);
 
         // Exactly at voting end
         vm.warp(block.timestamp + VOTING_PERIOD);
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, charlie);
 
         // One second later should fail
         vm.warp(block.timestamp + 1);
         vm.expectRevert();
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 1, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 1, charlie);
     }
 
     /// @notice Test proposal cancellation across journeys
     function testProposalCancellation_CrossJourney() public {
         // ✅ CORRECT: Fetch absolute timeline from contract following CLAUDE.md pattern
         uint256 deploymentTime = block.timestamp; // When mechanism was deployed
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
+        uint256 votingDelay = _tokenized().votingDelay();
         uint256 votingStartTime = deploymentTime + votingDelay;
 
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
+        _tokenized().signup(LARGE_DEPOSIT);
         vm.stopPrank();
 
         // Test proposal states during cancellation
         vm.prank(alice);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Cancellable proposal");
+        uint256 pid = _tokenized().propose(charlie, "Cancellable proposal");
 
         // Should be in Pending state initially (before votingStartTime)
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Pending)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Pending));
 
         // During voting delay period, still Pending
         vm.warp(votingStartTime - 50);
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Pending)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Pending));
 
         // Proposer cancels during Pending state
         vm.prank(alice);
-        _tokenized(address(mechanism)).cancelProposal(pid);
+        _tokenized().cancelProposal(pid);
 
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Canceled)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Canceled));
 
         // Cannot vote on canceled proposal even after voting starts
         vm.warp(votingStartTime + 1);
         vm.expectRevert();
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, charlie);
 
         // Non-proposer cannot cancel
         vm.prank(alice);
-        uint256 pid2 = _tokenized(address(mechanism)).propose(dave, "Another proposal");
+        uint256 pid2 = _tokenized().propose(dave, "Another proposal");
 
         vm.expectRevert(abi.encodeWithSelector(TokenizedAllocationMechanism.NotProposer.selector, bob, alice));
         vm.prank(bob);
-        _tokenized(address(mechanism)).cancelProposal(pid2);
+        _tokenized().cancelProposal(pid2);
     }
 
     /// @notice Test multi-proposal complex scenarios
@@ -412,28 +352,28 @@ contract QuadraticVotingCrossJourneyTest is Test {
         // Setup diverse voter base
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
+        _tokenized().signup(LARGE_DEPOSIT);
         vm.stopPrank();
 
         vm.startPrank(bob);
         token.approve(address(mechanism), MEDIUM_DEPOSIT);
-        _tokenized(address(mechanism)).signup(MEDIUM_DEPOSIT);
+        _tokenized().signup(MEDIUM_DEPOSIT);
         vm.stopPrank();
 
         vm.startPrank(frank);
         token.approve(address(mechanism), SMALL_DEPOSIT);
-        _tokenized(address(mechanism)).signup(SMALL_DEPOSIT);
+        _tokenized().signup(SMALL_DEPOSIT);
         vm.stopPrank();
 
         // Create competing proposals
         vm.prank(alice);
-        uint256 pid1 = _tokenized(address(mechanism)).propose(charlie, "High-impact Infrastructure");
+        uint256 pid1 = _tokenized().propose(charlie, "High-impact Infrastructure");
 
         vm.prank(bob);
-        uint256 pid2 = _tokenized(address(mechanism)).propose(dave, "Community Education");
+        uint256 pid2 = _tokenized().propose(dave, "Community Education");
 
         vm.prank(alice);
-        uint256 pid3 = _tokenized(address(mechanism)).propose(eve, "Healthcare Access");
+        uint256 pid3 = _tokenized().propose(eve, "Healthcare Access");
 
         // Advance to voting period
         vm.warp(block.timestamp + VOTING_DELAY + 1);
@@ -441,62 +381,56 @@ contract QuadraticVotingCrossJourneyTest is Test {
         // Strategic voting with power distribution
         // Alice: Supports infrastructure but opposes healthcare
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 25, charlie);
+        _tokenized().castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 25, charlie);
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid3, TokenizedAllocationMechanism.VoteType.For, 20, eve);
+        _tokenized().castVote(pid3, TokenizedAllocationMechanism.VoteType.For, 20, eve);
 
         // Bob: Supports education and healthcare
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 25, dave);
+        _tokenized().castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 25, dave);
 
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pid3, TokenizedAllocationMechanism.VoteType.For, 10, eve);
+        _tokenized().castVote(pid3, TokenizedAllocationMechanism.VoteType.For, 10, eve);
 
         // Frank: All-in on healthcare
         vm.prank(frank);
-        _tokenized(address(mechanism)).castVote(pid3, TokenizedAllocationMechanism.VoteType.For, 10, eve);
+        _tokenized().castVote(pid3, TokenizedAllocationMechanism.VoteType.For, 10, eve);
 
         // Finalize and determine outcomes
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check complex voting outcomes using QuadraticFunding
         // pid1: Alice(25) = (25)² × 0.5 + contributions × 0.5 = weighted funding meets quorum
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid1)),
-            uint(TokenizedAllocationMechanism.ProposalState.Succeeded)
-        );
+        assertEq(uint256(_tokenized().state(pid1)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded));
 
         // pid2: Bob(25) = (25)² × 0.5 + contributions × 0.5 = weighted funding meets quorum
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid2)),
-            uint(TokenizedAllocationMechanism.ProposalState.Succeeded)
-        );
+        assertEq(uint256(_tokenized().state(pid2)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded));
 
         // pid3: Alice(20) + Bob(10) + Frank(10) = (40)² × 0.5 + contributions × 0.5
         // Determine actual state based on quorum calculation
-        uint8 pid3State = uint8(_tokenized(address(mechanism)).state(pid3));
+        uint8 pid3State = uint8(_tokenized().state(pid3));
         // State could be Succeeded or Defeated depending on whether weighted funding meets 500 quorum
         assertTrue(
-            pid3State == uint8(TokenizedAllocationMechanism.ProposalState.Succeeded) ||
-                pid3State == uint8(TokenizedAllocationMechanism.ProposalState.Defeated),
+            pid3State == uint8(TokenizedAllocationMechanism.ProposalState.Succeeded)
+                || pid3State == uint8(TokenizedAllocationMechanism.ProposalState.Defeated),
             "pid3 should be either Succeeded or Defeated"
         );
 
         // Queue successful proposals
-        (bool success1, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
+        (bool success1,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
         require(success1, "Queue pid1 failed");
 
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
         require(success2, "Queue pid2 failed");
 
         // Verify share distribution based on actual proposal outcomes
-        uint256 charlieShares = _tokenized(address(mechanism)).balanceOf(charlie);
-        uint256 daveShares = _tokenized(address(mechanism)).balanceOf(dave);
-        uint256 eveShares = _tokenized(address(mechanism)).balanceOf(eve);
-        uint256 totalSupply = _tokenized(address(mechanism)).totalSupply();
+        uint256 charlieShares = _tokenized().balanceOf(charlie);
+        uint256 daveShares = _tokenized().balanceOf(dave);
+        uint256 eveShares = _tokenized().balanceOf(eve);
+        uint256 totalSupply = _tokenized().totalSupply();
 
         assertTrue(charlieShares > 0, "Charlie should receive shares");
         assertTrue(daveShares > 0, "Dave should receive shares");
@@ -507,22 +441,22 @@ contract QuadraticVotingCrossJourneyTest is Test {
         vm.warp(block.timestamp + TIMELOCK_DELAY + 1);
 
         vm.prank(charlie);
-        uint256 charlieAssets = _tokenized(address(mechanism)).redeem(charlieShares, charlie, charlie);
+        uint256 charlieAssets = _tokenized().redeem(charlieShares, charlie, charlie);
         assertTrue(charlieAssets > 0, "Charlie should redeem assets");
 
         vm.prank(dave);
-        uint256 daveAssets = _tokenized(address(mechanism)).redeem(daveShares, dave, dave);
+        uint256 daveAssets = _tokenized().redeem(daveShares, dave, dave);
         assertTrue(daveAssets > 0, "Dave should redeem assets");
 
         // Redeem Eve's shares if any
         uint256 eveAssets = 0;
         if (eveShares > 0) {
             vm.prank(eve);
-            eveAssets = _tokenized(address(mechanism)).redeem(eveShares, eve, eve);
+            eveAssets = _tokenized().redeem(eveShares, eve, eve);
         }
 
         // Final state verification
-        assertEq(_tokenized(address(mechanism)).totalSupply(), 0);
+        assertEq(_tokenized().totalSupply(), 0);
 
         // With matching pool, total assets redeemed should equal total mechanism assets
         uint256 totalMechanismAssets = LARGE_DEPOSIT + MEDIUM_DEPOSIT + SMALL_DEPOSIT + 2000 ether;

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingCrossJourneyTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingCrossJourneyTest.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Cross-Journey Integration Tests
 /// @notice Tests complete end-to-end workflows across voter, admin, and recipient journeys
@@ -104,12 +104,15 @@ contract QuadraticVotingCrossJourneyTest is QuadraticVotingTestBase {
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
 
         // Admin finalizes voting
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check final outcomes using QuadraticFunding algorithm
         // Charlie: Alice(30) + Bob(10) = (40)² × 0.5 + contributions × 0.5 = weighted funding meets quorum ✓
-        assertEq(uint256(_tokenized().state(pidCharlie)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded));
+        assertEq(
+            uint256(_tokenized().state(pidCharlie)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Succeeded)
+        );
 
         // Dave: Alice(10) + Bob(20) = (30)² × 0.5 + contributions × 0.5 = weighted funding meets quorum ✓
         assertEq(uint256(_tokenized().state(pidDave)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded));
@@ -118,10 +121,10 @@ contract QuadraticVotingCrossJourneyTest is QuadraticVotingTestBase {
         assertEq(uint256(_tokenized().state(pidEve)), uint256(TokenizedAllocationMechanism.ProposalState.Defeated));
 
         // Admin queues successful proposals
-        (bool success1,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidCharlie));
+        (bool success1, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidCharlie));
         require(success1, "Queue Charlie failed");
 
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidDave));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidDave));
         require(success2, "Queue Dave failed");
 
         // PHASE 5: RECIPIENT REDEMPTION AND ASSET UTILIZATION
@@ -199,7 +202,7 @@ contract QuadraticVotingCrossJourneyTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie);
 
         // Emergency pause during voting
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success, "Pause failed");
 
         // All operations blocked
@@ -208,7 +211,7 @@ contract QuadraticVotingCrossJourneyTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, charlie);
 
         // Resume operations
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
         require(success2, "Unpause failed");
 
         // Operations work again - use bob since alice already voted
@@ -216,24 +219,25 @@ contract QuadraticVotingCrossJourneyTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 15, charlie);
 
         // Ownership transfer during crisis
-        (bool success3,) =
-            address(mechanism).call(abi.encodeWithSignature("transferOwnership(address)", emergencyAdmin));
+        (bool success3, ) = address(mechanism).call(
+            abi.encodeWithSignature("transferOwnership(address)", emergencyAdmin)
+        );
         require(success3, "Transfer ownership failed");
 
         // New owner accepts ownership
         vm.prank(emergencyAdmin);
-        (bool success3b,) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
+        (bool success3b, ) = address(mechanism).call(abi.encodeWithSignature("acceptOwnership()"));
         require(success3b, "Accept ownership failed");
 
         // New owner manages crisis
         vm.startPrank(emergencyAdmin);
-        (bool success4,) = address(mechanism).call(abi.encodeWithSignature("pause()"));
+        (bool success4, ) = address(mechanism).call(abi.encodeWithSignature("pause()"));
         require(success4, "Emergency admin pause failed");
         vm.stopPrank();
 
         // System recovery
         vm.startPrank(emergencyAdmin);
-        (bool success5,) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
+        (bool success5, ) = address(mechanism).call(abi.encodeWithSignature("unpause()"));
         require(success5, "Recovery unpause failed");
         vm.stopPrank();
 
@@ -241,10 +245,10 @@ contract QuadraticVotingCrossJourneyTest is QuadraticVotingTestBase {
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
 
         vm.startPrank(emergencyAdmin);
-        (bool success6,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success6, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success6, "Emergency finalization failed");
 
-        (bool success7,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success7, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success7, "Emergency queuing failed");
         vm.stopPrank();
 
@@ -399,7 +403,7 @@ contract QuadraticVotingCrossJourneyTest is QuadraticVotingTestBase {
 
         // Finalize and determine outcomes
         vm.warp(block.timestamp + VOTING_PERIOD + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check complex voting outcomes using QuadraticFunding
@@ -414,16 +418,16 @@ contract QuadraticVotingCrossJourneyTest is QuadraticVotingTestBase {
         uint8 pid3State = uint8(_tokenized().state(pid3));
         // State could be Succeeded or Defeated depending on whether weighted funding meets 500 quorum
         assertTrue(
-            pid3State == uint8(TokenizedAllocationMechanism.ProposalState.Succeeded)
-                || pid3State == uint8(TokenizedAllocationMechanism.ProposalState.Defeated),
+            pid3State == uint8(TokenizedAllocationMechanism.ProposalState.Succeeded) ||
+                pid3State == uint8(TokenizedAllocationMechanism.ProposalState.Defeated),
             "pid3 should be either Succeeded or Defeated"
         );
 
         // Queue successful proposals
-        (bool success1,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
+        (bool success1, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
         require(success1, "Queue pid1 failed");
 
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
         require(success2, "Queue pid2 failed");
 
         // Verify share distribution based on actual proposal outcomes

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDebugTimelockTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDebugTimelockTest.t.sol
@@ -1,98 +1,61 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
-contract QuadraticVotingDebugTimelockTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1);
-    address charlie = address(0x3);
-
+contract QuadraticVotingDebugTimelockTest is QuadraticVotingTestBase {
     uint256 constant LARGE_DEPOSIT = 1000 ether;
     uint256 constant TIMELOCK_DELAY = 1 days;
-
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
 
     function setUp() public {
         // Set timestamp before deploying mechanism
         vm.warp(100000);
 
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting("Debug Test", "DEBUG", 100, 1000, 500, TIMELOCK_DELAY, 7 days, 50, 100);
         token.mint(alice, 2000 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Debug Test",
-            symbol: "DEBUG",
-            votingDelay: 100,
-            votingPeriod: 1000,
-            quorumShares: 500,
-            timelockDelay: TIMELOCK_DELAY,
-            gracePeriod: 7 days,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-        _tokenized(address(mechanism)).setKeeper(alice);
+        _tokenized().setKeeper(alice);
     }
 
     function testDebugTimelock() public {
         console.log("Initial timestamp:", block.timestamp);
 
         // Setup successful proposal during delay period (before voting starts)
-        vm.startPrank(alice);
-        token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Charlie's Project");
-        vm.stopPrank();
+        _signup(alice, LARGE_DEPOSIT);
+        uint256 pid = _propose(alice, charlie, "Charlie's Project");
 
         // Move to voting period: startTime + votingDelay = 100000 + 100 = 100100
         vm.warp(100100);
 
-        vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 31, charlie); // 31^2 = 961 > 500 quorum
+        _vote(alice, pid, 31, charlie); // 31^2 = 961 > 500 quorum
 
         // Move past voting period: startTime + votingDelay + votingPeriod = 100000 + 100 + 1000 = 101100
         vm.warp(101101);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         console.log("=== BEFORE QUEUING ===");
         console.log("Current timestamp:", block.timestamp);
-        console.log("Charlie redeemableAfter BEFORE:", _tokenized(address(mechanism)).globalRedemptionStart());
-        console.log("Charlie balance BEFORE:", _tokenized(address(mechanism)).balanceOf(charlie));
-        console.log("Charlie maxRedeem BEFORE:", _tokenized(address(mechanism)).maxRedeem(charlie));
+        console.log("Charlie redeemableAfter BEFORE:", _tokenized().globalRedemptionStart());
+        console.log("Charlie balance BEFORE:", _tokenized().balanceOf(charlie));
+        console.log("Charlie maxRedeem BEFORE:", _tokenized().maxRedeem(charlie));
 
         uint256 queueTime = block.timestamp;
         console.log("Queue time:", queueTime);
-        console.log("Timelock delay:", _tokenized(address(mechanism)).timelockDelay());
+        console.log("Timelock delay:", _tokenized().timelockDelay());
         console.log("Expected redeemable time:", queueTime + TIMELOCK_DELAY);
 
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         console.log("=== AFTER QUEUING ===");
         console.log("Current timestamp:", block.timestamp);
-        console.log("Charlie redeemableAfter AFTER:", _tokenized(address(mechanism)).globalRedemptionStart());
-        console.log("Charlie balance AFTER:", _tokenized(address(mechanism)).balanceOf(charlie));
-        console.log("Charlie maxRedeem AFTER:", _tokenized(address(mechanism)).maxRedeem(charlie));
+        console.log("Charlie redeemableAfter AFTER:", _tokenized().globalRedemptionStart());
+        console.log("Charlie balance AFTER:", _tokenized().balanceOf(charlie));
+        console.log("Charlie maxRedeem AFTER:", _tokenized().maxRedeem(charlie));
 
         // Check if timelock is working
-        uint256 maxRedeem = _tokenized(address(mechanism)).maxRedeem(charlie);
+        uint256 maxRedeem = _tokenized().maxRedeem(charlie);
         console.log("Max redeem immediately after queue:", maxRedeem);
 
         if (maxRedeem == 0) {
@@ -103,7 +66,7 @@ contract QuadraticVotingDebugTimelockTest is Test {
         }
 
         // Debug the _availableWithdrawLimit logic step by step
-        uint256 redeemableTime = _tokenized(address(mechanism)).globalRedemptionStart();
+        uint256 redeemableTime = _tokenized().globalRedemptionStart();
         console.log("Debug - redeemableTime:", redeemableTime);
         console.log("Debug - block.timestamp:", block.timestamp);
         console.log("Debug - block.timestamp < redeemableTime:", block.timestamp < redeemableTime);

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDebugTimelockTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDebugTimelockTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 contract QuadraticVotingDebugTimelockTest is QuadraticVotingTestBase {
     uint256 constant LARGE_DEPOSIT = 1000 ether;
@@ -31,7 +31,7 @@ contract QuadraticVotingDebugTimelockTest is QuadraticVotingTestBase {
 
         // Move past voting period: startTime + votingDelay + votingPeriod = 100000 + 100 + 1000 = 101100
         vm.warp(101101);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         console.log("=== BEFORE QUEUING ===");
@@ -45,7 +45,7 @@ contract QuadraticVotingDebugTimelockTest is QuadraticVotingTestBase {
         console.log("Timelock delay:", _tokenized().timelockDelay());
         console.log("Expected redeemable time:", queueTime + TIMELOCK_DELAY);
 
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         console.log("=== AFTER QUEUING ===");

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDecimalNormalizationTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDecimalNormalizationTest.t.sol
@@ -1,15 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
-import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {AllocationTestHelpers} from "../utils/AllocationTestHelpers.sol";
 
 /// @title Mock ERC20 with configurable decimals
 contract MockToken is ERC20 {
@@ -32,7 +30,7 @@ contract MockToken is ERC20 {
 /// @notice Tests that calculateOptimalAlpha() works correctly with tokens of different decimal configurations
 /// @dev Demonstrates the fix for the decimal normalization bug where compareOptimalAlpha() would
 ///      incorrectly compare raw token amounts with 18-decimal normalized quadratic/linear sums
-contract QuadraticVotingDecimalNormalizationTest is Test {
+contract QuadraticVotingDecimalNormalizationTest is AllocationTestHelpers {
     AllocationMechanismFactory factory;
     MockToken token6Decimals; // USDC-like token
     MockToken token18Decimals; // ETH-like token
@@ -54,10 +52,6 @@ contract QuadraticVotingDecimalNormalizationTest is Test {
     uint256 constant GRACE_PERIOD = 7 days;
     uint256 constant QUORUM_REQUIREMENT = 100 ether; // In 18 decimals
 
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
     function setUp() public {
         factory = new AllocationMechanismFactory();
 
@@ -76,20 +70,22 @@ contract QuadraticVotingDecimalNormalizationTest is Test {
     }
 
     function _deployMechanism(MockToken token) internal returns (QuadraticVotingMechanism) {
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: string.concat("QV Mechanism ", token.symbol()),
-            symbol: string.concat("QV", token.symbol()),
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_REQUIREMENT,
-            timelockDelay: TIMELOCK_DELAY,
-            gracePeriod: GRACE_PERIOD,
-            owner: address(this)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 1, 2); // Alpha = 0.5
-        return QuadraticVotingMechanism(payable(mechanismAddr));
+        return _deployQuadraticVoting(
+            factory,
+            _config({
+                asset: IERC20(address(token)),
+                name: string.concat("QV Mechanism ", token.symbol()),
+                symbol: string.concat("QV", token.symbol()),
+                votingDelay: VOTING_DELAY,
+                votingPeriod: VOTING_PERIOD,
+                quorumShares: QUORUM_REQUIREMENT,
+                timelockDelay: TIMELOCK_DELAY,
+                gracePeriod: GRACE_PERIOD,
+                owner: address(this)
+            }),
+            1,
+            2
+        );
     }
 
     function _fundUsers() internal {
@@ -104,7 +100,7 @@ contract QuadraticVotingDecimalNormalizationTest is Test {
 
         // Fund each user for each token
         address[3] memory users = [alice, bob, charlie];
-        for (uint i = 0; i < users.length; i++) {
+        for (uint256 i = 0; i < users.length; i++) {
             token6Decimals.mint(users[i], amount6 * 10); // Extra for testing
             token18Decimals.mint(users[i], amount18 * 10);
             token8Decimals.mint(users[i], amount8 * 10);
@@ -185,10 +181,8 @@ contract QuadraticVotingDecimalNormalizationTest is Test {
         console.log("Total assets (6 decimals):", totalAssets);
         console.log("Total assets normalized (18 decimals):", totalAssets * 10 ** 12);
 
-        (uint256 alphaNumerator, uint256 alphaDenominator) = mechanism6.calculateOptimalAlpha(
-            smallMatchingPool,
-            smallUserDeposits
-        );
+        (uint256 alphaNumerator, uint256 alphaDenominator) =
+            mechanism6.calculateOptimalAlpha(smallMatchingPool, smallUserDeposits);
 
         console.log("Calculated alpha:", alphaNumerator, "/", alphaDenominator);
 
@@ -219,7 +213,7 @@ contract QuadraticVotingDecimalNormalizationTest is Test {
 
         // Users register and approve tokens
         address[3] memory users = [alice, bob, charlie];
-        for (uint i = 0; i < users.length; i++) {
+        for (uint256 i = 0; i < users.length; i++) {
             vm.startPrank(users[i]);
             token.approve(address(mechanism), depositAmount);
             _tokenized(address(mechanism)).signup(depositAmount);
@@ -249,8 +243,8 @@ contract QuadraticVotingDecimalNormalizationTest is Test {
         address[3] memory users = [alice, bob, charlie];
         QuadraticVotingMechanism[3] memory mechanisms = [mechanism6, mechanism18, mechanism8];
 
-        for (uint m = 0; m < mechanisms.length; m++) {
-            for (uint i = 0; i < users.length; i++) {
+        for (uint256 m = 0; m < mechanisms.length; m++) {
+            for (uint256 i = 0; i < users.length; i++) {
                 vm.startPrank(users[i]);
 
                 // Vote on proposal 1 and 2 with weight 10 each
@@ -277,7 +271,7 @@ contract QuadraticVotingDecimalNormalizationTest is Test {
         // Cast votes on the mechanism
         address[3] memory users = [alice, bob, charlie];
 
-        for (uint i = 0; i < users.length; i++) {
+        for (uint256 i = 0; i < users.length; i++) {
             vm.startPrank(users[i]);
 
             // Vote on proposal 1 and 2 with weight 10 each

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDecimalNormalizationTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDecimalNormalizationTest.t.sol
@@ -2,12 +2,12 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import {AllocationTestHelpers} from "../utils/AllocationTestHelpers.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20 } from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import { AllocationTestHelpers } from "../utils/AllocationTestHelpers.sol";
 
 /// @title Mock ERC20 with configurable decimals
 contract MockToken is ERC20 {
@@ -70,22 +70,23 @@ contract QuadraticVotingDecimalNormalizationTest is AllocationTestHelpers {
     }
 
     function _deployMechanism(MockToken token) internal returns (QuadraticVotingMechanism) {
-        return _deployQuadraticVoting(
-            factory,
-            _config({
-                asset: IERC20(address(token)),
-                name: string.concat("QV Mechanism ", token.symbol()),
-                symbol: string.concat("QV", token.symbol()),
-                votingDelay: VOTING_DELAY,
-                votingPeriod: VOTING_PERIOD,
-                quorumShares: QUORUM_REQUIREMENT,
-                timelockDelay: TIMELOCK_DELAY,
-                gracePeriod: GRACE_PERIOD,
-                owner: address(this)
-            }),
-            1,
-            2
-        );
+        return
+            _deployQuadraticVoting(
+                factory,
+                _config({
+                    asset: IERC20(address(token)),
+                    name: string.concat("QV Mechanism ", token.symbol()),
+                    symbol: string.concat("QV", token.symbol()),
+                    votingDelay: VOTING_DELAY,
+                    votingPeriod: VOTING_PERIOD,
+                    quorumShares: QUORUM_REQUIREMENT,
+                    timelockDelay: TIMELOCK_DELAY,
+                    gracePeriod: GRACE_PERIOD,
+                    owner: address(this)
+                }),
+                1,
+                2
+            );
     }
 
     function _fundUsers() internal {
@@ -181,8 +182,10 @@ contract QuadraticVotingDecimalNormalizationTest is AllocationTestHelpers {
         console.log("Total assets (6 decimals):", totalAssets);
         console.log("Total assets normalized (18 decimals):", totalAssets * 10 ** 12);
 
-        (uint256 alphaNumerator, uint256 alphaDenominator) =
-            mechanism6.calculateOptimalAlpha(smallMatchingPool, smallUserDeposits);
+        (uint256 alphaNumerator, uint256 alphaDenominator) = mechanism6.calculateOptimalAlpha(
+            smallMatchingPool,
+            smallUserDeposits
+        );
 
         console.log("Calculated alpha:", alphaNumerator, "/", alphaDenominator);
 

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDefeatedStateTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDefeatedStateTest.t.sol
@@ -1,52 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
-contract QuadraticVotingDefeatedStateTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1);
-    address frank = address(0x6);
-
+contract QuadraticVotingDefeatedStateTest is QuadraticVotingTestBase {
     uint256 constant LARGE_DEPOSIT = 1000 ether;
     uint256 constant QUORUM_REQUIREMENT = 200 ether;
     uint256 constant VOTING_DELAY = 100;
     uint256 constant VOTING_PERIOD = 1000;
 
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting(
+            "Debug Defeated", "DEBUG", VOTING_DELAY, VOTING_PERIOD, QUORUM_REQUIREMENT, 1 days, 7 days, 50, 100
+        );
         token.mint(alice, 2000 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Debug Defeated",
-            symbol: "DEBUG",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_REQUIREMENT,
-            timelockDelay: 1 days,
-            gracePeriod: 7 days,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-        _tokenized(address(mechanism)).setKeeper(alice);
+        _tokenized().setKeeper(alice);
     }
 
     function testDebugDefeatedState() public {
@@ -54,8 +24,8 @@ contract QuadraticVotingDefeatedStateTest is Test {
         // The mechanism sets startTime = block.timestamp during initialization
         // We can calculate the timeline from the deployment time and configuration
         uint256 deploymentTime = block.timestamp; // Time when mechanism was deployed in setUp()
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
 
         // Calculate absolute timeline timestamps
         uint256 startTime = deploymentTime; // Contract sets this during initialization
@@ -67,30 +37,25 @@ contract QuadraticVotingDefeatedStateTest is Test {
         console.log("Timeline - Voting End:", votingEndTime);
 
         // Setup voter
-        vm.startPrank(alice);
-        token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        vm.stopPrank();
+        _signup(alice, LARGE_DEPOSIT);
 
-        console.log("Alice voting power:", _tokenized(address(mechanism)).votingPower(alice));
-        console.log("Quorum requirement:", _tokenized(address(mechanism)).quorumShares());
+        console.log("Alice voting power:", _tokenized().votingPower(alice));
+        console.log("Quorum requirement:", _tokenized().quorumShares());
 
         // Create proposal that should be defeated
-        vm.prank(alice);
-        uint256 pid = _tokenized(address(mechanism)).propose(frank, "Frank's Low Vote Proposal");
+        uint256 pid = _propose(alice, frank, "Frank's Low Vote Proposal");
 
         // Warp to absolute voting start time (not relative)
         vm.warp(votingStartTime + 1);
         console.log("Warped to voting time:", block.timestamp);
 
         // Vote with insufficient amount for quorum - QuadraticFunding calculation needed
-        vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, frank);
+        _vote(alice, pid, 10, frank);
 
         console.log("Vote weight: 10, quadratic cost: 100 voting power");
 
         // Check vote tally before finalization using getTally() from ProperQF
-        (, , uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
+        (,, uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
         uint256 forVotes = quadraticFunding + linearFunding;
         uint256 againstVotes = 0; // QuadraticVoting only supports For votes
         uint256 abstainVotes = 0; // QuadraticVoting only supports For votes
@@ -101,11 +66,11 @@ contract QuadraticVotingDefeatedStateTest is Test {
         // Warp to absolute voting end time for finalization (not relative)
         vm.warp(votingEndTime + 1);
         console.log("Warped to finalization time:", block.timestamp);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check if proposal has quorum
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("hasQuorumHook(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("hasQuorumHook(uint256)", pid));
         console.log("hasQuorumHook call success:", success2);
 
         // Check QuadraticFunding weighted total for quorum
@@ -114,20 +79,20 @@ contract QuadraticVotingDefeatedStateTest is Test {
         console.log("Has quorum:", forVotes >= QUORUM_REQUIREMENT);
 
         // Check actual state
-        uint256 actualState = uint(_tokenized(address(mechanism)).state(pid));
+        uint256 actualState = uint256(_tokenized().state(pid));
         console.log("Actual state:", actualState);
-        console.log("Expected Defeated state:", uint(TokenizedAllocationMechanism.ProposalState.Defeated));
+        console.log("Expected Defeated state:", uint256(TokenizedAllocationMechanism.ProposalState.Defeated));
 
-        if (actualState == uint(TokenizedAllocationMechanism.ProposalState.Defeated)) {
+        if (actualState == uint256(TokenizedAllocationMechanism.ProposalState.Defeated)) {
             console.log("SUCCESS: Proposal is correctly DEFEATED");
         } else {
             console.log("FAILURE: Proposal should be DEFEATED but has different state");
 
-            if (actualState == uint(TokenizedAllocationMechanism.ProposalState.Active)) {
+            if (actualState == uint256(TokenizedAllocationMechanism.ProposalState.Active)) {
                 console.log("State is ACTIVE");
-            } else if (actualState == uint(TokenizedAllocationMechanism.ProposalState.Succeeded)) {
+            } else if (actualState == uint256(TokenizedAllocationMechanism.ProposalState.Succeeded)) {
                 console.log("State is SUCCEEDED");
-            } else if (actualState == uint(TokenizedAllocationMechanism.ProposalState.Pending)) {
+            } else if (actualState == uint256(TokenizedAllocationMechanism.ProposalState.Pending)) {
                 console.log("State is PENDING");
             }
         }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDefeatedStateTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingDefeatedStateTest.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 contract QuadraticVotingDefeatedStateTest is QuadraticVotingTestBase {
     uint256 constant LARGE_DEPOSIT = 1000 ether;
@@ -13,7 +13,15 @@ contract QuadraticVotingDefeatedStateTest is QuadraticVotingTestBase {
 
     function setUp() public {
         _setUpQuadraticVoting(
-            "Debug Defeated", "DEBUG", VOTING_DELAY, VOTING_PERIOD, QUORUM_REQUIREMENT, 1 days, 7 days, 50, 100
+            "Debug Defeated",
+            "DEBUG",
+            VOTING_DELAY,
+            VOTING_PERIOD,
+            QUORUM_REQUIREMENT,
+            1 days,
+            7 days,
+            50,
+            100
         );
         token.mint(alice, 2000 ether);
         _tokenized().setKeeper(alice);
@@ -55,7 +63,7 @@ contract QuadraticVotingDefeatedStateTest is QuadraticVotingTestBase {
         console.log("Vote weight: 10, quadratic cost: 100 voting power");
 
         // Check vote tally before finalization using getTally() from ProperQF
-        (,, uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
+        (, , uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
         uint256 forVotes = quadraticFunding + linearFunding;
         uint256 againstVotes = 0; // QuadraticVoting only supports For votes
         uint256 abstainVotes = 0; // QuadraticVoting only supports For votes
@@ -66,11 +74,11 @@ contract QuadraticVotingDefeatedStateTest is QuadraticVotingTestBase {
         // Warp to absolute voting end time for finalization (not relative)
         vm.warp(votingEndTime + 1);
         console.log("Warped to finalization time:", block.timestamp);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check if proposal has quorum
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("hasQuorumHook(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("hasQuorumHook(uint256)", pid));
         console.log("hasQuorumHook call success:", success2);
 
         // Check QuadraticFunding weighted total for quorum

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingE2E.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingE2E.t.sol
@@ -1,19 +1,17 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {AllocationTestHelpers} from "../utils/AllocationTestHelpers.sol";
 
 /// @title Quadratic Voting End-to-End Test
 /// @notice Complete end-to-end testing of the quadratic voting mechanism
 /// @dev Tests the full user journey from registration through final redemption
-contract QuadraticVotingE2E is Test {
+contract QuadraticVotingE2E is AllocationTestHelpers {
     // General purpose struct to avoid stack too deep errors
     struct TestData {
         // Common data
@@ -85,18 +83,11 @@ contract QuadraticVotingE2E is Test {
     uint256 constant TIMELOCK_DELAY = 1 days;
     uint256 constant GRACE_PERIOD = 7 days;
 
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
     /// @notice Helper function to sign up a user with specified deposit
     /// @param user Address of user to sign up
     /// @param depositAmount Amount of tokens to deposit
     function _signupUser(address user, uint256 depositAmount) internal {
-        vm.startPrank(user);
-        token.approve(address(mechanism), depositAmount);
-        _tokenized(address(mechanism)).signup(depositAmount);
-        vm.stopPrank();
+        _signupUser(token, mechanism, user, depositAmount);
     }
 
     /// @notice Helper function to create a proposal
@@ -105,13 +96,11 @@ contract QuadraticVotingE2E is Test {
     /// @param recipient Address that will receive funds if proposal passes
     /// @param description Description of the proposal
     /// @return pid The proposal ID
-    function _createProposal(
-        address proposer,
-        address recipient,
-        string memory description
-    ) internal returns (uint256 pid) {
-        vm.prank(proposer);
-        pid = _tokenized(address(mechanism)).propose(recipient, description);
+    function _createProposal(address proposer, address recipient, string memory description)
+        internal
+        returns (uint256 pid)
+    {
+        pid = _createProposal(mechanism, proposer, recipient, description);
     }
 
     /// @notice Helper function to cast a vote on a proposal
@@ -120,15 +109,12 @@ contract QuadraticVotingE2E is Test {
     /// @param weight Vote weight (quadratic cost = weight^2)
     /// @return previousPower Voting power before the vote
     /// @return newPower Voting power after the vote
-    function _castVote(
-        address voter,
-        uint256 pid,
-        uint256 weight,
-        address recipient
-    ) internal returns (uint256 previousPower, uint256 newPower) {
+    function _castVote(address voter, uint256 pid, uint256 weight, address recipient)
+        internal
+        returns (uint256 previousPower, uint256 newPower)
+    {
         previousPower = _tokenized(address(mechanism)).votingPower(voter);
-        vm.prank(voter);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, weight, recipient);
+        _castVote(mechanism, voter, pid, weight, recipient);
         newPower = _tokenized(address(mechanism)).votingPower(voter);
     }
 
@@ -137,9 +123,11 @@ contract QuadraticVotingE2E is Test {
     /// @return matchingFundsNeeded Amount of additional funds needed for 1:1 ratio
     /// @return totalQuadraticSum Total quadratic sum from all proposals
     /// @return totalLinearSum Total linear sum from all proposals (user contributions)
-    function _calculateMatchingFunds(
-        uint256 totalUserDeposits
-    ) internal view returns (uint256 matchingFundsNeeded, uint256 totalQuadraticSum, uint256 totalLinearSum) {
+    function _calculateMatchingFunds(uint256 totalUserDeposits)
+        internal
+        view
+        returns (uint256 matchingFundsNeeded, uint256 totalQuadraticSum, uint256 totalLinearSum)
+    {
         totalQuadraticSum = mechanism.totalQuadraticSum();
         totalLinearSum = mechanism.totalLinearSum();
 
@@ -216,22 +204,22 @@ contract QuadraticVotingE2E is Test {
         token.mint(bob, INITIAL_TOKEN_BALANCE);
         token.mint(charlie, INITIAL_TOKEN_BALANCE);
 
-        // Configure the allocation mechanism
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "E2E Test Mechanism",
-            symbol: "E2E",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_REQUIREMENT,
-            timelockDelay: TIMELOCK_DELAY,
-            gracePeriod: GRACE_PERIOD,
-            owner: address(0)
-        });
-
-        // Deploy quadratic voting mechanism with 100% quadratic funding
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, ALPHA_NUMERATOR, ALPHA_DENOMINATOR);
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
+        mechanism = _deployQuadraticVoting(
+            factory,
+            _config({
+                asset: token,
+                name: "E2E Test Mechanism",
+                symbol: "E2E",
+                votingDelay: VOTING_DELAY,
+                votingPeriod: VOTING_PERIOD,
+                quorumShares: QUORUM_REQUIREMENT,
+                timelockDelay: TIMELOCK_DELAY,
+                gracePeriod: GRACE_PERIOD,
+                owner: address(0)
+            }),
+            ALPHA_NUMERATOR,
+            ALPHA_DENOMINATOR
+        );
 
         // Set alice as keeper and bob as management (both can create proposals)
         _tokenized(address(mechanism)).setKeeper(alice);
@@ -289,9 +277,7 @@ contract QuadraticVotingE2E is Test {
         assertEq(_tokenized(address(mechanism)).votingPower(alice), 0, "Alice should have no voting power initially");
         assertEq(_tokenized(address(mechanism)).votingPower(bob), 0, "Bob should have no voting power initially");
         assertEq(
-            _tokenized(address(mechanism)).votingPower(charlie),
-            0,
-            "Charlie should have no voting power initially"
+            _tokenized(address(mechanism)).votingPower(charlie), 0, "Charlie should have no voting power initially"
         );
 
         // Verify recipient addresses have zero balances
@@ -335,9 +321,7 @@ contract QuadraticVotingE2E is Test {
             "Bob should have voting power equal to his deposit"
         );
         assertEq(
-            token.balanceOf(address(mechanism)),
-            DEPOSIT_AMOUNT + bobDeposit,
-            "Mechanism should have both deposits"
+            token.balanceOf(address(mechanism)), DEPOSIT_AMOUNT + bobDeposit, "Mechanism should have both deposits"
         );
 
         // Sign up Charlie with zero deposit
@@ -454,18 +438,13 @@ contract QuadraticVotingE2E is Test {
 
         // Verify mechanism state remains consistent
         assertEq(
-            token.balanceOf(address(mechanism)),
-            totalDeposits,
-            "Mechanism balance should be unchanged by proposals"
+            token.balanceOf(address(mechanism)), totalDeposits, "Mechanism balance should be unchanged by proposals"
         );
-        assertEq(
-            _tokenized(address(mechanism)).totalSupply(),
-            0,
-            "No shares should be minted during proposal creation"
-        );
+        assertEq(_tokenized(address(mechanism)).totalSupply(), 0, "No shares should be minted during proposal creation");
 
         console.log("Workflow test complete - 3 users signed up, 3 proposals created");
     }
+
     /// @notice Test voting edge cases and error conditions
     function testVotingErrorConditions() public {
         // ✅ CORRECT: Fetch absolute timeline from contract
@@ -674,9 +653,8 @@ contract QuadraticVotingE2E is Test {
         console.log("=== MATCHING FUNDS CALCULATION TEST ===");
 
         // Calculate matching funds needed before finalization
-        (uint256 matchingFundsNeeded, uint256 totalQuadraticSum, uint256 totalLinearSum) = _calculateMatchingFunds(
-            totalUserDeposits
-        );
+        (uint256 matchingFundsNeeded, uint256 totalQuadraticSum, uint256 totalLinearSum) =
+            _calculateMatchingFunds(totalUserDeposits);
 
         console.log("Total Quadratic Sum:", totalQuadraticSum);
         console.log("Total Linear Sum:", totalLinearSum);
@@ -795,12 +773,8 @@ contract QuadraticVotingE2E is Test {
         uint256 fixedMatchingPool = 300 ether;
 
         // Calculate optimal alpha
-        (uint256 alphaNumerator, uint256 alphaDenominator) = _calculateOptimalAlpha(
-            fixedMatchingPool,
-            totalQuadraticSum,
-            totalLinearSum,
-            totalUserDeposits
-        );
+        (uint256 alphaNumerator, uint256 alphaDenominator) =
+            _calculateOptimalAlpha(fixedMatchingPool, totalQuadraticSum, totalLinearSum, totalUserDeposits);
 
         // console.log("Fixed matching pool:", fixedMatchingPool);
         // console.log("Calculated alpha:", alphaNumerator, "/", alphaDenominator);
@@ -920,10 +894,8 @@ contract QuadraticVotingE2E is Test {
         uint256 smallMatchingPool = 200 ether;
 
         // Calculate optimal alpha using mechanism's function
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            smallMatchingPool,
-            totalUserDeposits
-        );
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(smallMatchingPool, totalUserDeposits);
 
         console.log("Small matching pool:", smallMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1001,10 +973,8 @@ contract QuadraticVotingE2E is Test {
         uint256 mediumMatchingPool = 600 ether;
 
         // Calculate optimal alpha
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            mediumMatchingPool,
-            totalUserDeposits
-        );
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(mediumMatchingPool, totalUserDeposits);
 
         console.log("Medium matching pool:", mediumMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1087,10 +1057,8 @@ contract QuadraticVotingE2E is Test {
         uint256 variedMatchingPool = 500 ether;
 
         // Calculate optimal alpha
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            variedMatchingPool,
-            totalUserDeposits
-        );
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(variedMatchingPool, totalUserDeposits);
 
         console.log("Varied matching pool:", variedMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1128,9 +1096,7 @@ contract QuadraticVotingE2E is Test {
         assertTrue(recipient2Shares > 0, "Recipient 2 should receive shares");
         assertTrue(recipient3Shares > 0, "Recipient 3 should receive shares");
         assertEq(
-            recipient1Shares + recipient2Shares + recipient3Shares,
-            totalShares,
-            "Individual shares should sum to total"
+            recipient1Shares + recipient2Shares + recipient3Shares, totalShares, "Individual shares should sum to total"
         );
 
         console.log("Alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1188,10 +1154,8 @@ contract QuadraticVotingE2E is Test {
         uint256 largeMatchingPool = 50_000_000 ether; // 50M tokens
 
         // Calculate optimal alpha with large numbers
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            largeMatchingPool,
-            totalUserDeposits
-        );
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(largeMatchingPool, totalUserDeposits);
 
         console.log("Large matching pool:", largeMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1218,10 +1182,7 @@ contract QuadraticVotingE2E is Test {
         uint256 totalShares = _tokenized(address(mechanism)).totalSupply();
         uint256 totalAssets = token.balanceOf(address(mechanism));
         assertApproxEqAbs(
-            totalShares,
-            totalAssets,
-            1000,
-            "Total shares should approximately equal total assets at large scale"
+            totalShares, totalAssets, 1000, "Total shares should approximately equal total assets at large scale"
         );
 
         console.log("Large scale alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1269,10 +1230,8 @@ contract QuadraticVotingE2E is Test {
         uint256 tinyMatchingPool = 1;
 
         // Calculate optimal alpha with tiny matching pool
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            tinyMatchingPool,
-            totalUserDeposits
-        );
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(tinyMatchingPool, totalUserDeposits);
 
         console.log("Tiny matching pool:", tinyMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1299,10 +1258,7 @@ contract QuadraticVotingE2E is Test {
         uint256 totalShares = _tokenized(address(mechanism)).totalSupply();
         uint256 totalAssets = token.balanceOf(address(mechanism));
         assertApproxEqAbs(
-            totalShares,
-            totalAssets,
-            100,
-            "Total shares should approximately equal total assets with tiny pool"
+            totalShares, totalAssets, 100, "Total shares should approximately equal total assets with tiny pool"
         );
 
         console.log("Tiny pool alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1355,10 +1311,8 @@ contract QuadraticVotingE2E is Test {
         uint256 nearFullMatchingPool = quadraticAdvantage - 1; // 1 wei short of full quadratic
 
         // Calculate optimal alpha (should be very close to 1)
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            nearFullMatchingPool,
-            totalUserDeposits
-        );
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(nearFullMatchingPool, totalUserDeposits);
 
         console.log("Near-full matching pool:", nearFullMatchingPool);
         console.log("Quadratic advantage:", quadraticAdvantage);
@@ -1383,9 +1337,7 @@ contract QuadraticVotingE2E is Test {
         // Verify 1:1 ratio is not violated (it's OK to be over 1:1, but not under)
         uint256 assetsFor1Share = _tokenized(address(mechanism)).convertToAssets(1e18);
         assertGe(
-            assetsFor1Share,
-            1e18,
-            "1:1 ratio should not be violated - users should get at least 1:1 assets per share"
+            assetsFor1Share, 1e18, "1:1 ratio should not be violated - users should get at least 1:1 assets per share"
         );
 
         uint256 totalShares = _tokenized(address(mechanism)).totalSupply();
@@ -1452,10 +1404,8 @@ contract QuadraticVotingE2E is Test {
         uint256 moderateMatchingPool = 5000 ether; // Much smaller than quadratic advantage
 
         // Calculate optimal alpha (should have large denominator)
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            moderateMatchingPool,
-            totalUserDeposits
-        );
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(moderateMatchingPool, totalUserDeposits);
 
         console.log("Moderate matching pool:", moderateMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1483,10 +1433,7 @@ contract QuadraticVotingE2E is Test {
         uint256 totalShares = _tokenized(address(mechanism)).totalSupply();
         uint256 totalAssets = token.balanceOf(address(mechanism));
         assertApproxEqAbs(
-            totalShares,
-            totalAssets,
-            100,
-            "Total shares should approximately equal total assets with huge advantage"
+            totalShares, totalAssets, 100, "Total shares should approximately equal total assets with huge advantage"
         );
 
         console.log("Huge advantage alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1540,10 +1487,8 @@ contract QuadraticVotingE2E is Test {
         console.log("Excess matching funds:", excessMatchingFunds);
 
         // Calculate optimal alpha with excess funds (should be alpha = 1)
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            excessMatchingFunds,
-            totalUserDeposits
-        );
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(excessMatchingFunds, totalUserDeposits);
 
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
 
@@ -1574,9 +1519,7 @@ contract QuadraticVotingE2E is Test {
         // With alpha=1 and excess matching funds, the ratio should be >1:1
         assertGt(assetsFor1Share, 1e18, "Ratio should be >1:1 when alpha=1 and there are excess matching funds");
         assertGt(
-            totalAssets,
-            totalShares,
-            "Total assets should exceed total shares when there are excess matching funds"
+            totalAssets, totalShares, "Total assets should exceed total shares when there are excess matching funds"
         );
 
         // Verify that total shares equals total quadratic funding (since alpha=1)
@@ -1584,11 +1527,7 @@ contract QuadraticVotingE2E is Test {
 
         // Verify that excess funds remain in the contract (not allocated to shares)
         uint256 expectedExcessAssets = totalUserDeposits + excessMatchingFunds;
-        assertEq(
-            totalAssets,
-            expectedExcessAssets,
-            "Total assets should include user deposits + excess matching funds"
-        );
+        assertEq(totalAssets, expectedExcessAssets, "Total assets should include user deposits + excess matching funds");
 
         console.log("=== VALIDATION COMPLETE ===");
         console.log("Confirmed: >1:1 ratio only occurs with alpha=1 and excess matching funds");
@@ -1628,18 +1567,15 @@ contract QuadraticVotingE2E is Test {
         uint256 limitedMatchingPool = 400 ether; // Less than full quadratic advantage
 
         // Calculate optimal alpha (should be < 1)
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            limitedMatchingPool,
-            totalUserDeposits
-        );
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(limitedMatchingPool, totalUserDeposits);
 
         console.log("Limited matching pool:", limitedMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
 
         // Verify alpha < 1
         assertTrue(
-            optimalAlphaNumerator < optimalAlphaDenominator,
-            "Alpha should be less than 1 with limited matching funds"
+            optimalAlphaNumerator < optimalAlphaDenominator, "Alpha should be less than 1 with limited matching funds"
         );
 
         // Apply limited matching funds and fractional alpha
@@ -1665,10 +1601,7 @@ contract QuadraticVotingE2E is Test {
         // With fractional alpha, ratio should be 1:1 (or very close due to rounding)
         assertApproxEqAbs(assetsFor1Share, 1e18, 10, "Ratio should be approximately 1:1 when alpha < 1");
         assertApproxEqAbs(
-            totalAssets,
-            totalShares,
-            10,
-            "Total assets should approximately equal total shares when alpha < 1"
+            totalAssets, totalShares, 10, "Total assets should approximately equal total shares when alpha < 1"
         );
 
         // Verify that we're not over-collateralized when alpha < 1
@@ -1772,10 +1705,8 @@ contract QuadraticVotingE2E is Test {
 
         // Finalize and test actual share distribution
         vm.warp(
-            data.deploymentTime +
-                _tokenized(address(mechanism)).votingDelay() +
-                _tokenized(address(mechanism)).votingPeriod() +
-                1
+            data.deploymentTime + _tokenized(address(mechanism)).votingDelay()
+                + _tokenized(address(mechanism)).votingPeriod() + 1
         );
         _tokenized(address(mechanism)).finalizeVoteTally();
         _tokenized(address(mechanism)).queueProposal(data.pid1);
@@ -1829,10 +1760,8 @@ contract QuadraticVotingE2E is Test {
         data.totalLinearSum = mechanism.totalLinearSum();
 
         // Calculate optimal alpha
-        (data.optimalAlphaNumerator, data.optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            data.fixedMatchingPool,
-            data.totalUserDeposits
-        );
+        (data.optimalAlphaNumerator, data.optimalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(data.fixedMatchingPool, data.totalUserDeposits);
 
         // Apply optimal alpha and add matching pool
         token.mint(address(this), data.fixedMatchingPool);
@@ -1850,20 +1779,18 @@ contract QuadraticVotingE2E is Test {
         assertTrue(totalFundingAfterAlpha != totalFundingBeforeAlpha, "setAlpha should update totalFunding");
 
         // Calculate expected total funding with optimal alpha
-        uint256 expectedTotalFunding = (data.totalQuadraticSum * data.optimalAlphaNumerator) /
-            data.optimalAlphaDenominator +
-            (data.totalLinearSum * (data.optimalAlphaDenominator - data.optimalAlphaNumerator)) /
-            data.optimalAlphaDenominator;
+        uint256 expectedTotalFunding = (data.totalQuadraticSum * data.optimalAlphaNumerator)
+            / data.optimalAlphaDenominator
+            + (data.totalLinearSum * (data.optimalAlphaDenominator - data.optimalAlphaNumerator))
+            / data.optimalAlphaDenominator;
 
         // Check if setAlpha updated totalFunding correctly
         assertEq(totalFundingAfterAlpha, expectedTotalFunding, "setAlpha should update totalFunding correctly");
 
         // Finalize to update totalFunding storage
         vm.warp(
-            data.deploymentTime +
-                _tokenized(address(mechanism)).votingDelay() +
-                _tokenized(address(mechanism)).votingPeriod() +
-                1
+            data.deploymentTime + _tokenized(address(mechanism)).votingDelay()
+                + _tokenized(address(mechanism)).votingPeriod() + 1
         );
         _tokenized(address(mechanism)).finalizeVoteTally();
 
@@ -1883,10 +1810,7 @@ contract QuadraticVotingE2E is Test {
 
         // With optimal alpha, total funding should approximately equal total assets
         assertApproxEqAbs(
-            actualTotalFunding,
-            data.totalAssets,
-            10,
-            "Total funding should approximately match total assets"
+            actualTotalFunding, data.totalAssets, 10, "Total funding should approximately match total assets"
         );
 
         // Queue all proposals and verify shares
@@ -1895,9 +1819,9 @@ contract QuadraticVotingE2E is Test {
         _tokenized(address(mechanism)).queueProposal(data.pid3);
 
         // Verify individual project funding adds up to total
-        (, , uint256 q1, uint256 l1) = mechanism.getTally(data.pid1);
-        (, , uint256 q2, uint256 l2) = mechanism.getTally(data.pid2);
-        (, , uint256 q3, uint256 l3) = mechanism.getTally(data.pid3);
+        (,, uint256 q1, uint256 l1) = mechanism.getTally(data.pid1);
+        (,, uint256 q2, uint256 l2) = mechanism.getTally(data.pid2);
+        (,, uint256 q3, uint256 l3) = mechanism.getTally(data.pid3);
 
         uint256 sumOfProjectFunding = (q1 + l1) + (q2 + l2) + (q3 + l3);
 
@@ -1969,16 +1893,12 @@ contract QuadraticVotingE2E is Test {
             uint256 matchingPool = matchingPoolSizes[i];
 
             // Calculate optimal alpha for this matching pool size
-            (uint256 alphaNumerator, uint256 alphaDenominator) = mechanism.calculateOptimalAlpha(
-                matchingPool,
-                data.totalUserDeposits
-            );
+            (uint256 alphaNumerator, uint256 alphaDenominator) =
+                mechanism.calculateOptimalAlpha(matchingPool, data.totalUserDeposits);
 
             // Calculate expected total funding
-            uint256 expectedTotalFunding = (data.totalQuadraticSum * alphaNumerator) /
-                alphaDenominator +
-                (data.totalLinearSum * (alphaDenominator - alphaNumerator)) /
-                alphaDenominator;
+            uint256 expectedTotalFunding = (data.totalQuadraticSum * alphaNumerator) / alphaDenominator
+                + (data.totalLinearSum * (alphaDenominator - alphaNumerator)) / alphaDenominator;
 
             uint256 expectedTotalAssets = data.totalUserDeposits + matchingPool;
 
@@ -2002,19 +1922,15 @@ contract QuadraticVotingE2E is Test {
         token.mint(address(this), data.finalMatchingPool);
         token.transfer(address(mechanism), data.finalMatchingPool);
 
-        (data.finalAlphaNumerator, data.finalAlphaDenominator) = mechanism.calculateOptimalAlpha(
-            data.finalMatchingPool,
-            data.totalUserDeposits
-        );
+        (data.finalAlphaNumerator, data.finalAlphaDenominator) =
+            mechanism.calculateOptimalAlpha(data.finalMatchingPool, data.totalUserDeposits);
 
         mechanism.setAlpha(data.finalAlphaNumerator, data.finalAlphaDenominator);
 
         // Finalize and verify total funding is updated correctly
         vm.warp(
-            data.deploymentTime +
-                _tokenized(address(mechanism)).votingDelay() +
-                _tokenized(address(mechanism)).votingPeriod() +
-                1
+            data.deploymentTime + _tokenized(address(mechanism)).votingDelay()
+                + _tokenized(address(mechanism)).votingPeriod() + 1
         );
         _tokenized(address(mechanism)).finalizeVoteTally();
 
@@ -2022,10 +1938,7 @@ contract QuadraticVotingE2E is Test {
         data.finalTotalAssets = token.balanceOf(address(mechanism));
 
         assertApproxEqAbs(
-            data.finalTotalFunding,
-            data.finalTotalAssets,
-            10,
-            "Final total funding should match total assets"
+            data.finalTotalFunding, data.finalTotalAssets, 10, "Final total funding should match total assets"
         );
 
         // Queue all proposals and verify individual funding
@@ -2037,7 +1950,7 @@ contract QuadraticVotingE2E is Test {
         // Calculate sum of individual project funding
         uint256 totalProjectFunding = 0;
         for (uint256 pid = data.pid1; pid <= data.pid4; pid++) {
-            (, , uint256 q, uint256 l) = mechanism.getTally(pid);
+            (,, uint256 q, uint256 l) = mechanism.getTally(pid);
             uint256 projectFunding = q + l;
             totalProjectFunding += projectFunding;
         }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingE2E.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingE2E.t.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
-import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
-import {AllocationTestHelpers} from "../utils/AllocationTestHelpers.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { AllocationTestHelpers } from "../utils/AllocationTestHelpers.sol";
 
 /// @title Quadratic Voting End-to-End Test
 /// @notice Complete end-to-end testing of the quadratic voting mechanism
@@ -96,10 +96,11 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
     /// @param recipient Address that will receive funds if proposal passes
     /// @param description Description of the proposal
     /// @return pid The proposal ID
-    function _createProposal(address proposer, address recipient, string memory description)
-        internal
-        returns (uint256 pid)
-    {
+    function _createProposal(
+        address proposer,
+        address recipient,
+        string memory description
+    ) internal returns (uint256 pid) {
         pid = _createProposal(mechanism, proposer, recipient, description);
     }
 
@@ -109,10 +110,12 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
     /// @param weight Vote weight (quadratic cost = weight^2)
     /// @return previousPower Voting power before the vote
     /// @return newPower Voting power after the vote
-    function _castVote(address voter, uint256 pid, uint256 weight, address recipient)
-        internal
-        returns (uint256 previousPower, uint256 newPower)
-    {
+    function _castVote(
+        address voter,
+        uint256 pid,
+        uint256 weight,
+        address recipient
+    ) internal returns (uint256 previousPower, uint256 newPower) {
         previousPower = _tokenized(address(mechanism)).votingPower(voter);
         _castVote(mechanism, voter, pid, weight, recipient);
         newPower = _tokenized(address(mechanism)).votingPower(voter);
@@ -123,11 +126,9 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
     /// @return matchingFundsNeeded Amount of additional funds needed for 1:1 ratio
     /// @return totalQuadraticSum Total quadratic sum from all proposals
     /// @return totalLinearSum Total linear sum from all proposals (user contributions)
-    function _calculateMatchingFunds(uint256 totalUserDeposits)
-        internal
-        view
-        returns (uint256 matchingFundsNeeded, uint256 totalQuadraticSum, uint256 totalLinearSum)
-    {
+    function _calculateMatchingFunds(
+        uint256 totalUserDeposits
+    ) internal view returns (uint256 matchingFundsNeeded, uint256 totalQuadraticSum, uint256 totalLinearSum) {
         totalQuadraticSum = mechanism.totalQuadraticSum();
         totalLinearSum = mechanism.totalLinearSum();
 
@@ -277,7 +278,9 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         assertEq(_tokenized(address(mechanism)).votingPower(alice), 0, "Alice should have no voting power initially");
         assertEq(_tokenized(address(mechanism)).votingPower(bob), 0, "Bob should have no voting power initially");
         assertEq(
-            _tokenized(address(mechanism)).votingPower(charlie), 0, "Charlie should have no voting power initially"
+            _tokenized(address(mechanism)).votingPower(charlie),
+            0,
+            "Charlie should have no voting power initially"
         );
 
         // Verify recipient addresses have zero balances
@@ -321,7 +324,9 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
             "Bob should have voting power equal to his deposit"
         );
         assertEq(
-            token.balanceOf(address(mechanism)), DEPOSIT_AMOUNT + bobDeposit, "Mechanism should have both deposits"
+            token.balanceOf(address(mechanism)),
+            DEPOSIT_AMOUNT + bobDeposit,
+            "Mechanism should have both deposits"
         );
 
         // Sign up Charlie with zero deposit
@@ -438,9 +443,15 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
 
         // Verify mechanism state remains consistent
         assertEq(
-            token.balanceOf(address(mechanism)), totalDeposits, "Mechanism balance should be unchanged by proposals"
+            token.balanceOf(address(mechanism)),
+            totalDeposits,
+            "Mechanism balance should be unchanged by proposals"
         );
-        assertEq(_tokenized(address(mechanism)).totalSupply(), 0, "No shares should be minted during proposal creation");
+        assertEq(
+            _tokenized(address(mechanism)).totalSupply(),
+            0,
+            "No shares should be minted during proposal creation"
+        );
 
         console.log("Workflow test complete - 3 users signed up, 3 proposals created");
     }
@@ -653,8 +664,9 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         console.log("=== MATCHING FUNDS CALCULATION TEST ===");
 
         // Calculate matching funds needed before finalization
-        (uint256 matchingFundsNeeded, uint256 totalQuadraticSum, uint256 totalLinearSum) =
-            _calculateMatchingFunds(totalUserDeposits);
+        (uint256 matchingFundsNeeded, uint256 totalQuadraticSum, uint256 totalLinearSum) = _calculateMatchingFunds(
+            totalUserDeposits
+        );
 
         console.log("Total Quadratic Sum:", totalQuadraticSum);
         console.log("Total Linear Sum:", totalLinearSum);
@@ -773,8 +785,12 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 fixedMatchingPool = 300 ether;
 
         // Calculate optimal alpha
-        (uint256 alphaNumerator, uint256 alphaDenominator) =
-            _calculateOptimalAlpha(fixedMatchingPool, totalQuadraticSum, totalLinearSum, totalUserDeposits);
+        (uint256 alphaNumerator, uint256 alphaDenominator) = _calculateOptimalAlpha(
+            fixedMatchingPool,
+            totalQuadraticSum,
+            totalLinearSum,
+            totalUserDeposits
+        );
 
         // console.log("Fixed matching pool:", fixedMatchingPool);
         // console.log("Calculated alpha:", alphaNumerator, "/", alphaDenominator);
@@ -894,8 +910,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 smallMatchingPool = 200 ether;
 
         // Calculate optimal alpha using mechanism's function
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(smallMatchingPool, totalUserDeposits);
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            smallMatchingPool,
+            totalUserDeposits
+        );
 
         console.log("Small matching pool:", smallMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -973,8 +991,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 mediumMatchingPool = 600 ether;
 
         // Calculate optimal alpha
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(mediumMatchingPool, totalUserDeposits);
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            mediumMatchingPool,
+            totalUserDeposits
+        );
 
         console.log("Medium matching pool:", mediumMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1057,8 +1077,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 variedMatchingPool = 500 ether;
 
         // Calculate optimal alpha
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(variedMatchingPool, totalUserDeposits);
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            variedMatchingPool,
+            totalUserDeposits
+        );
 
         console.log("Varied matching pool:", variedMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1096,7 +1118,9 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         assertTrue(recipient2Shares > 0, "Recipient 2 should receive shares");
         assertTrue(recipient3Shares > 0, "Recipient 3 should receive shares");
         assertEq(
-            recipient1Shares + recipient2Shares + recipient3Shares, totalShares, "Individual shares should sum to total"
+            recipient1Shares + recipient2Shares + recipient3Shares,
+            totalShares,
+            "Individual shares should sum to total"
         );
 
         console.log("Alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1154,8 +1178,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 largeMatchingPool = 50_000_000 ether; // 50M tokens
 
         // Calculate optimal alpha with large numbers
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(largeMatchingPool, totalUserDeposits);
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            largeMatchingPool,
+            totalUserDeposits
+        );
 
         console.log("Large matching pool:", largeMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1182,7 +1208,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 totalShares = _tokenized(address(mechanism)).totalSupply();
         uint256 totalAssets = token.balanceOf(address(mechanism));
         assertApproxEqAbs(
-            totalShares, totalAssets, 1000, "Total shares should approximately equal total assets at large scale"
+            totalShares,
+            totalAssets,
+            1000,
+            "Total shares should approximately equal total assets at large scale"
         );
 
         console.log("Large scale alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1230,8 +1259,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 tinyMatchingPool = 1;
 
         // Calculate optimal alpha with tiny matching pool
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(tinyMatchingPool, totalUserDeposits);
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            tinyMatchingPool,
+            totalUserDeposits
+        );
 
         console.log("Tiny matching pool:", tinyMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1258,7 +1289,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 totalShares = _tokenized(address(mechanism)).totalSupply();
         uint256 totalAssets = token.balanceOf(address(mechanism));
         assertApproxEqAbs(
-            totalShares, totalAssets, 100, "Total shares should approximately equal total assets with tiny pool"
+            totalShares,
+            totalAssets,
+            100,
+            "Total shares should approximately equal total assets with tiny pool"
         );
 
         console.log("Tiny pool alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1311,8 +1345,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 nearFullMatchingPool = quadraticAdvantage - 1; // 1 wei short of full quadratic
 
         // Calculate optimal alpha (should be very close to 1)
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(nearFullMatchingPool, totalUserDeposits);
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            nearFullMatchingPool,
+            totalUserDeposits
+        );
 
         console.log("Near-full matching pool:", nearFullMatchingPool);
         console.log("Quadratic advantage:", quadraticAdvantage);
@@ -1337,7 +1373,9 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         // Verify 1:1 ratio is not violated (it's OK to be over 1:1, but not under)
         uint256 assetsFor1Share = _tokenized(address(mechanism)).convertToAssets(1e18);
         assertGe(
-            assetsFor1Share, 1e18, "1:1 ratio should not be violated - users should get at least 1:1 assets per share"
+            assetsFor1Share,
+            1e18,
+            "1:1 ratio should not be violated - users should get at least 1:1 assets per share"
         );
 
         uint256 totalShares = _tokenized(address(mechanism)).totalSupply();
@@ -1404,8 +1442,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 moderateMatchingPool = 5000 ether; // Much smaller than quadratic advantage
 
         // Calculate optimal alpha (should have large denominator)
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(moderateMatchingPool, totalUserDeposits);
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            moderateMatchingPool,
+            totalUserDeposits
+        );
 
         console.log("Moderate matching pool:", moderateMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1433,7 +1473,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 totalShares = _tokenized(address(mechanism)).totalSupply();
         uint256 totalAssets = token.balanceOf(address(mechanism));
         assertApproxEqAbs(
-            totalShares, totalAssets, 100, "Total shares should approximately equal total assets with huge advantage"
+            totalShares,
+            totalAssets,
+            100,
+            "Total shares should approximately equal total assets with huge advantage"
         );
 
         console.log("Huge advantage alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
@@ -1487,8 +1530,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         console.log("Excess matching funds:", excessMatchingFunds);
 
         // Calculate optimal alpha with excess funds (should be alpha = 1)
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(excessMatchingFunds, totalUserDeposits);
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            excessMatchingFunds,
+            totalUserDeposits
+        );
 
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
 
@@ -1519,7 +1564,9 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         // With alpha=1 and excess matching funds, the ratio should be >1:1
         assertGt(assetsFor1Share, 1e18, "Ratio should be >1:1 when alpha=1 and there are excess matching funds");
         assertGt(
-            totalAssets, totalShares, "Total assets should exceed total shares when there are excess matching funds"
+            totalAssets,
+            totalShares,
+            "Total assets should exceed total shares when there are excess matching funds"
         );
 
         // Verify that total shares equals total quadratic funding (since alpha=1)
@@ -1527,7 +1574,11 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
 
         // Verify that excess funds remain in the contract (not allocated to shares)
         uint256 expectedExcessAssets = totalUserDeposits + excessMatchingFunds;
-        assertEq(totalAssets, expectedExcessAssets, "Total assets should include user deposits + excess matching funds");
+        assertEq(
+            totalAssets,
+            expectedExcessAssets,
+            "Total assets should include user deposits + excess matching funds"
+        );
 
         console.log("=== VALIDATION COMPLETE ===");
         console.log("Confirmed: >1:1 ratio only occurs with alpha=1 and excess matching funds");
@@ -1567,15 +1618,18 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         uint256 limitedMatchingPool = 400 ether; // Less than full quadratic advantage
 
         // Calculate optimal alpha (should be < 1)
-        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(limitedMatchingPool, totalUserDeposits);
+        (uint256 optimalAlphaNumerator, uint256 optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            limitedMatchingPool,
+            totalUserDeposits
+        );
 
         console.log("Limited matching pool:", limitedMatchingPool);
         console.log("Calculated optimal alpha:", optimalAlphaNumerator, "/", optimalAlphaDenominator);
 
         // Verify alpha < 1
         assertTrue(
-            optimalAlphaNumerator < optimalAlphaDenominator, "Alpha should be less than 1 with limited matching funds"
+            optimalAlphaNumerator < optimalAlphaDenominator,
+            "Alpha should be less than 1 with limited matching funds"
         );
 
         // Apply limited matching funds and fractional alpha
@@ -1601,7 +1655,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         // With fractional alpha, ratio should be 1:1 (or very close due to rounding)
         assertApproxEqAbs(assetsFor1Share, 1e18, 10, "Ratio should be approximately 1:1 when alpha < 1");
         assertApproxEqAbs(
-            totalAssets, totalShares, 10, "Total assets should approximately equal total shares when alpha < 1"
+            totalAssets,
+            totalShares,
+            10,
+            "Total assets should approximately equal total shares when alpha < 1"
         );
 
         // Verify that we're not over-collateralized when alpha < 1
@@ -1705,8 +1762,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
 
         // Finalize and test actual share distribution
         vm.warp(
-            data.deploymentTime + _tokenized(address(mechanism)).votingDelay()
-                + _tokenized(address(mechanism)).votingPeriod() + 1
+            data.deploymentTime +
+                _tokenized(address(mechanism)).votingDelay() +
+                _tokenized(address(mechanism)).votingPeriod() +
+                1
         );
         _tokenized(address(mechanism)).finalizeVoteTally();
         _tokenized(address(mechanism)).queueProposal(data.pid1);
@@ -1760,8 +1819,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         data.totalLinearSum = mechanism.totalLinearSum();
 
         // Calculate optimal alpha
-        (data.optimalAlphaNumerator, data.optimalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(data.fixedMatchingPool, data.totalUserDeposits);
+        (data.optimalAlphaNumerator, data.optimalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            data.fixedMatchingPool,
+            data.totalUserDeposits
+        );
 
         // Apply optimal alpha and add matching pool
         token.mint(address(this), data.fixedMatchingPool);
@@ -1779,18 +1840,20 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         assertTrue(totalFundingAfterAlpha != totalFundingBeforeAlpha, "setAlpha should update totalFunding");
 
         // Calculate expected total funding with optimal alpha
-        uint256 expectedTotalFunding = (data.totalQuadraticSum * data.optimalAlphaNumerator)
-            / data.optimalAlphaDenominator
-            + (data.totalLinearSum * (data.optimalAlphaDenominator - data.optimalAlphaNumerator))
-            / data.optimalAlphaDenominator;
+        uint256 expectedTotalFunding = (data.totalQuadraticSum * data.optimalAlphaNumerator) /
+            data.optimalAlphaDenominator +
+            (data.totalLinearSum * (data.optimalAlphaDenominator - data.optimalAlphaNumerator)) /
+            data.optimalAlphaDenominator;
 
         // Check if setAlpha updated totalFunding correctly
         assertEq(totalFundingAfterAlpha, expectedTotalFunding, "setAlpha should update totalFunding correctly");
 
         // Finalize to update totalFunding storage
         vm.warp(
-            data.deploymentTime + _tokenized(address(mechanism)).votingDelay()
-                + _tokenized(address(mechanism)).votingPeriod() + 1
+            data.deploymentTime +
+                _tokenized(address(mechanism)).votingDelay() +
+                _tokenized(address(mechanism)).votingPeriod() +
+                1
         );
         _tokenized(address(mechanism)).finalizeVoteTally();
 
@@ -1810,7 +1873,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
 
         // With optimal alpha, total funding should approximately equal total assets
         assertApproxEqAbs(
-            actualTotalFunding, data.totalAssets, 10, "Total funding should approximately match total assets"
+            actualTotalFunding,
+            data.totalAssets,
+            10,
+            "Total funding should approximately match total assets"
         );
 
         // Queue all proposals and verify shares
@@ -1819,9 +1885,9 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         _tokenized(address(mechanism)).queueProposal(data.pid3);
 
         // Verify individual project funding adds up to total
-        (,, uint256 q1, uint256 l1) = mechanism.getTally(data.pid1);
-        (,, uint256 q2, uint256 l2) = mechanism.getTally(data.pid2);
-        (,, uint256 q3, uint256 l3) = mechanism.getTally(data.pid3);
+        (, , uint256 q1, uint256 l1) = mechanism.getTally(data.pid1);
+        (, , uint256 q2, uint256 l2) = mechanism.getTally(data.pid2);
+        (, , uint256 q3, uint256 l3) = mechanism.getTally(data.pid3);
 
         uint256 sumOfProjectFunding = (q1 + l1) + (q2 + l2) + (q3 + l3);
 
@@ -1893,12 +1959,16 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
             uint256 matchingPool = matchingPoolSizes[i];
 
             // Calculate optimal alpha for this matching pool size
-            (uint256 alphaNumerator, uint256 alphaDenominator) =
-                mechanism.calculateOptimalAlpha(matchingPool, data.totalUserDeposits);
+            (uint256 alphaNumerator, uint256 alphaDenominator) = mechanism.calculateOptimalAlpha(
+                matchingPool,
+                data.totalUserDeposits
+            );
 
             // Calculate expected total funding
-            uint256 expectedTotalFunding = (data.totalQuadraticSum * alphaNumerator) / alphaDenominator
-                + (data.totalLinearSum * (alphaDenominator - alphaNumerator)) / alphaDenominator;
+            uint256 expectedTotalFunding = (data.totalQuadraticSum * alphaNumerator) /
+                alphaDenominator +
+                (data.totalLinearSum * (alphaDenominator - alphaNumerator)) /
+                alphaDenominator;
 
             uint256 expectedTotalAssets = data.totalUserDeposits + matchingPool;
 
@@ -1922,15 +1992,19 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         token.mint(address(this), data.finalMatchingPool);
         token.transfer(address(mechanism), data.finalMatchingPool);
 
-        (data.finalAlphaNumerator, data.finalAlphaDenominator) =
-            mechanism.calculateOptimalAlpha(data.finalMatchingPool, data.totalUserDeposits);
+        (data.finalAlphaNumerator, data.finalAlphaDenominator) = mechanism.calculateOptimalAlpha(
+            data.finalMatchingPool,
+            data.totalUserDeposits
+        );
 
         mechanism.setAlpha(data.finalAlphaNumerator, data.finalAlphaDenominator);
 
         // Finalize and verify total funding is updated correctly
         vm.warp(
-            data.deploymentTime + _tokenized(address(mechanism)).votingDelay()
-                + _tokenized(address(mechanism)).votingPeriod() + 1
+            data.deploymentTime +
+                _tokenized(address(mechanism)).votingDelay() +
+                _tokenized(address(mechanism)).votingPeriod() +
+                1
         );
         _tokenized(address(mechanism)).finalizeVoteTally();
 
@@ -1938,7 +2012,10 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         data.finalTotalAssets = token.balanceOf(address(mechanism));
 
         assertApproxEqAbs(
-            data.finalTotalFunding, data.finalTotalAssets, 10, "Final total funding should match total assets"
+            data.finalTotalFunding,
+            data.finalTotalAssets,
+            10,
+            "Final total funding should match total assets"
         );
 
         // Queue all proposals and verify individual funding
@@ -1950,7 +2027,7 @@ contract QuadraticVotingE2E is AllocationTestHelpers {
         // Calculate sum of individual project funding
         uint256 totalProjectFunding = 0;
         for (uint256 pid = data.pid1; pid <= data.pid4; pid++) {
-            (,, uint256 q, uint256 l) = mechanism.getTally(pid);
+            (, , uint256 q, uint256 l) = mechanism.getTally(pid);
             uint256 projectFunding = q + l;
             totalProjectFunding += projectFunding;
         }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingGasAnalysisTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingGasAnalysisTest.t.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
-import {AllocationTestHelpers} from "../utils/AllocationTestHelpers.sol";
+import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { AllocationTestHelpers } from "../utils/AllocationTestHelpers.sol";
 
 /// @title Gas Analysis Test for Cold vs Warm Storage Operations
 /// @notice Analyzes gas costs for voting on new projects (cold storage) vs existing projects (warm storage)
@@ -437,7 +437,11 @@ contract QuadraticVotingGasAnalysisTest is AllocationTestHelpers {
             uint256 penaltyPercent = (firstVotePenalty * 100) / gasUsed[0];
             console.log("First vote penalty:", firstVotePenalty, "gas");
             emit GasComparison(
-                "First_vs_Avg_Subsequent_Votes", gasUsed[0], avgSubsequent, firstVotePenalty, penaltyPercent
+                "First_vs_Avg_Subsequent_Votes",
+                gasUsed[0],
+                avgSubsequent,
+                firstVotePenalty,
+                penaltyPercent
             );
         }
 

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingGasAnalysisTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingGasAnalysisTest.t.sol
@@ -1,18 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {AllocationTestHelpers} from "../utils/AllocationTestHelpers.sol";
 
 /// @title Gas Analysis Test for Cold vs Warm Storage Operations
 /// @notice Analyzes gas costs for voting on new projects (cold storage) vs existing projects (warm storage)
-contract QuadraticVotingGasAnalysisTest is Test {
+contract QuadraticVotingGasAnalysisTest is AllocationTestHelpers {
     // Events for gas measurement logging
     event GasMeasurement(string operation, uint256 gasUsed);
     event GasComparison(string comparison, uint256 gasA, uint256 gasB, uint256 difference, uint256 percentSavings);
@@ -35,26 +33,23 @@ contract QuadraticVotingGasAnalysisTest is Test {
         factory = new AllocationMechanismFactory();
         token = new ERC20Mock();
 
-        // Deploy mechanism with alpha = 1.0 (pure quadratic)
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Gas Analysis Test",
-            symbol: "GAT",
-            votingDelay: 5, // voting delay blocks
-            votingPeriod: 100, // voting period blocks
-            quorumShares: 1000 ether,
-            timelockDelay: 10, // timelock blocks
-            gracePeriod: 50, // grace period blocks
-            owner: address(this) // will be set by factory
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(
-            config,
+        mechanism = _deployQuadraticVoting(
+            factory,
+            _config({
+                asset: token,
+                name: "Gas Analysis Test",
+                symbol: "GAT",
+                votingDelay: 5,
+                votingPeriod: 100,
+                quorumShares: 1000 ether,
+                timelockDelay: 10,
+                gracePeriod: 50,
+                owner: address(this)
+            }),
             10000, // alpha numerator (1.0)
             10000 // alpha denominator (1.0)
         );
 
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
         TokenizedAllocationMechanism(address(mechanism)).setKeeper(alice);
         TokenizedAllocationMechanism(address(mechanism)).setManagement(david);
 
@@ -442,11 +437,7 @@ contract QuadraticVotingGasAnalysisTest is Test {
             uint256 penaltyPercent = (firstVotePenalty * 100) / gasUsed[0];
             console.log("First vote penalty:", firstVotePenalty, "gas");
             emit GasComparison(
-                "First_vs_Avg_Subsequent_Votes",
-                gasUsed[0],
-                avgSubsequent,
-                firstVotePenalty,
-                penaltyPercent
+                "First_vs_Avg_Subsequent_Votes", gasUsed[0], avgSubsequent, firstVotePenalty, penaltyPercent
             );
         }
 

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingProposalStateTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingProposalStateTest.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Proposal State Journey Tests
 /// @notice Comprehensive tests for all possible proposal states and recipient experiences
@@ -96,7 +96,7 @@ contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
         vm.prank(alice);
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, dave);
 
-        (,, uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
+        (, , uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
         uint256 forVotes = quadraticFunding + linearFunding;
         assertEq(forVotes, 900);
 
@@ -184,13 +184,17 @@ contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
 
         // Finalize voting
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Verify DEFEATED states
-        assertEq(uint256(_tokenized().state(pidLowVotes)), uint256(TokenizedAllocationMechanism.ProposalState.Defeated));
         assertEq(
-            uint256(_tokenized().state(pidNegativeVotes)), uint256(TokenizedAllocationMechanism.ProposalState.Defeated)
+            uint256(_tokenized().state(pidLowVotes)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Defeated)
+        );
+        assertEq(
+            uint256(_tokenized().state(pidNegativeVotes)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Defeated)
         );
 
         // Recipients get nothing from defeated proposals
@@ -228,7 +232,7 @@ contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, henry);
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Verify SUCCEEDED state
@@ -242,7 +246,7 @@ contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
         assertFalse(proposal.canceled);
 
         // Verify vote tallies are correct using getTally() from ProperQF
-        (,, uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
+        (, , uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
         uint256 forVotes = quadraticFunding + linearFunding;
         uint256 againstVotes = 0; // QuadraticVoting only supports For votes
         assertEq(forVotes, 900);
@@ -272,12 +276,12 @@ contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie);
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue the proposal
         uint256 timestampBefore = block.timestamp;
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         // Verify QUEUED state
@@ -300,7 +304,7 @@ contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
 
         // Cannot queue again
         vm.expectRevert(TokenizedAllocationMechanism.AlreadyQueued.selector);
-        (bool success3,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success3, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         assertFalse(success3);
     }
 
@@ -326,10 +330,10 @@ contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, dave);
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         // Fast forward past timelock
@@ -380,10 +384,10 @@ contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, eve);
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         // Fast forward past timelock + grace period
@@ -436,21 +440,28 @@ contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
 
         // Start with all in PENDING
         assertEq(
-            uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Pending)
+            uint256(_tokenized().state(pidSuccessful)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Pending)
         );
         assertEq(uint256(_tokenized().state(pidDefeated)), uint256(TokenizedAllocationMechanism.ProposalState.Pending));
         assertEq(uint256(_tokenized().state(pidCanceled)), uint256(TokenizedAllocationMechanism.ProposalState.Pending));
 
         // Move to ACTIVE
         vm.warp(votingStartTime + 1);
-        assertEq(uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Active));
+        assertEq(
+            uint256(_tokenized().state(pidSuccessful)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Active)
+        );
         assertEq(uint256(_tokenized().state(pidDefeated)), uint256(TokenizedAllocationMechanism.ProposalState.Active));
         assertEq(uint256(_tokenized().state(pidCanceled)), uint256(TokenizedAllocationMechanism.ProposalState.Active));
 
         // Cancel one proposal
         vm.prank(alice);
         _tokenized().cancelProposal(pidCanceled);
-        assertEq(uint256(_tokenized().state(pidCanceled)), uint256(TokenizedAllocationMechanism.ProposalState.Canceled));
+        assertEq(
+            uint256(_tokenized().state(pidCanceled)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Canceled)
+        );
 
         // Vote on remaining proposals
         vm.prank(alice);
@@ -461,21 +472,31 @@ contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
 
         // Finalize
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check final states
         assertEq(
-            uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded)
+            uint256(_tokenized().state(pidSuccessful)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Succeeded)
         );
-        assertEq(uint256(_tokenized().state(pidDefeated)), uint256(TokenizedAllocationMechanism.ProposalState.Defeated));
-        assertEq(uint256(_tokenized().state(pidCanceled)), uint256(TokenizedAllocationMechanism.ProposalState.Canceled));
+        assertEq(
+            uint256(_tokenized().state(pidDefeated)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Defeated)
+        );
+        assertEq(
+            uint256(_tokenized().state(pidCanceled)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Canceled)
+        );
 
         // Queue successful proposal
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidSuccessful));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidSuccessful));
         require(success2, "Queue failed");
 
-        assertEq(uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Queued));
+        assertEq(
+            uint256(_tokenized().state(pidSuccessful)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Queued)
+        );
 
         // Verify recipient outcomes
         assertEq(_tokenized().balanceOf(charlie), 900); // Success

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingProposalStateTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingProposalStateTest.t.sol
@@ -1,31 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
-import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Proposal State Journey Tests
 /// @notice Comprehensive tests for all possible proposal states and recipient experiences
-contract QuadraticVotingProposalStateTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1); // Voter/Proposer
-    address bob = address(0x2); // Voter
-    address charlie = address(0x3); // Recipient
-    address dave = address(0x4); // Recipient
-    address eve = address(0x5); // Recipient
-    address frank = address(0x6); // Recipient
-    address grace = address(0x7); // Recipient
-    address henry = address(0x8); // Recipient
-
+contract QuadraticVotingProposalStateTest is QuadraticVotingTestBase {
     uint256 constant LARGE_DEPOSIT = 1000 ether;
     uint256 constant MEDIUM_DEPOSIT = 500 ether;
     uint256 constant QUORUM_REQUIREMENT = 500;
@@ -34,33 +15,22 @@ contract QuadraticVotingProposalStateTest is Test {
     uint256 constant TIMELOCK_DELAY = 1 days;
     uint256 constant GRACE_PERIOD = 7 days;
 
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting(
+            "Proposal State Test",
+            "PSTEST",
+            VOTING_DELAY,
+            VOTING_PERIOD,
+            QUORUM_REQUIREMENT,
+            TIMELOCK_DELAY,
+            GRACE_PERIOD,
+            50,
+            100
+        );
 
         token.mint(alice, 2000 ether);
         token.mint(bob, 1500 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Proposal State Test",
-            symbol: "PSTEST",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_REQUIREMENT,
-            timelockDelay: TIMELOCK_DELAY,
-            gracePeriod: GRACE_PERIOD,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-        _tokenized(address(mechanism)).setKeeper(alice);
-        _tokenized(address(mechanism)).setManagement(bob);
+        _setRoles(alice, bob);
 
         // Pre-fund matching pool - this will be included in total assets during finalize
         uint256 matchingPoolAmount = 2000 ether;
@@ -72,7 +42,7 @@ contract QuadraticVotingProposalStateTest is Test {
     function testProposalState_Pending() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
+        uint256 votingDelay = _tokenized().votingDelay();
         uint256 votingStartTime = deploymentTime + votingDelay;
 
         // Before voting starts (still in delay period) - warp before creating proposal
@@ -81,226 +51,198 @@ contract QuadraticVotingProposalStateTest is Test {
         // Register and create proposal
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Charlie's Pending Proposal");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(charlie, "Charlie's Pending Proposal");
         vm.stopPrank();
 
         // Verify PENDING state
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Pending)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Pending));
 
         // Recipient can monitor but cannot vote yet
-        TokenizedAllocationMechanism.Proposal memory proposal = _tokenized(address(mechanism)).proposals(pid);
+        TokenizedAllocationMechanism.Proposal memory proposal = _tokenized().proposals(pid);
         assertEq(proposal.recipient, charlie);
         assertEq(proposal.proposer, alice);
 
         // Move closer to start but still pending
         vm.warp(votingStartTime - 1);
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Pending)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Pending));
     }
 
     /// @notice Test ACTIVE state - proposal during voting delay and voting period
     function testProposalState_Active() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup and create proposal
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(dave, "Dave's Active Proposal");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(dave, "Dave's Active Proposal");
         vm.stopPrank();
 
         // During voting delay - PENDING (before voting can start)
         vm.warp(votingStartTime - 50);
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Pending)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Pending));
 
         // During voting period - ACTIVE
         vm.warp(votingStartTime + 50);
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Active)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Active));
 
         // Recipient can monitor voting progress
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, dave);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, dave);
 
-        (, , uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
+        (,, uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
         uint256 forVotes = quadraticFunding + linearFunding;
         assertEq(forVotes, 900);
 
         // TALLYING after voting ends but before finalized
         vm.warp(votingEndTime + 10);
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Tallying)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Tallying));
     }
 
     /// @notice Test CANCELED state - proposer cancels before queuing
     function testProposalState_Canceled() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(eve, "Eve's Canceled Proposal");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(eve, "Eve's Canceled Proposal");
         vm.stopPrank();
 
         // Proposer cancels during active period
         vm.warp(votingStartTime + 50);
         vm.prank(alice);
-        _tokenized(address(mechanism)).cancelProposal(pid);
+        _tokenized().cancelProposal(pid);
 
         // Verify CANCELED state
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Canceled)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Canceled));
 
         // Recipient cannot receive anything from canceled proposal
-        TokenizedAllocationMechanism.Proposal memory proposal = _tokenized(address(mechanism)).proposals(pid);
+        TokenizedAllocationMechanism.Proposal memory proposal = _tokenized().proposals(pid);
         assertTrue(proposal.canceled);
 
         // Cannot vote on canceled proposal
         vm.expectRevert();
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, dave);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, dave);
 
         // State remains CANCELED permanently
         vm.warp(votingEndTime + 100);
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Canceled)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Canceled));
     }
 
     /// @notice Test DEFEATED state - proposal fails to meet quorum or has negative votes
     function testProposalState_Defeated() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup voters
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
+        _tokenized().signup(LARGE_DEPOSIT);
         vm.stopPrank();
 
         vm.startPrank(bob);
         token.approve(address(mechanism), MEDIUM_DEPOSIT);
-        _tokenized(address(mechanism)).signup(MEDIUM_DEPOSIT);
+        _tokenized().signup(MEDIUM_DEPOSIT);
         vm.stopPrank();
 
         // Create proposals that will be defeated
         vm.prank(alice);
-        uint256 pidLowVotes = _tokenized(address(mechanism)).propose(frank, "Frank's Low Vote Proposal");
+        uint256 pidLowVotes = _tokenized().propose(frank, "Frank's Low Vote Proposal");
 
         vm.prank(bob);
-        uint256 pidNegativeVotes = _tokenized(address(mechanism)).propose(grace, "Grace's Low Vote Proposal");
+        uint256 pidNegativeVotes = _tokenized().propose(grace, "Grace's Low Vote Proposal");
 
         vm.warp(votingStartTime + 1);
 
         // Proposal 1: Insufficient votes (below quorum)
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pidLowVotes, TokenizedAllocationMechanism.VoteType.For, 10, frank);
+        _tokenized().castVote(pidLowVotes, TokenizedAllocationMechanism.VoteType.For, 10, frank);
 
         // Proposal 2: Low total votes (below quorum)
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pidNegativeVotes, TokenizedAllocationMechanism.VoteType.For, 15, grace);
+        _tokenized().castVote(pidNegativeVotes, TokenizedAllocationMechanism.VoteType.For, 15, grace);
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pidNegativeVotes, TokenizedAllocationMechanism.VoteType.For, 10, grace);
+        _tokenized().castVote(pidNegativeVotes, TokenizedAllocationMechanism.VoteType.For, 10, grace);
 
         // Finalize voting
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Verify DEFEATED states
+        assertEq(uint256(_tokenized().state(pidLowVotes)), uint256(TokenizedAllocationMechanism.ProposalState.Defeated));
         assertEq(
-            uint(_tokenized(address(mechanism)).state(pidLowVotes)),
-            uint(TokenizedAllocationMechanism.ProposalState.Defeated)
-        );
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidNegativeVotes)),
-            uint(TokenizedAllocationMechanism.ProposalState.Defeated)
+            uint256(_tokenized().state(pidNegativeVotes)), uint256(TokenizedAllocationMechanism.ProposalState.Defeated)
         );
 
         // Recipients get nothing from defeated proposals
-        assertEq(_tokenized(address(mechanism)).balanceOf(frank), 0);
-        assertEq(_tokenized(address(mechanism)).balanceOf(grace), 0);
+        assertEq(_tokenized().balanceOf(frank), 0);
+        assertEq(_tokenized().balanceOf(grace), 0);
 
         // Cannot queue defeated proposals should revert with NoQuorum
         vm.expectRevert();
-        _tokenized(address(mechanism)).queueProposal(pidLowVotes);
+        _tokenized().queueProposal(pidLowVotes);
 
         vm.expectRevert();
-        _tokenized(address(mechanism)).queueProposal(pidNegativeVotes);
+        _tokenized().queueProposal(pidNegativeVotes);
     }
 
     /// @notice Test SUCCEEDED state - proposal meets quorum but not yet queued
     function testProposalState_Succeeded() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(henry, "Henry's Successful Proposal");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(henry, "Henry's Successful Proposal");
         vm.stopPrank();
 
         vm.warp(votingStartTime + 1);
 
         // Vote to meet quorum
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, henry);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, henry);
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Verify SUCCEEDED state
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Succeeded)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded));
 
         // Recipient knows they will receive allocation but shares not minted yet
-        assertEq(_tokenized(address(mechanism)).balanceOf(henry), 0);
+        assertEq(_tokenized().balanceOf(henry), 0);
 
         // Proposal can be queued by admin
-        TokenizedAllocationMechanism.Proposal memory proposal = _tokenized(address(mechanism)).proposals(pid);
+        TokenizedAllocationMechanism.Proposal memory proposal = _tokenized().proposals(pid);
         assertFalse(proposal.canceled);
 
         // Verify vote tallies are correct using getTally() from ProperQF
-        (, , uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
+        (,, uint256 quadraticFunding, uint256 linearFunding) = mechanism.getTally(pid);
         uint256 forVotes = quadraticFunding + linearFunding;
         uint256 againstVotes = 0; // QuadraticVoting only supports For votes
         assertEq(forVotes, 900);
@@ -312,56 +254,53 @@ contract QuadraticVotingProposalStateTest is Test {
     function testProposalState_Queued() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup successful proposal
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Charlie's Queued Proposal");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(charlie, "Charlie's Queued Proposal");
         vm.stopPrank();
 
         vm.warp(votingStartTime + 1);
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie);
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue the proposal
         uint256 timestampBefore = block.timestamp;
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         // Verify QUEUED state
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Queued)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Queued));
 
         // Recipient receives shares but cannot redeem yet due to timelock
         uint256 expectedShares = 900;
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), expectedShares);
-        assertEq(_tokenized(address(mechanism)).proposalShares(pid), expectedShares);
+        assertEq(_tokenized().balanceOf(charlie), expectedShares);
+        assertEq(_tokenized().proposalShares(pid), expectedShares);
 
         // Timelock is active
-        uint256 globalRedemptionStart = _tokenized(address(mechanism)).globalRedemptionStart();
+        uint256 globalRedemptionStart = _tokenized().globalRedemptionStart();
         assertEq(globalRedemptionStart, timestampBefore + TIMELOCK_DELAY);
-        assertEq(_tokenized(address(mechanism)).globalRedemptionStart(), globalRedemptionStart);
+        assertEq(_tokenized().globalRedemptionStart(), globalRedemptionStart);
 
         // Cannot redeem during timelock
         vm.expectRevert("Allocation: redeem more than max");
         vm.prank(charlie);
-        _tokenized(address(mechanism)).redeem(expectedShares, charlie, charlie);
+        _tokenized().redeem(expectedShares, charlie, charlie);
 
         // Cannot queue again
         vm.expectRevert(TokenizedAllocationMechanism.AlreadyQueued.selector);
-        (bool success3, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success3,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         assertFalse(success3);
     }
 
@@ -369,28 +308,28 @@ contract QuadraticVotingProposalStateTest is Test {
     function testProposalState_ShareRedemption() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup and execute successful proposal
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(dave, "Dave's Executed Proposal");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(dave, "Dave's Executed Proposal");
         vm.stopPrank();
 
         vm.warp(votingStartTime + 1);
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, dave);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, dave);
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         // Fast forward past timelock
@@ -401,13 +340,13 @@ contract QuadraticVotingProposalStateTest is Test {
         uint256 daveTokensBefore = token.balanceOf(dave);
 
         vm.prank(dave);
-        uint256 assetsReceived = _tokenized(address(mechanism)).redeem(expectedShares, dave, dave);
+        uint256 assetsReceived = _tokenized().redeem(expectedShares, dave, dave);
 
         // After redemption, the proposal remains in Queued state
         // The state logic checks for shares balance and redeemable time
 
         // Verify redemption effects
-        assertEq(_tokenized(address(mechanism)).balanceOf(dave), 0);
+        assertEq(_tokenized().balanceOf(dave), 0);
         assertEq(token.balanceOf(dave), daveTokensBefore + assetsReceived);
 
         // With matching pool: total assets = 1000 (alice) + 2000 (matching pool) = 3000 ether
@@ -416,76 +355,70 @@ contract QuadraticVotingProposalStateTest is Test {
         assertEq(assetsReceived, expectedAssets);
 
         // During redemption period, proposals with shares are in REDEEMABLE state
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Redeemable)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Redeemable));
     }
 
     /// @notice Test EXPIRED state - proposal queued but grace period exceeded
     function testProposalState_Expired() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup proposal that will expire
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(eve, "Eve's Expired Proposal");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(eve, "Eve's Expired Proposal");
         vm.stopPrank();
 
         vm.warp(votingStartTime + 1);
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, eve);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, eve);
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         // Fast forward past timelock + grace period
         vm.warp(block.timestamp + TIMELOCK_DELAY + GRACE_PERIOD + 1);
 
         // Verify EXPIRED state
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Expired)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Expired));
 
         // Recipient still has shares but cannot redeem (expired)
-        assertEq(_tokenized(address(mechanism)).balanceOf(eve), 900);
+        assertEq(_tokenized().balanceOf(eve), 900);
 
         // Redemption should fail due to expiration
         vm.expectRevert("Allocation: redeem more than max");
         vm.prank(eve);
-        _tokenized(address(mechanism)).redeem(900, eve, eve);
+        _tokenized().redeem(900, eve, eve);
     }
 
     /// @notice Test complete recipient journey through multiple proposal states
     function testRecipientJourney_MultipleProposalStates() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup multiple voters
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
+        _tokenized().signup(LARGE_DEPOSIT);
         vm.stopPrank();
 
         vm.startPrank(bob);
         token.approve(address(mechanism), MEDIUM_DEPOSIT);
-        _tokenized(address(mechanism)).signup(MEDIUM_DEPOSIT);
+        _tokenized().signup(MEDIUM_DEPOSIT);
         vm.stopPrank();
 
         // Before voting starts (still in delay period) - warp before creating proposals
@@ -493,96 +426,67 @@ contract QuadraticVotingProposalStateTest is Test {
 
         // Create proposals that will have different outcomes
         vm.prank(alice);
-        uint256 pidSuccessful = _tokenized(address(mechanism)).propose(charlie, "Charlie's Success Story");
+        uint256 pidSuccessful = _tokenized().propose(charlie, "Charlie's Success Story");
 
         vm.prank(bob);
-        uint256 pidDefeated = _tokenized(address(mechanism)).propose(dave, "Dave's Defeat");
+        uint256 pidDefeated = _tokenized().propose(dave, "Dave's Defeat");
 
         vm.prank(alice);
-        uint256 pidCanceled = _tokenized(address(mechanism)).propose(eve, "Eve's Cancellation");
+        uint256 pidCanceled = _tokenized().propose(eve, "Eve's Cancellation");
 
         // Start with all in PENDING
         assertEq(
-            uint(_tokenized(address(mechanism)).state(pidSuccessful)),
-            uint(TokenizedAllocationMechanism.ProposalState.Pending)
+            uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Pending)
         );
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidDefeated)),
-            uint(TokenizedAllocationMechanism.ProposalState.Pending)
-        );
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidCanceled)),
-            uint(TokenizedAllocationMechanism.ProposalState.Pending)
-        );
+        assertEq(uint256(_tokenized().state(pidDefeated)), uint256(TokenizedAllocationMechanism.ProposalState.Pending));
+        assertEq(uint256(_tokenized().state(pidCanceled)), uint256(TokenizedAllocationMechanism.ProposalState.Pending));
 
         // Move to ACTIVE
         vm.warp(votingStartTime + 1);
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidSuccessful)),
-            uint(TokenizedAllocationMechanism.ProposalState.Active)
-        );
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidDefeated)),
-            uint(TokenizedAllocationMechanism.ProposalState.Active)
-        );
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidCanceled)),
-            uint(TokenizedAllocationMechanism.ProposalState.Active)
-        );
+        assertEq(uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Active));
+        assertEq(uint256(_tokenized().state(pidDefeated)), uint256(TokenizedAllocationMechanism.ProposalState.Active));
+        assertEq(uint256(_tokenized().state(pidCanceled)), uint256(TokenizedAllocationMechanism.ProposalState.Active));
 
         // Cancel one proposal
         vm.prank(alice);
-        _tokenized(address(mechanism)).cancelProposal(pidCanceled);
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidCanceled)),
-            uint(TokenizedAllocationMechanism.ProposalState.Canceled)
-        );
+        _tokenized().cancelProposal(pidCanceled);
+        assertEq(uint256(_tokenized().state(pidCanceled)), uint256(TokenizedAllocationMechanism.ProposalState.Canceled));
 
         // Vote on remaining proposals
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pidSuccessful, TokenizedAllocationMechanism.VoteType.For, 30, charlie);
+        _tokenized().castVote(pidSuccessful, TokenizedAllocationMechanism.VoteType.For, 30, charlie);
 
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pidDefeated, TokenizedAllocationMechanism.VoteType.For, 10, dave); // Below quorum
+        _tokenized().castVote(pidDefeated, TokenizedAllocationMechanism.VoteType.For, 10, dave); // Below quorum
 
         // Finalize
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Check final states
         assertEq(
-            uint(_tokenized(address(mechanism)).state(pidSuccessful)),
-            uint(TokenizedAllocationMechanism.ProposalState.Succeeded)
+            uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Succeeded)
         );
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidDefeated)),
-            uint(TokenizedAllocationMechanism.ProposalState.Defeated)
-        );
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidCanceled)),
-            uint(TokenizedAllocationMechanism.ProposalState.Canceled)
-        );
+        assertEq(uint256(_tokenized().state(pidDefeated)), uint256(TokenizedAllocationMechanism.ProposalState.Defeated));
+        assertEq(uint256(_tokenized().state(pidCanceled)), uint256(TokenizedAllocationMechanism.ProposalState.Canceled));
 
         // Queue successful proposal
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidSuccessful));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pidSuccessful));
         require(success2, "Queue failed");
 
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pidSuccessful)),
-            uint(TokenizedAllocationMechanism.ProposalState.Queued)
-        );
+        assertEq(uint256(_tokenized().state(pidSuccessful)), uint256(TokenizedAllocationMechanism.ProposalState.Queued));
 
         // Verify recipient outcomes
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), 900); // Success
-        assertEq(_tokenized(address(mechanism)).balanceOf(dave), 0); // Defeated
-        assertEq(_tokenized(address(mechanism)).balanceOf(eve), 0); // Canceled
+        assertEq(_tokenized().balanceOf(charlie), 900); // Success
+        assertEq(_tokenized().balanceOf(dave), 0); // Defeated
+        assertEq(_tokenized().balanceOf(eve), 0); // Canceled
 
         // Fast forward and redeem
         vm.warp(block.timestamp + TIMELOCK_DELAY + 1);
 
         vm.prank(charlie);
-        uint256 charlieAssets = _tokenized(address(mechanism)).redeem(900, charlie, charlie);
+        uint256 charlieAssets = _tokenized().redeem(900, charlie, charlie);
 
         // With matching pool: total assets = 1500 (alice + bob) + 2000 (matching pool) = 3500 ether
         // 900 shares out of 900 total shares = 100% of 3500 ether = 3500 ether

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingRecipientJourneyTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingRecipientJourneyTest.t.sol
@@ -1,29 +1,12 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
-import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Recipient Journey Integration Tests
 /// @notice Comprehensive tests for recipient user journey covering advocacy, allocation, and redemption
-contract QuadraticVotingRecipientJourneyTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1);
-    address bob = address(0x2);
-    address charlie = address(0x3);
-    address dave = address(0x4);
-    address eve = address(0x5);
-    address frank = address(0x6);
-
+contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
     uint256 constant LARGE_DEPOSIT = 1000 ether;
     uint256 constant MEDIUM_DEPOSIT = 500 ether;
     uint256 constant QUORUM_REQUIREMENT = 500;
@@ -130,68 +113,23 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         currentTestCtx.eveFor = 0;
     }
 
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
-    /// @notice Helper function to sign up a user with specified deposit
-    /// @param user Address of user to sign up
-    /// @param depositAmount Amount of tokens to deposit
-    function _signupUser(address user, uint256 depositAmount) internal {
-        vm.startPrank(user);
-        token.approve(address(mechanism), depositAmount);
-        _tokenized(address(mechanism)).signup(depositAmount);
-        vm.stopPrank();
-    }
-
-    /// @notice Helper function to create a proposal
-    /// @param proposer Address creating the proposal
-    /// @param recipient Address that will receive funds if proposal passes
-    /// @param description Description of the proposal
-    /// @return pid The proposal ID
-    function _createProposal(
-        address proposer,
-        address recipient,
-        string memory description
-    ) internal returns (uint256 pid) {
-        vm.prank(proposer);
-        pid = _tokenized(address(mechanism)).propose(recipient, description);
-    }
-
-    /// @notice Helper function to cast a vote on a proposal
-    /// @param voter Address casting the vote
-    /// @param pid Proposal ID to vote on
-    /// @param weight Vote weight (quadratic cost = weight^2)
-    /// @param recipient Expected recipient address for the proposal
-    function _castVote(address voter, uint256 pid, uint256 weight, address recipient) internal {
-        vm.prank(voter);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, weight, recipient);
-    }
-
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting(
+            "Recipient Journey Test",
+            "RJTEST",
+            VOTING_DELAY,
+            VOTING_PERIOD,
+            QUORUM_REQUIREMENT,
+            TIMELOCK_DELAY,
+            7 days,
+            50,
+            100
+        );
 
         token.mint(alice, 2000 ether);
         token.mint(bob, 1500 ether);
         token.mint(frank, 200 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Recipient Journey Test",
-            symbol: "RJTEST",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_REQUIREMENT,
-            timelockDelay: TIMELOCK_DELAY,
-            gracePeriod: 7 days,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-        _tokenized(address(mechanism)).setKeeper(alice);
-        _tokenized(address(mechanism)).setManagement(bob);
+        _setRoles(alice, bob);
 
         // Pre-fund matching pool - this will be included in total assets during finalize
         uint256 matchingPoolAmount = 2000 ether;
@@ -201,7 +139,7 @@ contract QuadraticVotingRecipientJourneyTest is Test {
 
     /// @notice Test recipient proposal advocacy and creation
     function testRecipientAdvocacy_ProposalCreation() public {
-        uint256 startBlock = _tokenized(address(mechanism)).startBlock();
+        uint256 startBlock = _tokenized().startBlock();
         vm.roll(startBlock - 1);
 
         // Recipients need proposers with voting power
@@ -211,7 +149,7 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         // Successful proposal creation for recipient
         uint256 pid1 = _createProposal(alice, charlie, "Charlie's Clean Energy Initiative");
 
-        TokenizedAllocationMechanism.Proposal memory proposal1 = _tokenized(address(mechanism)).proposals(pid1);
+        TokenizedAllocationMechanism.Proposal memory proposal1 = _tokenized().proposals(pid1);
         assertEq(proposal1.proposer, alice);
         assertEq(proposal1.recipient, charlie);
         assertEq(proposal1.description, "Charlie's Clean Energy Initiative");
@@ -221,22 +159,22 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         _createProposal(bob, dave, "Dave's Education Platform");
         _createProposal(alice, eve, "Eve's Healthcare Program");
 
-        assertEq(_tokenized(address(mechanism)).getProposalCount(), 3);
+        assertEq(_tokenized().getProposalCount(), 3);
 
         // Recipient uniqueness constraint
         vm.expectRevert(abi.encodeWithSelector(TokenizedAllocationMechanism.RecipientUsed.selector, charlie));
         vm.prank(bob);
-        _tokenized(address(mechanism)).propose(charlie, "Another proposal for Charlie");
+        _tokenized().propose(charlie, "Another proposal for Charlie");
 
         // Recipient cannot self-propose (no voting power)
         vm.expectRevert(abi.encodeWithSelector(TokenizedAllocationMechanism.ProposeNotAllowed.selector, charlie));
         vm.prank(charlie);
-        _tokenized(address(mechanism)).propose(frank, "Self-initiated proposal");
+        _tokenized().propose(frank, "Self-initiated proposal");
 
         // Zero address cannot be recipient
         vm.expectRevert(abi.encodeWithSelector(TokenizedAllocationMechanism.InvalidRecipient.selector, address(0)));
         vm.prank(alice);
-        _tokenized(address(mechanism)).propose(address(0), "Invalid recipient");
+        _tokenized().propose(address(0), "Invalid recipient");
     }
 
     /// @notice Test recipient monitoring and outcome tracking
@@ -245,8 +183,8 @@ contract QuadraticVotingRecipientJourneyTest is Test {
 
         // ✅ CORRECT: Fetch absolute timeline from contract
         uint256 deploymentTime = block.timestamp; // When mechanism was deployed
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
@@ -276,44 +214,41 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         _castVote(frank, currentTestCtx.pidEve, 8, eve);
 
         // Recipients can monitor progress in real-time using getTally() from ProperQF
-        (, , currentTestCtx.charlieQuadraticFunding, currentTestCtx.charlieLinearFunding) = mechanism.getTally(
-            currentTestCtx.pidCharlie
-        );
+        (,, currentTestCtx.charlieQuadraticFunding, currentTestCtx.charlieLinearFunding) =
+            mechanism.getTally(currentTestCtx.pidCharlie);
         currentTestCtx.charlieFor = currentTestCtx.charlieQuadraticFunding + currentTestCtx.charlieLinearFunding;
         // Charlie: Alice(25) + Bob(12) = (37)² × 0.5 = 684.5, rounded funding calculation
         assertTrue(currentTestCtx.charlieFor > 0, "Charlie should have funding from QuadraticFunding calculation");
 
-        (, , currentTestCtx.daveQuadraticFunding, currentTestCtx.daveLinearFunding) = mechanism.getTally(
-            currentTestCtx.pidDave
-        );
+        (,, currentTestCtx.daveQuadraticFunding, currentTestCtx.daveLinearFunding) =
+            mechanism.getTally(currentTestCtx.pidDave);
         currentTestCtx.daveFor = currentTestCtx.daveQuadraticFunding + currentTestCtx.daveLinearFunding;
         // Dave: Bob(10) = (10)² × 0.5 = 50
         assertTrue(currentTestCtx.daveFor > 0, "Dave should have some funding");
 
-        (, , currentTestCtx.eveQuadraticFunding, currentTestCtx.eveLinearFunding) = mechanism.getTally(
-            currentTestCtx.pidEve
-        );
+        (,, currentTestCtx.eveQuadraticFunding, currentTestCtx.eveLinearFunding) =
+            mechanism.getTally(currentTestCtx.pidEve);
         currentTestCtx.eveFor = currentTestCtx.eveQuadraticFunding + currentTestCtx.eveLinearFunding;
         // Eve: Alice(12) + Frank(8) = (20)² × 0.5 = 200
         assertTrue(currentTestCtx.eveFor > 0, "Eve should have funding from For votes");
 
         // End voting and finalize
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Test outcome tracking
         assertEq(
-            uint(_tokenized(address(mechanism)).state(currentTestCtx.pidCharlie)),
-            uint(TokenizedAllocationMechanism.ProposalState.Succeeded)
+            uint256(_tokenized().state(currentTestCtx.pidCharlie)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Succeeded)
         );
         assertEq(
-            uint(_tokenized(address(mechanism)).state(currentTestCtx.pidDave)),
-            uint(TokenizedAllocationMechanism.ProposalState.Defeated)
+            uint256(_tokenized().state(currentTestCtx.pidDave)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Defeated)
         );
         assertEq(
-            uint(_tokenized(address(mechanism)).state(currentTestCtx.pidEve)),
-            uint(TokenizedAllocationMechanism.ProposalState.Defeated)
+            uint256(_tokenized().state(currentTestCtx.pidEve)),
+            uint256(TokenizedAllocationMechanism.ProposalState.Defeated)
         );
     }
 
@@ -321,8 +256,8 @@ contract QuadraticVotingRecipientJourneyTest is Test {
     function testRecipientShares_AllocationRedemption() public {
         // ✅ CORRECT: Fetch absolute timeline from contract
         uint256 deploymentTime = block.timestamp; // When mechanism was deployed
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
@@ -340,36 +275,36 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         _castVote(bob, pid, 20, charlie);
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Share allocation on queuing
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), 0);
-        assertEq(_tokenized(address(mechanism)).totalSupply(), 0);
+        assertEq(_tokenized().balanceOf(charlie), 0);
+        assertEq(_tokenized().totalSupply(), 0);
 
         uint256 timestampBefore = block.timestamp;
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue proposal failed");
 
         // Verify share allocation based on QuadraticFunding calculation
-        uint256 actualShares = _tokenized(address(mechanism)).balanceOf(charlie);
+        uint256 actualShares = _tokenized().balanceOf(charlie);
         assertTrue(actualShares > 0, "Charlie should receive shares based on QuadraticFunding");
-        assertEq(_tokenized(address(mechanism)).totalSupply(), actualShares);
+        assertEq(_tokenized().totalSupply(), actualShares);
 
         // With matching pool: totalAssets = user deposits + matching pool
         uint256 expectedTotalAssets = LARGE_DEPOSIT + MEDIUM_DEPOSIT + 2000 ether; // 1000 + 500 + 2000 = 3500
-        assertEq(_tokenized(address(mechanism)).totalAssets(), expectedTotalAssets);
-        assertEq(_tokenized(address(mechanism)).proposalShares(pid), actualShares);
+        assertEq(_tokenized().totalAssets(), expectedTotalAssets);
+        assertEq(_tokenized().proposalShares(pid), actualShares);
 
         // Timelock enforcement
-        uint256 redeemableTime = _tokenized(address(mechanism)).globalRedemptionStart();
+        uint256 redeemableTime = _tokenized().globalRedemptionStart();
         assertEq(redeemableTime, timestampBefore + TIMELOCK_DELAY);
         assertGt(redeemableTime, block.timestamp);
 
         // Cannot redeem before timelock
         vm.expectRevert("Allocation: redeem more than max");
         vm.prank(charlie);
-        _tokenized(address(mechanism)).redeem(actualShares, charlie, charlie);
+        _tokenized().redeem(actualShares, charlie, charlie);
 
         // Successful redemption after timelock
         vm.warp(redeemableTime + 1);
@@ -378,11 +313,11 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         uint256 mechanismTokensBefore = token.balanceOf(address(mechanism));
 
         vm.prank(charlie);
-        uint256 assetsReceived = _tokenized(address(mechanism)).redeem(actualShares, charlie, charlie);
+        uint256 assetsReceived = _tokenized().redeem(actualShares, charlie, charlie);
 
         // Verify redemption effects
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), 0);
-        assertEq(_tokenized(address(mechanism)).totalSupply(), 0);
+        assertEq(_tokenized().balanceOf(charlie), 0);
+        assertEq(_tokenized().totalSupply(), 0);
         assertEq(token.balanceOf(charlie), charlieTokensBefore + assetsReceived);
         assertEq(token.balanceOf(address(mechanism)), mechanismTokensBefore - assetsReceived);
         // With matching pool: charlie gets 100% of shares, so 100% of total assets
@@ -397,20 +332,20 @@ contract QuadraticVotingRecipientJourneyTest is Test {
 
         // ✅ CORRECT: Fetch absolute timeline from contract
         uint256 deploymentTime = block.timestamp; // When mechanism was deployed
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup multiple successful recipients
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
+        _tokenized().signup(LARGE_DEPOSIT);
         vm.stopPrank();
 
         vm.startPrank(bob);
         token.approve(address(mechanism), MEDIUM_DEPOSIT);
-        _tokenized(address(mechanism)).signup(MEDIUM_DEPOSIT);
+        _tokenized().signup(MEDIUM_DEPOSIT);
         vm.stopPrank();
 
         currentTestCtx.pid1 = _createProposal(alice, charlie, "Charlie's Project");
@@ -424,7 +359,7 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         _castVote(bob, currentTestCtx.pid2, 25, dave);
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue both proposals at the same time to ensure same timelock schedule
@@ -432,22 +367,20 @@ contract QuadraticVotingRecipientJourneyTest is Test {
 
         // Warp to a specific time BEFORE queuing to ensure both get the same timestamp
         vm.warp(currentTestCtx.queueTime);
-        (bool success1, ) = address(mechanism).call(
-            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1)
-        );
+        (bool success1,) =
+            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1));
         require(success1, "Queue proposal 1 failed");
 
         // Reset to same timestamp for second proposal
         vm.warp(currentTestCtx.queueTime);
-        (bool success2, ) = address(mechanism).call(
-            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2)
-        );
+        (bool success2,) =
+            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2));
         require(success2, "Queue proposal 2 failed");
 
         // Verify both recipients received shares based on QuadraticFunding calculations
-        currentTestCtx.charlieShares = _tokenized(address(mechanism)).balanceOf(charlie);
-        currentTestCtx.daveShares = _tokenized(address(mechanism)).balanceOf(dave);
-        currentTestCtx.totalSupply = _tokenized(address(mechanism)).totalSupply();
+        currentTestCtx.charlieShares = _tokenized().balanceOf(charlie);
+        currentTestCtx.daveShares = _tokenized().balanceOf(dave);
+        currentTestCtx.totalSupply = _tokenized().totalSupply();
 
         assertTrue(currentTestCtx.charlieShares > 0, "Charlie should receive shares");
         assertTrue(currentTestCtx.daveShares > 0, "Dave should receive shares");
@@ -457,112 +390,76 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         vm.warp(block.timestamp + TIMELOCK_DELAY + 100);
 
         // Charlie partial redemption (50%) - use maxRedeem to avoid boundary issues
-        currentTestCtx.charlieMaxRedeem = _tokenized(address(mechanism)).maxRedeem(charlie);
+        currentTestCtx.charlieMaxRedeem = _tokenized().maxRedeem(charlie);
         currentTestCtx.charliePartialRedeem = currentTestCtx.charlieMaxRedeem / 2; // Redeem half of what's allowed
         vm.prank(charlie);
-        currentTestCtx.charlieAssets1 = _tokenized(address(mechanism)).redeem(
-            currentTestCtx.charliePartialRedeem,
-            charlie,
-            charlie
-        );
+        currentTestCtx.charlieAssets1 = _tokenized().redeem(currentTestCtx.charliePartialRedeem, charlie, charlie);
 
         currentTestCtx.charlieRemainingShares = currentTestCtx.charlieShares - currentTestCtx.charliePartialRedeem;
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), currentTestCtx.charlieRemainingShares);
-        assertEq(
-            _tokenized(address(mechanism)).totalSupply(),
-            currentTestCtx.totalSupply - currentTestCtx.charliePartialRedeem
-        );
+        assertEq(_tokenized().balanceOf(charlie), currentTestCtx.charlieRemainingShares);
+        assertEq(_tokenized().totalSupply(), currentTestCtx.totalSupply - currentTestCtx.charliePartialRedeem);
 
         // With matching pool: calculate expected assets based on share-to-asset ratio
         currentTestCtx.totalAssets = LARGE_DEPOSIT + MEDIUM_DEPOSIT + 2000 ether; // 3500 ether
         currentTestCtx.expectedCharlieAssets1 =
-            (currentTestCtx.charliePartialRedeem * currentTestCtx.totalAssets) /
-            currentTestCtx.totalSupply;
+            (currentTestCtx.charliePartialRedeem * currentTestCtx.totalAssets) / currentTestCtx.totalSupply;
         assertApproxEqAbs(
-            currentTestCtx.charlieAssets1,
-            currentTestCtx.expectedCharlieAssets1,
-            1,
-            "Charlie assets1 within 1 wei"
+            currentTestCtx.charlieAssets1, currentTestCtx.expectedCharlieAssets1, 1, "Charlie assets1 within 1 wei"
         );
 
         // Dave full redemption - use maxRedeem to handle any rounding issues
-        currentTestCtx.daveMaxRedeemShares = _tokenized(address(mechanism)).maxRedeem(dave);
+        currentTestCtx.daveMaxRedeemShares = _tokenized().maxRedeem(dave);
         vm.prank(dave);
-        currentTestCtx.daveAssets = _tokenized(address(mechanism)).redeem(
-            currentTestCtx.daveMaxRedeemShares,
-            dave,
-            dave
-        );
+        currentTestCtx.daveAssets = _tokenized().redeem(currentTestCtx.daveMaxRedeemShares, dave, dave);
 
         currentTestCtx.daveRemainingShares = currentTestCtx.daveShares - currentTestCtx.daveMaxRedeemShares;
-        assertEq(_tokenized(address(mechanism)).balanceOf(dave), currentTestCtx.daveRemainingShares);
-        assertEq(
-            _tokenized(address(mechanism)).totalSupply(),
-            currentTestCtx.charlieRemainingShares + currentTestCtx.daveRemainingShares
-        );
+        assertEq(_tokenized().balanceOf(dave), currentTestCtx.daveRemainingShares);
+        assertEq(_tokenized().totalSupply(), currentTestCtx.charlieRemainingShares + currentTestCtx.daveRemainingShares);
 
         currentTestCtx.expectedDaveAssets =
-            (currentTestCtx.daveMaxRedeemShares * currentTestCtx.totalAssets) /
-            currentTestCtx.totalSupply;
+            (currentTestCtx.daveMaxRedeemShares * currentTestCtx.totalAssets) / currentTestCtx.totalSupply;
         assertApproxEqAbs(currentTestCtx.daveAssets, currentTestCtx.expectedDaveAssets, 1, "Dave assets within 1 wei");
 
         // Charlie remaining redemption - redeem whatever is left and allowed
-        currentTestCtx.charlieMaxRedeem2 = _tokenized(address(mechanism)).maxRedeem(charlie);
+        currentTestCtx.charlieMaxRedeem2 = _tokenized().maxRedeem(charlie);
         vm.prank(charlie);
-        currentTestCtx.charlieAssets2 = _tokenized(address(mechanism)).redeem(
-            currentTestCtx.charlieMaxRedeem2,
-            charlie,
-            charlie
-        );
+        currentTestCtx.charlieAssets2 = _tokenized().redeem(currentTestCtx.charlieMaxRedeem2, charlie, charlie);
 
         // If Charlie has any remaining shares due to rounding, redeem them too
-        currentTestCtx.charlieRemainingAfterSecond = _tokenized(address(mechanism)).balanceOf(charlie);
+        currentTestCtx.charlieRemainingAfterSecond = _tokenized().balanceOf(charlie);
         currentTestCtx.charlieAssets3 = 0;
         if (currentTestCtx.charlieRemainingAfterSecond > 0) {
-            currentTestCtx.charlieMaxRedeem3 = _tokenized(address(mechanism)).maxRedeem(charlie);
+            currentTestCtx.charlieMaxRedeem3 = _tokenized().maxRedeem(charlie);
             if (currentTestCtx.charlieMaxRedeem3 > 0) {
                 vm.prank(charlie);
-                currentTestCtx.charlieAssets3 = _tokenized(address(mechanism)).redeem(
-                    currentTestCtx.charlieMaxRedeem3,
-                    charlie,
-                    charlie
-                );
+                currentTestCtx.charlieAssets3 = _tokenized().redeem(currentTestCtx.charlieMaxRedeem3, charlie, charlie);
             }
         }
 
         // Charlie should now have redeemed all shares
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), 0, "Charlie should have redeemed all shares");
-        assertEq(_tokenized(address(mechanism)).totalSupply(), currentTestCtx.daveRemainingShares);
+        assertEq(_tokenized().balanceOf(charlie), 0, "Charlie should have redeemed all shares");
+        assertEq(_tokenized().totalSupply(), currentTestCtx.daveRemainingShares);
 
         currentTestCtx.expectedCharlieAssets2 =
-            (currentTestCtx.charlieMaxRedeem2 * currentTestCtx.totalAssets) /
-            currentTestCtx.totalSupply;
+            (currentTestCtx.charlieMaxRedeem2 * currentTestCtx.totalAssets) / currentTestCtx.totalSupply;
         assertApproxEqAbs(
-            currentTestCtx.charlieAssets2,
-            currentTestCtx.expectedCharlieAssets2,
-            2,
-            "Charlie assets2 within 2 wei"
+            currentTestCtx.charlieAssets2, currentTestCtx.expectedCharlieAssets2, 2, "Charlie assets2 within 2 wei"
         );
 
         // Let Dave redeem any remaining shares too
         currentTestCtx.daveAssets2 = 0;
         if (currentTestCtx.daveRemainingShares > 0) {
-            currentTestCtx.daveMaxRedeem2 = _tokenized(address(mechanism)).maxRedeem(dave);
+            currentTestCtx.daveMaxRedeem2 = _tokenized().maxRedeem(dave);
             if (currentTestCtx.daveMaxRedeem2 > 0) {
                 vm.prank(dave);
-                currentTestCtx.daveAssets2 = _tokenized(address(mechanism)).redeem(
-                    currentTestCtx.daveMaxRedeem2,
-                    dave,
-                    dave
-                );
+                currentTestCtx.daveAssets2 = _tokenized().redeem(currentTestCtx.daveMaxRedeem2, dave, dave);
             }
         }
 
         // Verify total assets redeemed correctly with matching pool conversion using inline computation
         {
             currentTestCtx.charlieSharesRedeemed =
-                currentTestCtx.charliePartialRedeem +
-                currentTestCtx.charlieMaxRedeem2;
+                currentTestCtx.charliePartialRedeem + currentTestCtx.charlieMaxRedeem2;
             if (currentTestCtx.charlieAssets3 > 0) {
                 currentTestCtx.charlieSharesRedeemed += currentTestCtx.charlieRemainingAfterSecond;
             }
@@ -575,16 +472,12 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         }
 
         // Both recipients should have redeemed all or nearly all their shares
-        currentTestCtx.totalRemainingShares = _tokenized(address(mechanism)).totalSupply();
+        currentTestCtx.totalRemainingShares = _tokenized().totalSupply();
         assertTrue(currentTestCtx.totalRemainingShares <= 1, "Should have at most 1 remaining share due to rounding");
 
         // Verify total assets conservation - almost all assets should be redeemed
-        currentTestCtx.totalAssetsRedeemed =
-            currentTestCtx.charlieAssets1 +
-            currentTestCtx.charlieAssets2 +
-            currentTestCtx.charlieAssets3 +
-            currentTestCtx.daveAssets +
-            currentTestCtx.daveAssets2;
+        currentTestCtx.totalAssetsRedeemed = currentTestCtx.charlieAssets1 + currentTestCtx.charlieAssets2
+            + currentTestCtx.charlieAssets3 + currentTestCtx.daveAssets + currentTestCtx.daveAssets2;
         assertApproxEqAbs(
             currentTestCtx.totalAssetsRedeemed,
             currentTestCtx.totalAssets,
@@ -597,15 +490,15 @@ contract QuadraticVotingRecipientJourneyTest is Test {
     function testRecipientShares_TransferabilityERC20() public {
         // ✅ CORRECT: Fetch absolute timeline from contract
         uint256 deploymentTime = block.timestamp; // When mechanism was deployed
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup successful allocation
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
+        _tokenized().signup(LARGE_DEPOSIT);
         vm.stopPrank();
 
         uint256 pid = _createProposal(alice, charlie, "Charlie's Project");
@@ -616,20 +509,20 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         _castVote(alice, pid, 30, charlie);
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue proposal failed");
 
         // Charlie receives shares from QuadraticFunding calculation
-        uint256 charlieShares = _tokenized(address(mechanism)).balanceOf(charlie);
+        uint256 charlieShares = _tokenized().balanceOf(charlie);
         assertTrue(charlieShares > 0, "Charlie should receive shares");
 
         // Test that transfers are blocked before redemption period
         vm.prank(charlie);
         vm.expectRevert("Transfers only allowed during redemption period");
-        _tokenized(address(mechanism)).transfer(dave, charlieShares / 3);
+        _tokenized().transfer(dave, charlieShares / 3);
 
         // Fast forward to redemption period start
         vm.warp(block.timestamp + TIMELOCK_DELAY);
@@ -637,45 +530,45 @@ contract QuadraticVotingRecipientJourneyTest is Test {
         // Test share transferability (use reasonable portion of actual shares)
         uint256 transferAmount = charlieShares / 3; // Transfer 1/3 of shares
         vm.prank(charlie);
-        _tokenized(address(mechanism)).transfer(dave, transferAmount);
+        _tokenized().transfer(dave, transferAmount);
 
         // Verify transfer
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), charlieShares - transferAmount);
-        assertEq(_tokenized(address(mechanism)).balanceOf(dave), transferAmount);
-        assertEq(_tokenized(address(mechanism)).totalSupply(), charlieShares);
+        assertEq(_tokenized().balanceOf(charlie), charlieShares - transferAmount);
+        assertEq(_tokenized().balanceOf(dave), transferAmount);
+        assertEq(_tokenized().totalSupply(), charlieShares);
 
         // Test approval and transferFrom
         uint256 allowanceAmount = charlieShares / 5; // Approve 1/5 of original shares
         vm.prank(charlie);
-        _tokenized(address(mechanism)).approve(dave, allowanceAmount);
+        _tokenized().approve(dave, allowanceAmount);
 
-        assertEq(_tokenized(address(mechanism)).allowance(charlie, dave), allowanceAmount);
+        assertEq(_tokenized().allowance(charlie, dave), allowanceAmount);
 
         vm.prank(dave);
-        _tokenized(address(mechanism)).transferFrom(charlie, eve, allowanceAmount);
+        _tokenized().transferFrom(charlie, eve, allowanceAmount);
 
         // Verify transferFrom effects
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), charlieShares - transferAmount - allowanceAmount);
-        assertEq(_tokenized(address(mechanism)).balanceOf(eve), allowanceAmount);
-        assertEq(_tokenized(address(mechanism)).allowance(charlie, dave), 0);
+        assertEq(_tokenized().balanceOf(charlie), charlieShares - transferAmount - allowanceAmount);
+        assertEq(_tokenized().balanceOf(eve), allowanceAmount);
+        assertEq(_tokenized().allowance(charlie, dave), 0);
 
         // Dave can redeem transferred shares
         vm.prank(dave);
-        uint256 daveAssets = _tokenized(address(mechanism)).redeem(transferAmount, dave, dave);
+        uint256 daveAssets = _tokenized().redeem(transferAmount, dave, dave);
 
         // With matching pool: total assets = 1000 (alice) + 2000 (matching pool) = 3000 ether
         // Conversion ratio = 3000 ether / 900 shares = 3.333... ether per share
         uint256 totalAssets = LARGE_DEPOSIT + 2000 ether; // 3000 ether
         uint256 expectedDaveAssets = (transferAmount * totalAssets) / charlieShares;
         assertEq(daveAssets, expectedDaveAssets);
-        assertEq(_tokenized(address(mechanism)).balanceOf(dave), 0);
+        assertEq(_tokenized().balanceOf(dave), 0);
 
         // Eve can redeem transferred shares
         vm.prank(eve);
-        uint256 eveAssets = _tokenized(address(mechanism)).redeem(allowanceAmount, eve, eve);
+        uint256 eveAssets = _tokenized().redeem(allowanceAmount, eve, eve);
 
         uint256 expectedEveAssets = (allowanceAmount * totalAssets) / charlieShares;
         assertEq(eveAssets, expectedEveAssets);
-        assertEq(_tokenized(address(mechanism)).balanceOf(eve), 0);
+        assertEq(_tokenized().balanceOf(eve), 0);
     }
 }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingRecipientJourneyTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingRecipientJourneyTest.t.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Recipient Journey Integration Tests
 /// @notice Comprehensive tests for recipient user journey covering advocacy, allocation, and redemption
@@ -214,27 +214,30 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
         _castVote(frank, currentTestCtx.pidEve, 8, eve);
 
         // Recipients can monitor progress in real-time using getTally() from ProperQF
-        (,, currentTestCtx.charlieQuadraticFunding, currentTestCtx.charlieLinearFunding) =
-            mechanism.getTally(currentTestCtx.pidCharlie);
+        (, , currentTestCtx.charlieQuadraticFunding, currentTestCtx.charlieLinearFunding) = mechanism.getTally(
+            currentTestCtx.pidCharlie
+        );
         currentTestCtx.charlieFor = currentTestCtx.charlieQuadraticFunding + currentTestCtx.charlieLinearFunding;
         // Charlie: Alice(25) + Bob(12) = (37)² × 0.5 = 684.5, rounded funding calculation
         assertTrue(currentTestCtx.charlieFor > 0, "Charlie should have funding from QuadraticFunding calculation");
 
-        (,, currentTestCtx.daveQuadraticFunding, currentTestCtx.daveLinearFunding) =
-            mechanism.getTally(currentTestCtx.pidDave);
+        (, , currentTestCtx.daveQuadraticFunding, currentTestCtx.daveLinearFunding) = mechanism.getTally(
+            currentTestCtx.pidDave
+        );
         currentTestCtx.daveFor = currentTestCtx.daveQuadraticFunding + currentTestCtx.daveLinearFunding;
         // Dave: Bob(10) = (10)² × 0.5 = 50
         assertTrue(currentTestCtx.daveFor > 0, "Dave should have some funding");
 
-        (,, currentTestCtx.eveQuadraticFunding, currentTestCtx.eveLinearFunding) =
-            mechanism.getTally(currentTestCtx.pidEve);
+        (, , currentTestCtx.eveQuadraticFunding, currentTestCtx.eveLinearFunding) = mechanism.getTally(
+            currentTestCtx.pidEve
+        );
         currentTestCtx.eveFor = currentTestCtx.eveQuadraticFunding + currentTestCtx.eveLinearFunding;
         // Eve: Alice(12) + Frank(8) = (20)² × 0.5 = 200
         assertTrue(currentTestCtx.eveFor > 0, "Eve should have funding from For votes");
 
         // End voting and finalize
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Test outcome tracking
@@ -275,7 +278,7 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
         _castVote(bob, pid, 20, charlie);
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Share allocation on queuing
@@ -283,7 +286,7 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
         assertEq(_tokenized().totalSupply(), 0);
 
         uint256 timestampBefore = block.timestamp;
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue proposal failed");
 
         // Verify share allocation based on QuadraticFunding calculation
@@ -359,7 +362,7 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
         _castVote(bob, currentTestCtx.pid2, 25, dave);
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue both proposals at the same time to ensure same timelock schedule
@@ -367,14 +370,16 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
 
         // Warp to a specific time BEFORE queuing to ensure both get the same timestamp
         vm.warp(currentTestCtx.queueTime);
-        (bool success1,) =
-            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1));
+        (bool success1, ) = address(mechanism).call(
+            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid1)
+        );
         require(success1, "Queue proposal 1 failed");
 
         // Reset to same timestamp for second proposal
         vm.warp(currentTestCtx.queueTime);
-        (bool success2,) =
-            address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2));
+        (bool success2, ) = address(mechanism).call(
+            abi.encodeWithSignature("queueProposal(uint256)", currentTestCtx.pid2)
+        );
         require(success2, "Queue proposal 2 failed");
 
         // Verify both recipients received shares based on QuadraticFunding calculations
@@ -402,9 +407,13 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
         // With matching pool: calculate expected assets based on share-to-asset ratio
         currentTestCtx.totalAssets = LARGE_DEPOSIT + MEDIUM_DEPOSIT + 2000 ether; // 3500 ether
         currentTestCtx.expectedCharlieAssets1 =
-            (currentTestCtx.charliePartialRedeem * currentTestCtx.totalAssets) / currentTestCtx.totalSupply;
+            (currentTestCtx.charliePartialRedeem * currentTestCtx.totalAssets) /
+            currentTestCtx.totalSupply;
         assertApproxEqAbs(
-            currentTestCtx.charlieAssets1, currentTestCtx.expectedCharlieAssets1, 1, "Charlie assets1 within 1 wei"
+            currentTestCtx.charlieAssets1,
+            currentTestCtx.expectedCharlieAssets1,
+            1,
+            "Charlie assets1 within 1 wei"
         );
 
         // Dave full redemption - use maxRedeem to handle any rounding issues
@@ -414,10 +423,14 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
 
         currentTestCtx.daveRemainingShares = currentTestCtx.daveShares - currentTestCtx.daveMaxRedeemShares;
         assertEq(_tokenized().balanceOf(dave), currentTestCtx.daveRemainingShares);
-        assertEq(_tokenized().totalSupply(), currentTestCtx.charlieRemainingShares + currentTestCtx.daveRemainingShares);
+        assertEq(
+            _tokenized().totalSupply(),
+            currentTestCtx.charlieRemainingShares + currentTestCtx.daveRemainingShares
+        );
 
         currentTestCtx.expectedDaveAssets =
-            (currentTestCtx.daveMaxRedeemShares * currentTestCtx.totalAssets) / currentTestCtx.totalSupply;
+            (currentTestCtx.daveMaxRedeemShares * currentTestCtx.totalAssets) /
+            currentTestCtx.totalSupply;
         assertApproxEqAbs(currentTestCtx.daveAssets, currentTestCtx.expectedDaveAssets, 1, "Dave assets within 1 wei");
 
         // Charlie remaining redemption - redeem whatever is left and allowed
@@ -441,9 +454,13 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
         assertEq(_tokenized().totalSupply(), currentTestCtx.daveRemainingShares);
 
         currentTestCtx.expectedCharlieAssets2 =
-            (currentTestCtx.charlieMaxRedeem2 * currentTestCtx.totalAssets) / currentTestCtx.totalSupply;
+            (currentTestCtx.charlieMaxRedeem2 * currentTestCtx.totalAssets) /
+            currentTestCtx.totalSupply;
         assertApproxEqAbs(
-            currentTestCtx.charlieAssets2, currentTestCtx.expectedCharlieAssets2, 2, "Charlie assets2 within 2 wei"
+            currentTestCtx.charlieAssets2,
+            currentTestCtx.expectedCharlieAssets2,
+            2,
+            "Charlie assets2 within 2 wei"
         );
 
         // Let Dave redeem any remaining shares too
@@ -459,7 +476,8 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
         // Verify total assets redeemed correctly with matching pool conversion using inline computation
         {
             currentTestCtx.charlieSharesRedeemed =
-                currentTestCtx.charliePartialRedeem + currentTestCtx.charlieMaxRedeem2;
+                currentTestCtx.charliePartialRedeem +
+                currentTestCtx.charlieMaxRedeem2;
             if (currentTestCtx.charlieAssets3 > 0) {
                 currentTestCtx.charlieSharesRedeemed += currentTestCtx.charlieRemainingAfterSecond;
             }
@@ -476,8 +494,12 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
         assertTrue(currentTestCtx.totalRemainingShares <= 1, "Should have at most 1 remaining share due to rounding");
 
         // Verify total assets conservation - almost all assets should be redeemed
-        currentTestCtx.totalAssetsRedeemed = currentTestCtx.charlieAssets1 + currentTestCtx.charlieAssets2
-            + currentTestCtx.charlieAssets3 + currentTestCtx.daveAssets + currentTestCtx.daveAssets2;
+        currentTestCtx.totalAssetsRedeemed =
+            currentTestCtx.charlieAssets1 +
+            currentTestCtx.charlieAssets2 +
+            currentTestCtx.charlieAssets3 +
+            currentTestCtx.daveAssets +
+            currentTestCtx.daveAssets2;
         assertApproxEqAbs(
             currentTestCtx.totalAssetsRedeemed,
             currentTestCtx.totalAssets,
@@ -509,10 +531,10 @@ contract QuadraticVotingRecipientJourneyTest is QuadraticVotingTestBase {
         _castVote(alice, pid, 30, charlie);
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue proposal failed");
 
         // Charlie receives shares from QuadraticFunding calculation

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingSimpleTimelockTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingSimpleTimelockTest.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 contract QuadraticVotingSimpleTimelockTest is QuadraticVotingTestBase {
     function setUp() public {
@@ -32,14 +32,16 @@ contract QuadraticVotingSimpleTimelockTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 25, charlie); // Cost: 25^2 = 625
 
         // Debug: Check what quadratic funding this generates
-        (uint256 sumContributions,, uint256 quadraticFunding, uint256 linearFunding) = mechanism.getProposalFunding(pid);
+        (uint256 sumContributions, , uint256 quadraticFunding, uint256 linearFunding) = mechanism.getProposalFunding(
+            pid
+        );
         console.log("Funding amounts:");
         console.log("  sumContributions:", sumContributions);
         console.log("  quadraticFunding:", quadraticFunding);
         console.log("  linearFunding:", linearFunding);
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         console.log("=== BEFORE QUEUING ===");
@@ -49,7 +51,7 @@ contract QuadraticVotingSimpleTimelockTest is QuadraticVotingTestBase {
         console.log("Charlie maxRedeem:", _tokenized().maxRedeem(charlie));
 
         uint256 queueTime = block.timestamp;
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         console.log("=== AFTER QUEUING ===");
@@ -101,8 +103,8 @@ contract QuadraticVotingSimpleTimelockTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 20, charlie); // Cost: 20^2 = 400
 
         // Verify proposal has non-zero funding before cancellation
-        (uint256 sumContributions, uint256 sumSquareRoots, uint256 quadraticFunding, uint256 linearFunding) =
-            mechanism.getProposalFunding(pid);
+        (uint256 sumContributions, uint256 sumSquareRoots, uint256 quadraticFunding, uint256 linearFunding) = mechanism
+            .getProposalFunding(pid);
         assertTrue(sumContributions > 0, "Should have contributions before cancellation");
         assertTrue(sumSquareRoots > 0, "Should have square roots before cancellation");
         assertTrue(quadraticFunding > 0, "Should have quadratic funding before cancellation");
@@ -149,7 +151,7 @@ contract QuadraticVotingSimpleTimelockTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // High vote to meet quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue the proposal to set redemption period

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingSimpleTimelockTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingSimpleTimelockTest.t.sol
@@ -1,159 +1,118 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
-contract QuadraticVotingSimpleTimelockTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1);
-    address charlie = address(0x3);
-
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
+contract QuadraticVotingSimpleTimelockTest is QuadraticVotingTestBase {
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting("Simple Test", "SIMPLE", 10, 100, 500, 1000, 5000, 50, 100);
         token.mint(alice, 2000 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Simple Test",
-            symbol: "SIMPLE",
-            votingDelay: 10,
-            votingPeriod: 100,
-            quorumShares: 500, // Adjusted for quadratic funding
-            timelockDelay: 1000, // 1000 seconds for easier testing
-            gracePeriod: 5000, // 5000 seconds
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-        _tokenized(address(mechanism)).setKeeper(alice);
+        _tokenized().setKeeper(alice);
     }
 
     function testSimpleTimelock() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup
         vm.startPrank(alice);
         token.approve(address(mechanism), 1000 ether);
-        _tokenized(address(mechanism)).signup(1000 ether);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Test");
+        _tokenized().signup(1000 ether);
+        uint256 pid = _tokenized().propose(charlie, "Test");
         vm.stopPrank();
 
         vm.warp(votingStartTime + 1);
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 25, charlie); // Cost: 25^2 = 625
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 25, charlie); // Cost: 25^2 = 625
 
         // Debug: Check what quadratic funding this generates
-        (uint256 sumContributions, , uint256 quadraticFunding, uint256 linearFunding) = mechanism.getProposalFunding(
-            pid
-        );
+        (uint256 sumContributions,, uint256 quadraticFunding, uint256 linearFunding) = mechanism.getProposalFunding(pid);
         console.log("Funding amounts:");
         console.log("  sumContributions:", sumContributions);
         console.log("  quadraticFunding:", quadraticFunding);
         console.log("  linearFunding:", linearFunding);
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         console.log("=== BEFORE QUEUING ===");
         console.log("Current timestamp:", block.timestamp);
-        console.log("Charlie redeemableAfter:", _tokenized(address(mechanism)).globalRedemptionStart());
-        console.log("Charlie balance:", _tokenized(address(mechanism)).balanceOf(charlie));
-        console.log("Charlie maxRedeem:", _tokenized(address(mechanism)).maxRedeem(charlie));
+        console.log("Charlie redeemableAfter:", _tokenized().globalRedemptionStart());
+        console.log("Charlie balance:", _tokenized().balanceOf(charlie));
+        console.log("Charlie maxRedeem:", _tokenized().maxRedeem(charlie));
 
         uint256 queueTime = block.timestamp;
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         console.log("=== AFTER QUEUING ===");
         console.log("Queue time:", queueTime);
         console.log("Current timestamp:", block.timestamp);
-        console.log("Timelock delay:", _tokenized(address(mechanism)).timelockDelay());
+        console.log("Timelock delay:", _tokenized().timelockDelay());
         console.log("Expected redeemable time:", queueTime + 1000);
-        console.log("Charlie redeemableAfter:", _tokenized(address(mechanism)).globalRedemptionStart());
-        console.log("Charlie balance:", _tokenized(address(mechanism)).balanceOf(charlie));
-        console.log("Charlie maxRedeem:", _tokenized(address(mechanism)).maxRedeem(charlie));
+        console.log("Charlie redeemableAfter:", _tokenized().globalRedemptionStart());
+        console.log("Charlie balance:", _tokenized().balanceOf(charlie));
+        console.log("Charlie maxRedeem:", _tokenized().maxRedeem(charlie));
 
         // Verify shares were minted and timelock set correctly
-        assertGt(_tokenized(address(mechanism)).balanceOf(charlie), 0, "Should have shares after queue");
-        assertEq(
-            _tokenized(address(mechanism)).globalRedemptionStart(),
-            queueTime + 1000,
-            "Should have correct redeemableAfter"
-        );
+        assertGt(_tokenized().balanceOf(charlie), 0, "Should have shares after queue");
+        assertEq(_tokenized().globalRedemptionStart(), queueTime + 1000, "Should have correct redeemableAfter");
 
         // Test 1: Should be blocked immediately after queuing
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0, "Should be blocked at queue time");
+        assertEq(_tokenized().maxRedeem(charlie), 0, "Should be blocked at queue time");
 
         // Test 2: Should be blocked during timelock period (1 second before expiry)
         vm.warp(queueTime + 999);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0, "Should be blocked 1 second before expiry");
+        assertEq(_tokenized().maxRedeem(charlie), 0, "Should be blocked 1 second before expiry");
 
         // Test 3: Should be allowed at timelock expiry
         vm.warp(queueTime + 1000);
-        assertGt(_tokenized(address(mechanism)).maxRedeem(charlie), 0, "Should be allowed at timelock expiry");
+        assertGt(_tokenized().maxRedeem(charlie), 0, "Should be allowed at timelock expiry");
 
         // Test 4: Should still be allowed after timelock expiry
         vm.warp(queueTime + 1001);
-        assertGt(_tokenized(address(mechanism)).maxRedeem(charlie), 0, "Should be allowed after timelock expiry");
+        assertGt(_tokenized().maxRedeem(charlie), 0, "Should be allowed after timelock expiry");
     }
 
     /// @notice Test that getProposalFunding returns zero for cancelled proposals
     function test_CancelledProposalReturnsZeroFunding() public {
         // Get timeline calculations
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
+        uint256 votingDelay = _tokenized().votingDelay();
         uint256 votingStartTime = deploymentTime + votingDelay;
 
         // Setup user
         vm.startPrank(alice);
         token.approve(address(mechanism), 1000 ether);
-        _tokenized(address(mechanism)).signup(1000 ether);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Test cancelled funding");
+        _tokenized().signup(1000 ether);
+        uint256 pid = _tokenized().propose(charlie, "Test cancelled funding");
         vm.stopPrank();
 
         // Vote on proposal during active period
         vm.warp(votingStartTime + 1);
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 20, charlie); // Cost: 20^2 = 400
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 20, charlie); // Cost: 20^2 = 400
 
         // Verify proposal has non-zero funding before cancellation
-        (uint256 sumContributions, uint256 sumSquareRoots, uint256 quadraticFunding, uint256 linearFunding) = mechanism
-            .getProposalFunding(pid);
+        (uint256 sumContributions, uint256 sumSquareRoots, uint256 quadraticFunding, uint256 linearFunding) =
+            mechanism.getProposalFunding(pid);
         assertTrue(sumContributions > 0, "Should have contributions before cancellation");
         assertTrue(sumSquareRoots > 0, "Should have square roots before cancellation");
         assertTrue(quadraticFunding > 0, "Should have quadratic funding before cancellation");
 
         // Cancel the proposal (alice is proposer and keeper)
         vm.prank(alice);
-        _tokenized(address(mechanism)).cancelProposal(pid);
+        _tokenized().cancelProposal(pid);
 
         // Verify proposal is cancelled
-        assertEq(
-            uint(_tokenized(address(mechanism)).state(pid)),
-            uint(TokenizedAllocationMechanism.ProposalState.Canceled)
-        );
+        assertEq(uint256(_tokenized().state(pid)), uint256(TokenizedAllocationMechanism.ProposalState.Canceled));
 
         // Verify getProposalFunding returns all zeros for cancelled proposal
         (sumContributions, sumSquareRoots, quadraticFunding, linearFunding) = mechanism.getProposalFunding(pid);
@@ -167,60 +126,56 @@ contract QuadraticVotingSimpleTimelockTest is Test {
     function test_PreviewRedeemRedemptionPeriod() public {
         // Get timeline calculations
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup user
         vm.startPrank(alice);
         token.approve(address(mechanism), 1000 ether);
-        _tokenized(address(mechanism)).signup(1000 ether);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Test previewRedeem");
+        _tokenized().signup(1000 ether);
+        uint256 pid = _tokenized().propose(charlie, "Test previewRedeem");
         vm.stopPrank();
 
         uint256 testShares = 100 ether;
 
         // Phase 1: Before finalization - should return 0 (no redemption period set)
-        assertEq(_tokenized(address(mechanism)).previewRedeem(testShares), 0, "Should return 0 before finalization");
+        assertEq(_tokenized().previewRedeem(testShares), 0, "Should return 0 before finalization");
 
         // Vote and finalize
         vm.warp(votingStartTime + 1);
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // High vote to meet quorum
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // High vote to meet quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue the proposal to set redemption period
-        _tokenized(address(mechanism)).queueProposal(pid);
+        _tokenized().queueProposal(pid);
 
-        uint256 globalRedemptionStart = _tokenized(address(mechanism)).globalRedemptionStart();
-        uint256 gracePeriod = _tokenized(address(mechanism)).gracePeriod();
+        uint256 globalRedemptionStart = _tokenized().globalRedemptionStart();
+        uint256 gracePeriod = _tokenized().gracePeriod();
         uint256 globalRedemptionEnd = globalRedemptionStart + gracePeriod;
 
         // Phase 2: Before redemption period starts - should return 0
         vm.warp(globalRedemptionStart - 1);
-        assertEq(
-            _tokenized(address(mechanism)).previewRedeem(testShares),
-            0,
-            "Should return 0 before redemption starts"
-        );
+        assertEq(_tokenized().previewRedeem(testShares), 0, "Should return 0 before redemption starts");
 
         // Phase 3: During redemption period - should return non-zero
         vm.warp(globalRedemptionStart + 1);
-        uint256 previewDuringPeriod = _tokenized(address(mechanism)).previewRedeem(testShares);
+        uint256 previewDuringPeriod = _tokenized().previewRedeem(testShares);
         assertTrue(previewDuringPeriod > 0, "Should return non-zero during redemption period");
 
         // Phase 4: At end of redemption period - should still return non-zero
         vm.warp(globalRedemptionEnd);
-        uint256 previewAtEnd = _tokenized(address(mechanism)).previewRedeem(testShares);
+        uint256 previewAtEnd = _tokenized().previewRedeem(testShares);
         assertTrue(previewAtEnd > 0, "Should return non-zero at end of redemption period");
         assertEq(previewAtEnd, previewDuringPeriod, "Should be consistent during redemption period");
 
         // Phase 5: After redemption period ends - should return 0
         vm.warp(globalRedemptionEnd + 1);
-        assertEq(_tokenized(address(mechanism)).previewRedeem(testShares), 0, "Should return 0 after redemption ends");
+        assertEq(_tokenized().previewRedeem(testShares), 0, "Should return 0 after redemption ends");
     }
 }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingTimelockDebugTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingTimelockDebugTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 contract QuadraticVotingTimelockDebugTest is QuadraticVotingTestBase {
     function setUp() public {
@@ -27,7 +27,7 @@ contract QuadraticVotingTimelockDebugTest is QuadraticVotingTestBase {
         _vote(alice, pid, 31, charlie); // 31^2 = 961 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         console.log("Before queuing:");
@@ -36,7 +36,7 @@ contract QuadraticVotingTimelockDebugTest is QuadraticVotingTestBase {
         console.log("  Block timestamp:", block.timestamp);
 
         uint256 queueTime = block.timestamp;
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         console.log("After queuing:");

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingTimelockDebugTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingTimelockDebugTest.t.sol
@@ -1,97 +1,58 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
-contract QuadraticVotingTimelockDebugTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1);
-    address charlie = address(0x3);
-
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
+contract QuadraticVotingTimelockDebugTest is QuadraticVotingTestBase {
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting("Debug Test", "DEBUG", 100, 1000, 500, 1 days, 7 days, 50, 100);
         token.mint(alice, 2000 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Debug Test",
-            symbol: "DEBUG",
-            votingDelay: 100,
-            votingPeriod: 1000,
-            quorumShares: 500,
-            timelockDelay: 1 days,
-            gracePeriod: 7 days,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-
-        // Set alice as keeper so she can create proposals
-        _tokenized(address(mechanism)).setKeeper(alice);
+        _tokenized().setKeeper(alice);
     }
 
     function testTimelockDebug() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup
-        vm.startPrank(alice);
-        token.approve(address(mechanism), 1000 ether);
-        _tokenized(address(mechanism)).signup(1000 ether);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Test");
-        vm.stopPrank();
+        _signup(alice, 1000 ether);
+        uint256 pid = _propose(alice, charlie, "Test");
 
         vm.warp(votingStartTime + 1);
-        vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 31, charlie); // 31^2 = 961 > 500 quorum
+        _vote(alice, pid, 31, charlie); // 31^2 = 961 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         console.log("Before queuing:");
-        console.log("  Charlie balance:", _tokenized(address(mechanism)).balanceOf(charlie));
-        console.log("  Charlie redeemableAfter:", _tokenized(address(mechanism)).globalRedemptionStart());
+        console.log("  Charlie balance:", _tokenized().balanceOf(charlie));
+        console.log("  Charlie redeemableAfter:", _tokenized().globalRedemptionStart());
         console.log("  Block timestamp:", block.timestamp);
 
         uint256 queueTime = block.timestamp;
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         console.log("After queuing:");
-        console.log("  Charlie balance:", _tokenized(address(mechanism)).balanceOf(charlie));
-        console.log("  Charlie redeemableAfter:", _tokenized(address(mechanism)).globalRedemptionStart());
+        console.log("  Charlie balance:", _tokenized().balanceOf(charlie));
+        console.log("  Charlie redeemableAfter:", _tokenized().globalRedemptionStart());
         console.log("  Expected redeemableAfter:", queueTime + 1 days);
-        console.log("  Timelock delay:", _tokenized(address(mechanism)).timelockDelay());
-        console.log("  Grace period:", _tokenized(address(mechanism)).gracePeriod());
+        console.log("  Timelock delay:", _tokenized().timelockDelay());
+        console.log("  Grace period:", _tokenized().gracePeriod());
 
         // Check maxRedeem
-        uint256 maxRedeemNow = _tokenized(address(mechanism)).maxRedeem(charlie);
+        uint256 maxRedeemNow = _tokenized().maxRedeem(charlie);
         console.log("  Max redeem (during timelock):", maxRedeemNow);
 
         // Fast forward to timelock expiry
         vm.warp(queueTime + 1 days);
-        uint256 maxRedeemAfter = _tokenized(address(mechanism)).maxRedeem(charlie);
+        uint256 maxRedeemAfter = _tokenized().maxRedeem(charlie);
         console.log("After timelock expiry:");
         console.log("  Max redeem (after timelock):", maxRedeemAfter);
         console.log("  Current timestamp:", block.timestamp);

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingTimelockEnforcementTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingTimelockEnforcementTest.t.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Timelock Enforcement Test
 /// @notice Tests timelock and grace period enforcement through availableWithdrawLimit hook
@@ -63,11 +63,11 @@ contract QuadraticVotingTimelockEnforcementTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         uint256 queueTime = block.timestamp;
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         // Verify shares minted - QuadraticVoting: vote weight 30 produces 900 funding
@@ -128,11 +128,11 @@ contract QuadraticVotingTimelockEnforcementTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         uint256 queueTime = block.timestamp;
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         uint256 charlieShares = 900; // Vote weight 30 produces 900 shares
@@ -198,11 +198,11 @@ contract QuadraticVotingTimelockEnforcementTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         uint256 queueTime = block.timestamp;
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         uint256 charlieShares = 900; // Vote weight 30 produces 900 shares
@@ -275,16 +275,16 @@ contract QuadraticVotingTimelockEnforcementTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 30, bob); // 30^2 = 900 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue first proposal
-        (bool success1,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
+        (bool success1, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
         require(success1, "Queue 1 failed");
 
         // Wait some time then queue second proposal
         vm.warp(block.timestamp + 2 hours);
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
         require(success2, "Queue 2 failed");
 
         // Test different timelock schedules
@@ -356,10 +356,10 @@ contract QuadraticVotingTimelockEnforcementTest is QuadraticVotingTestBase {
         _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
-        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         uint256 redeemableTime = _tokenized().globalRedemptionStart();

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingTimelockEnforcementTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingTimelockEnforcementTest.t.sol
@@ -1,26 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Timelock Enforcement Test
 /// @notice Tests timelock and grace period enforcement through availableWithdrawLimit hook
-contract QuadraticVotingTimelockEnforcementTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1);
-    address bob = address(0x2);
-    address charlie = address(0x3);
-
+contract QuadraticVotingTimelockEnforcementTest is QuadraticVotingTestBase {
     uint256 constant LARGE_DEPOSIT = 1000 ether;
     uint256 constant QUORUM_REQUIREMENT = 500; // Adjusted for quadratic funding
     uint256 constant VOTING_DELAY = 100;
@@ -28,33 +15,22 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
     uint256 constant TIMELOCK_DELAY = 1 days;
     uint256 constant GRACE_PERIOD = 7 days;
 
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting(
+            "Timelock Enforcement Test",
+            "TLTEST",
+            VOTING_DELAY,
+            VOTING_PERIOD,
+            QUORUM_REQUIREMENT,
+            TIMELOCK_DELAY,
+            GRACE_PERIOD,
+            50,
+            100
+        );
 
         token.mint(alice, 2000 ether);
         token.mint(bob, 1500 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Timelock Enforcement Test",
-            symbol: "TLTEST",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_REQUIREMENT,
-            timelockDelay: TIMELOCK_DELAY,
-            gracePeriod: GRACE_PERIOD,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-        _tokenized(address(mechanism)).setKeeper(alice);
-        _tokenized(address(mechanism)).setManagement(bob);
+        _setRoles(alice, bob);
 
         // Pre-fund matching pool - this will be included in total assets during finalize
         uint256 matchingPoolAmount = 2000 ether;
@@ -69,62 +45,62 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
 
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod; // Start at timestamp 100000 to avoid edge cases
 
         // Setup successful proposal
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Charlie's Project");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(charlie, "Charlie's Project");
         vm.stopPrank();
 
         vm.warp(votingStartTime + 1);
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         uint256 queueTime = block.timestamp;
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         // Verify shares minted - QuadraticVoting: vote weight 30 produces 900 funding
         uint256 charlieShares = 900; // 30^2 = 900 with α=0.5 → 0.5×900 + 0.5×900 = 900
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), charlieShares);
+        assertEq(_tokenized().balanceOf(charlie), charlieShares);
 
         // Test 1: Immediately after queuing - should be blocked by timelock
         console.log("Current timestamp:", block.timestamp);
-        console.log("Charlie redeemableAfter:", _tokenized(address(mechanism)).globalRedemptionStart());
-        console.log("Time difference:", _tokenized(address(mechanism)).globalRedemptionStart() - block.timestamp);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0);
+        console.log("Charlie redeemableAfter:", _tokenized().globalRedemptionStart());
+        console.log("Time difference:", _tokenized().globalRedemptionStart() - block.timestamp);
+        assertEq(_tokenized().maxRedeem(charlie), 0);
 
         vm.expectRevert("Allocation: redeem more than max");
         vm.prank(charlie);
-        _tokenized(address(mechanism)).redeem(charlieShares, charlie, charlie);
+        _tokenized().redeem(charlieShares, charlie, charlie);
 
         // Test 2: Halfway through timelock - still blocked
         vm.warp(queueTime + TIMELOCK_DELAY / 2);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0);
+        assertEq(_tokenized().maxRedeem(charlie), 0);
 
         vm.expectRevert("Allocation: redeem more than max");
         vm.prank(charlie);
-        _tokenized(address(mechanism)).redeem(charlieShares, charlie, charlie);
+        _tokenized().redeem(charlieShares, charlie, charlie);
 
         // Test 3: One second before timelock expires - still blocked
         // Need to check what the actual redeemableAfter time is
-        uint256 redeemableTime = _tokenized(address(mechanism)).globalRedemptionStart();
+        uint256 redeemableTime = _tokenized().globalRedemptionStart();
         vm.warp(redeemableTime - 1);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0);
+        assertEq(_tokenized().maxRedeem(charlie), 0);
 
         vm.expectRevert("Allocation: redeem more than max");
         vm.prank(charlie);
-        _tokenized(address(mechanism)).redeem(charlieShares, charlie, charlie);
+        _tokenized().redeem(charlieShares, charlie, charlie);
     }
 
     /// @notice Test successful redemption in valid timelock window
@@ -134,29 +110,29 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
 
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod; // Different timestamp to avoid interference
 
         // Setup successful proposal
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Charlie's Project");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(charlie, "Charlie's Project");
         vm.stopPrank();
 
         vm.warp(votingStartTime + 1);
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         uint256 queueTime = block.timestamp;
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         uint256 charlieShares = 900; // Vote weight 30 produces 900 shares
@@ -164,37 +140,37 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
 
         // Test 1: Exactly when timelock expires - should work
         vm.warp(queueTime + TIMELOCK_DELAY);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), charlieShares);
+        assertEq(_tokenized().maxRedeem(charlie), charlieShares);
 
         vm.prank(charlie);
-        uint256 assetsReceived1 = _tokenized(address(mechanism)).redeem(300, charlie, charlie);
+        uint256 assetsReceived1 = _tokenized().redeem(300, charlie, charlie);
 
         // With matching pool: total assets = 1000 (alice) + 2000 (matching pool) = 3000 ether
         // 300 shares out of 900 total = (300/900) × 3000 = 1000 ether
         uint256 expectedAssets1 = 1000 ether;
         assertEq(assetsReceived1, expectedAssets1);
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), 600); // 900 - 300 = 600
+        assertEq(_tokenized().balanceOf(charlie), 600); // 900 - 300 = 600
 
         // Test 2: Middle of valid window - should work
         vm.warp(queueTime + TIMELOCK_DELAY + GRACE_PERIOD / 2);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 600); // 900 - 300 = 600
+        assertEq(_tokenized().maxRedeem(charlie), 600); // 900 - 300 = 600
 
         vm.prank(charlie);
-        uint256 assetsReceived2 = _tokenized(address(mechanism)).redeem(300, charlie, charlie);
+        uint256 assetsReceived2 = _tokenized().redeem(300, charlie, charlie);
         uint256 expectedAssets2 = 1000 ether; // Same ratio: (300/900) × 3000 = 1000 ether
         assertEq(assetsReceived2, expectedAssets2);
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), 300);
+        assertEq(_tokenized().balanceOf(charlie), 300);
 
         // Test 3: One second before grace period expires - should work
-        uint256 redeemableTime = _tokenized(address(mechanism)).globalRedemptionStart();
+        uint256 redeemableTime = _tokenized().globalRedemptionStart();
         vm.warp(redeemableTime + GRACE_PERIOD - 1);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 300);
+        assertEq(_tokenized().maxRedeem(charlie), 300);
 
         vm.prank(charlie);
-        uint256 assetsReceived3 = _tokenized(address(mechanism)).redeem(300, charlie, charlie);
+        uint256 assetsReceived3 = _tokenized().redeem(300, charlie, charlie);
         uint256 expectedAssets3 = 1000 ether; // Same ratio: (300/900) × 3000 = 1000 ether
         assertEq(assetsReceived3, expectedAssets3);
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), 0);
+        assertEq(_tokenized().balanceOf(charlie), 0);
 
         // Verify total redemption: 3 × 1000 ether = 3000 ether (all assets)
         assertEq(assetsReceived1 + assetsReceived2 + assetsReceived3, 3000 ether);
@@ -204,29 +180,29 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
     function testTimelockEnforcement_GracePeriodExpiration() public {
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup successful proposal
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Charlie's Expired Project");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(charlie, "Charlie's Expired Project");
         vm.stopPrank();
 
         vm.warp(votingStartTime + 1);
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         uint256 queueTime = block.timestamp;
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
         uint256 charlieShares = 900; // Vote weight 30 produces 900 shares
@@ -235,28 +211,28 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
         vm.warp(queueTime + TIMELOCK_DELAY + GRACE_PERIOD + 1);
 
         // Test 1: maxRedeem should return 0 after grace period
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0);
+        assertEq(_tokenized().maxRedeem(charlie), 0);
 
         // Test 2: Redemption should fail
         vm.expectRevert("Allocation: redeem more than max");
         vm.prank(charlie);
-        _tokenized(address(mechanism)).redeem(charlieShares, charlie, charlie);
+        _tokenized().redeem(charlieShares, charlie, charlie);
 
         // Test 3: Even partial redemption should fail
         vm.expectRevert("Allocation: redeem more than max");
         vm.prank(charlie);
-        _tokenized(address(mechanism)).redeem(1 ether, charlie, charlie);
+        _tokenized().redeem(1 ether, charlie, charlie);
 
         // Test 4: Shares still exist but are inaccessible
-        assertEq(_tokenized(address(mechanism)).balanceOf(charlie), charlieShares);
+        assertEq(_tokenized().balanceOf(charlie), charlieShares);
 
         // Test 5: Way past grace period - still blocked
         vm.warp(queueTime + TIMELOCK_DELAY + GRACE_PERIOD + 365 days);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0);
+        assertEq(_tokenized().maxRedeem(charlie), 0);
 
         vm.expectRevert("Allocation: redeem more than max");
         vm.prank(charlie);
-        _tokenized(address(mechanism)).redeem(charlieShares, charlie, charlie);
+        _tokenized().redeem(charlieShares, charlie, charlie);
     }
 
     /// @notice Test multiple recipients with different timelock schedules
@@ -266,67 +242,67 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
 
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod; // Different timestamp to avoid interference
 
         // Setup multiple voters and recipients
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
+        _tokenized().signup(LARGE_DEPOSIT);
         vm.stopPrank();
 
         vm.startPrank(bob);
         token.approve(address(mechanism), 500 ether);
-        _tokenized(address(mechanism)).signup(500 ether);
+        _tokenized().signup(500 ether);
         vm.stopPrank();
 
         // Create proposals
         vm.prank(alice);
-        uint256 pid1 = _tokenized(address(mechanism)).propose(charlie, "Charlie's Early Project");
+        uint256 pid1 = _tokenized().propose(charlie, "Charlie's Early Project");
 
         vm.prank(bob);
-        uint256 pid2 = _tokenized(address(mechanism)).propose(bob, "Bob's Later Project");
+        uint256 pid2 = _tokenized().propose(bob, "Bob's Later Project");
 
         vm.warp(votingStartTime + 1);
 
         // Vote for both
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
+        _tokenized().castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 30, bob); // 30^2 = 900 > 500 quorum
+        _tokenized().castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 30, bob); // 30^2 = 900 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
         // Queue first proposal
-        (bool success1, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
+        (bool success1,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid1));
         require(success1, "Queue 1 failed");
 
         // Wait some time then queue second proposal
         vm.warp(block.timestamp + 2 hours);
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid2));
         require(success2, "Queue 2 failed");
 
         // Test different timelock schedules
 
         // At charlie's timelock expiry - charlie can redeem, bob cannot
-        uint256 charlieRedeemableTime = _tokenized(address(mechanism)).globalRedemptionStart();
-        uint256 bobRedeemableTime = _tokenized(address(mechanism)).globalRedemptionStart();
+        uint256 charlieRedeemableTime = _tokenized().globalRedemptionStart();
+        uint256 bobRedeemableTime = _tokenized().globalRedemptionStart();
         vm.warp(charlieRedeemableTime);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 900);
+        assertEq(_tokenized().maxRedeem(charlie), 900);
         // Bob's timelock should still be active since he was queued later
         if (charlieRedeemableTime < bobRedeemableTime) {
-            assertEq(_tokenized(address(mechanism)).maxRedeem(bob), 0);
+            assertEq(_tokenized().maxRedeem(bob), 0);
         } else {
-            assertEq(_tokenized(address(mechanism)).maxRedeem(bob), 900);
+            assertEq(_tokenized().maxRedeem(bob), 900);
         }
 
         vm.prank(charlie);
-        uint256 charlieAssets = _tokenized(address(mechanism)).redeem(900, charlie, charlie);
+        uint256 charlieAssets = _tokenized().redeem(900, charlie, charlie);
 
         // With matching pool: total assets = 1500 (alice + bob) + 2000 (matching pool) = 3500 ether
         // Each recipient gets 900 shares, total shares = 1800
@@ -338,15 +314,15 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
         if (charlieRedeemableTime < bobRedeemableTime) {
             vm.expectRevert("Allocation: redeem more than max");
             vm.prank(bob);
-            _tokenized(address(mechanism)).redeem(900, bob, bob);
+            _tokenized().redeem(900, bob, bob);
         }
 
         // At bob's timelock expiry - bob can now redeem
         vm.warp(bobRedeemableTime);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(bob), 900);
+        assertEq(_tokenized().maxRedeem(bob), 900);
 
         vm.prank(bob);
-        uint256 bobAssets = _tokenized(address(mechanism)).redeem(900, bob, bob);
+        uint256 bobAssets = _tokenized().redeem(900, bob, bob);
         assertEq(bobAssets, expectedAssetsPerRecipient);
 
         // Verify independent schedules worked correctly
@@ -362,57 +338,57 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
 
         // Get absolute timeline from contract
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
         // Setup successful proposal for charlie
         vm.startPrank(alice);
         token.approve(address(mechanism), LARGE_DEPOSIT);
-        _tokenized(address(mechanism)).signup(LARGE_DEPOSIT);
-        uint256 pid = _tokenized(address(mechanism)).propose(charlie, "Charlie's Edge Case Project");
+        _tokenized().signup(LARGE_DEPOSIT);
+        uint256 pid = _tokenized().propose(charlie, "Charlie's Edge Case Project");
         vm.stopPrank();
 
         vm.warp(votingStartTime + 1);
 
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 30, charlie); // 30^2 = 900 > 500 quorum
 
         vm.warp(votingEndTime + 1);
-        (bool success, ) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
+        (bool success,) = address(mechanism).call(abi.encodeWithSignature("finalizeVoteTally()"));
         require(success, "Finalization failed");
 
-        (bool success2, ) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
+        (bool success2,) = address(mechanism).call(abi.encodeWithSignature("queueProposal(uint256)", pid));
         require(success2, "Queue failed");
 
-        uint256 redeemableTime = _tokenized(address(mechanism)).globalRedemptionStart();
+        uint256 redeemableTime = _tokenized().globalRedemptionStart();
 
         // Test 1: Inclusive window boundaries [start, start + gracePeriod]
         // Exactly at redemption start - full balance redeemable
         vm.warp(redeemableTime);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 900);
+        assertEq(_tokenized().maxRedeem(charlie), 900);
 
         // Exactly at grace period expiry - still redeemable (window end is inclusive)
         vm.warp(redeemableTime + GRACE_PERIOD);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 900);
+        assertEq(_tokenized().maxRedeem(charlie), 900);
 
         // One second past grace period expiry - no longer redeemable
         vm.warp(redeemableTime + GRACE_PERIOD + 1);
-        assertEq(_tokenized(address(mechanism)).maxRedeem(charlie), 0);
+        assertEq(_tokenized().maxRedeem(charlie), 0);
 
         // Test 2: Transfer shares and check the new owner can redeem within the window
         vm.warp(redeemableTime + GRACE_PERIOD / 2); // Valid window
 
         address newOwner = address(0x999);
         vm.prank(charlie);
-        _tokenized(address(mechanism)).transfer(newOwner, 300);
+        _tokenized().transfer(newOwner, 300);
 
         // Redemption is gated by the global window, so the new owner can redeem their balance
-        assertEq(_tokenized(address(mechanism)).maxRedeem(newOwner), 300);
+        assertEq(_tokenized().maxRedeem(newOwner), 300);
 
         vm.prank(newOwner);
-        uint256 newOwnerAssets = _tokenized(address(mechanism)).redeem(300, newOwner, newOwner);
+        uint256 newOwnerAssets = _tokenized().redeem(300, newOwner, newOwner);
 
         // total assets = 1000 (alice) + 2000 (matching pool) = 3000 ether
         // 300 shares out of 900 total = (300/900) × 3000 = 1000 ether
@@ -420,10 +396,10 @@ contract QuadraticVotingTimelockEnforcementTest is Test {
 
         // Test 3: Approved (allowance-based) redemption on behalf of charlie
         vm.prank(charlie);
-        _tokenized(address(mechanism)).approve(newOwner, 300);
+        _tokenized().approve(newOwner, 300);
 
         vm.prank(newOwner);
-        uint256 approvedAssets = _tokenized(address(mechanism)).redeem(300, newOwner, charlie);
+        uint256 approvedAssets = _tokenized().redeem(300, newOwner, charlie);
 
         // 300 shares out of the remaining 600 total = (300/600) × 2000 = 1000 ether
         assertEq(approvedAssets, 1000 ether);

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingVoterJourneyTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingVoterJourneyTest.t.sol
@@ -1,30 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
 import "forge-std/console.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Voter Journey Integration Tests
 /// @notice Comprehensive tests for voter user journey with full branch coverage
-contract QuadraticVotingVoterJourneyTest is Test {
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    address alice = address(0x1);
-    address bob = address(0x2);
-    address charlie = address(0x3);
-    address dave = address(0x4);
-    address frank = address(0x6);
-    address grace = address(0x7);
-    address henry = address(0x8);
-
+contract QuadraticVotingVoterJourneyTest is QuadraticVotingTestBase {
     uint256 constant LARGE_DEPOSIT = 1000 ether;
     uint256 constant MEDIUM_DEPOSIT = 500 ether;
     uint256 constant SMALL_DEPOSIT = 100 ether;
@@ -32,55 +16,10 @@ contract QuadraticVotingVoterJourneyTest is Test {
     uint256 constant VOTING_DELAY = 100;
     uint256 constant VOTING_PERIOD = 1000;
 
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
-    /// @notice Helper function to sign up a user with specified deposit
-    /// @param user Address of user to sign up
-    /// @param depositAmount Amount of tokens to deposit
-    function _signupUser(address user, uint256 depositAmount) internal {
-        vm.startPrank(user);
-        token.approve(address(mechanism), depositAmount);
-        _tokenized(address(mechanism)).signup(depositAmount);
-        vm.stopPrank();
-    }
-
-    /// @notice Helper function to create a proposal
-    /// @param proposer Address creating the proposal
-    /// @param recipient Address that will receive funds if proposal passes
-    /// @param description Description of the proposal
-    /// @return pid The proposal ID
-    function _createProposal(
-        address proposer,
-        address recipient,
-        string memory description
-    ) internal returns (uint256 pid) {
-        vm.prank(proposer);
-        pid = _tokenized(address(mechanism)).propose(recipient, description);
-    }
-
-    /// @notice Helper function to cast a vote on a proposal
-    /// @param voter Address casting the vote
-    /// @param pid Proposal ID to vote on
-    /// @param weight Vote weight (quadratic cost = weight^2)
-    /// @return previousPower Voting power before the vote
-    /// @return newPower Voting power after the vote
-    function _castVote(
-        address voter,
-        uint256 pid,
-        uint256 weight,
-        address recipient
-    ) internal returns (uint256 previousPower, uint256 newPower) {
-        previousPower = _tokenized(address(mechanism)).votingPower(voter);
-        vm.prank(voter);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, weight, recipient);
-        newPower = _tokenized(address(mechanism)).votingPower(voter);
-    }
-
     function setUp() public {
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting(
+            "Voter Journey Test", "VJTEST", VOTING_DELAY, VOTING_PERIOD, QUORUM_REQUIREMENT, 1 days, 7 days, 50, 100
+        );
 
         // Mint tokens to test actors
         token.mint(alice, 2000 ether);
@@ -88,30 +27,14 @@ contract QuadraticVotingVoterJourneyTest is Test {
         token.mint(frank, 200 ether);
         token.mint(grace, 50 ether);
         token.mint(henry, 300 ether);
-
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Voter Journey Test",
-            symbol: "VJTEST",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_REQUIREMENT,
-            timelockDelay: 1 days,
-            gracePeriod: 7 days,
-            owner: address(0)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100); // 50% alpha
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-        _tokenized(address(mechanism)).setKeeper(alice);
-        _tokenized(address(mechanism)).setManagement(bob);
+        _setRoles(alice, bob);
     }
 
     /// @notice Test voter registration with various deposit amounts
     function testVoterRegistration_VariousDeposits() public {
         // Use absolute timeline pattern
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
+        uint256 votingDelay = _tokenized().votingDelay();
         uint256 votingStartTime = deploymentTime + votingDelay;
 
         // Warp to just before voting starts (signup period)
@@ -119,20 +42,20 @@ contract QuadraticVotingVoterJourneyTest is Test {
 
         // Large deposit registration
         _signupUser(alice, LARGE_DEPOSIT);
-        assertEq(_tokenized(address(mechanism)).votingPower(alice), LARGE_DEPOSIT);
+        assertEq(_tokenized().votingPower(alice), LARGE_DEPOSIT);
         assertEq(token.balanceOf(alice), 2000 ether - LARGE_DEPOSIT);
 
         // Medium deposit registration
         _signupUser(bob, MEDIUM_DEPOSIT);
-        assertEq(_tokenized(address(mechanism)).votingPower(bob), MEDIUM_DEPOSIT);
+        assertEq(_tokenized().votingPower(bob), MEDIUM_DEPOSIT);
 
         // Zero deposit registration
         _signupUser(grace, 0);
-        assertEq(_tokenized(address(mechanism)).votingPower(grace), 0);
+        assertEq(_tokenized().votingPower(grace), 0);
 
         // Small deposit registration
         _signupUser(frank, SMALL_DEPOSIT);
-        assertEq(_tokenized(address(mechanism)).votingPower(frank), SMALL_DEPOSIT);
+        assertEq(_tokenized().votingPower(frank), SMALL_DEPOSIT);
 
         // Verify total mechanism balance
         assertEq(token.balanceOf(address(mechanism)), LARGE_DEPOSIT + MEDIUM_DEPOSIT + SMALL_DEPOSIT);
@@ -142,8 +65,8 @@ contract QuadraticVotingVoterJourneyTest is Test {
     function testVoterRegistration_EdgeCases() public {
         // Use absolute timeline pattern
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
@@ -154,14 +77,14 @@ contract QuadraticVotingVoterJourneyTest is Test {
         _signupUser(alice, LARGE_DEPOSIT);
 
         // Can register multiple times in QuadraticVotingMechanism (accumulates voting power)
-        uint256 alicePowerBefore = _tokenized(address(mechanism)).votingPower(alice);
+        uint256 alicePowerBefore = _tokenized().votingPower(alice);
         vm.startPrank(alice);
         token.approve(address(mechanism), SMALL_DEPOSIT);
-        _tokenized(address(mechanism)).signup(SMALL_DEPOSIT);
+        _tokenized().signup(SMALL_DEPOSIT);
         vm.stopPrank();
 
         // Verify voting power accumulated
-        uint256 alicePowerAfter = _tokenized(address(mechanism)).votingPower(alice);
+        uint256 alicePowerAfter = _tokenized().votingPower(alice);
         assertEq(alicePowerAfter, alicePowerBefore + SMALL_DEPOSIT, "Multiple signups should accumulate voting power");
 
         // Cannot register after voting period ends
@@ -169,21 +92,21 @@ contract QuadraticVotingVoterJourneyTest is Test {
         vm.startPrank(henry);
         token.approve(address(mechanism), MEDIUM_DEPOSIT);
         vm.expectRevert();
-        _tokenized(address(mechanism)).signup(MEDIUM_DEPOSIT);
+        _tokenized().signup(MEDIUM_DEPOSIT);
         vm.stopPrank();
 
         // Can register at the last valid moment
         vm.warp(votingEndTime - 1);
         _signupUser(bob, MEDIUM_DEPOSIT);
 
-        assertEq(_tokenized(address(mechanism)).votingPower(bob), MEDIUM_DEPOSIT);
+        assertEq(_tokenized().votingPower(bob), MEDIUM_DEPOSIT);
     }
 
     /// @notice Test comprehensive voting patterns
     function testVotingPatterns_Comprehensive() public {
         // Use absolute timeline pattern
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
+        uint256 votingDelay = _tokenized().votingDelay();
         uint256 votingStartTime = deploymentTime + votingDelay;
 
         // Warp to just before voting starts (signup period)
@@ -211,15 +134,15 @@ contract QuadraticVotingVoterJourneyTest is Test {
 
         // Bob votes with weight 10, cost = 10^2 = 100 voting power
         _castVote(bob, pid1, 10, charlie);
-        assertEq(_tokenized(address(mechanism)).votingPower(bob), MEDIUM_DEPOSIT - (10 * 10));
+        assertEq(_tokenized().votingPower(bob), MEDIUM_DEPOSIT - (10 * 10));
 
         // Bob votes again with weight 15, cost = 15^2 = 225 voting power
         _castVote(bob, pid2, 15, dave);
-        assertEq(_tokenized(address(mechanism)).votingPower(bob), MEDIUM_DEPOSIT - 100 - 225);
+        assertEq(_tokenized().votingPower(bob), MEDIUM_DEPOSIT - 100 - 225);
 
         // Frank votes with weight 5, cost = 5^2 = 25 voting power
         _castVote(frank, pid2, 5, dave);
-        assertEq(_tokenized(address(mechanism)).votingPower(frank), SMALL_DEPOSIT - 25);
+        assertEq(_tokenized().votingPower(frank), SMALL_DEPOSIT - 25);
 
         // Note: QuadraticVoting uses ProperQF tallying, not simple vote counts
         // The actual funding calculation will be done during shares conversion
@@ -229,8 +152,8 @@ contract QuadraticVotingVoterJourneyTest is Test {
     function testVoting_ErrorConditions() public {
         // Use absolute timeline pattern
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingPeriod = _tokenized(address(mechanism)).votingPeriod();
+        uint256 votingDelay = _tokenized().votingDelay();
+        uint256 votingPeriod = _tokenized().votingPeriod();
         uint256 votingStartTime = deploymentTime + votingDelay;
         uint256 votingEndTime = votingStartTime + votingPeriod;
 
@@ -244,7 +167,7 @@ contract QuadraticVotingVoterJourneyTest is Test {
         vm.warp(votingStartTime - 50);
         vm.expectRevert();
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, charlie);
 
         // Warp to voting period
         vm.warp(votingStartTime + 1);
@@ -252,38 +175,33 @@ contract QuadraticVotingVoterJourneyTest is Test {
         // Cannot vote with more power than available
         vm.expectRevert();
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(
-            pid,
-            TokenizedAllocationMechanism.VoteType.For,
-            LARGE_DEPOSIT + 1,
-            charlie
-        );
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, LARGE_DEPOSIT + 1, charlie);
 
         // Cannot vote twice
         _castVote(alice, pid, 8, charlie);
 
         vm.expectRevert(abi.encodeWithSelector(QuadraticVotingMechanism.AlreadyVoted.selector, alice, pid));
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, charlie);
 
         // Cannot vote after voting period
         vm.warp(votingEndTime + 1);
         vm.expectRevert();
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 8, charlie);
 
         // Unregistered user cannot vote
         vm.warp(votingStartTime + 500);
         vm.expectRevert();
         vm.prank(henry);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 1, charlie);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 1, charlie);
     }
 
     /// @notice Test voter power conservation and management
     function testVoterPower_ConservationAndManagement() public {
         // Use absolute timeline pattern
         uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
+        uint256 votingDelay = _tokenized().votingDelay();
         uint256 votingStartTime = deploymentTime + votingDelay;
 
         // Warp to just before voting starts (signup period)
@@ -298,7 +216,7 @@ contract QuadraticVotingVoterJourneyTest is Test {
         vm.warp(votingStartTime + 1);
 
         // Track power consumption across multiple votes
-        uint256 initialPower = _tokenized(address(mechanism)).votingPower(alice);
+        uint256 initialPower = _tokenized().votingPower(alice);
         assertEq(initialPower, LARGE_DEPOSIT);
 
         // First vote - quadratic cost: 10^2 = 100
@@ -312,13 +230,13 @@ contract QuadraticVotingVoterJourneyTest is Test {
         uint256 vote2Weight = 10; // Quadratic cost: 10^2 = 100
         _castVote(alice, pid2, vote2Weight, dave);
 
-        uint256 powerAfterVote2 = _tokenized(address(mechanism)).votingPower(alice);
+        uint256 powerAfterVote2 = _tokenized().votingPower(alice);
         assertEq(powerAfterVote2, initialPower - (vote1Weight * vote1Weight) - (vote2Weight * vote2Weight));
         assertEq(powerAfterVote2, 1000 ether - (10 * 10) - (10 * 10)); // 1000 ether - 200 voting power units
 
         // Verify vote records
         assertTrue(mechanism.hasVoted(pid1, alice));
         assertTrue(mechanism.hasVoted(pid2, alice));
-        assertEq(_tokenized(address(mechanism)).votingPower(alice), 1000 ether - 200);
+        assertEq(_tokenized().votingPower(alice), 1000 ether - 200);
     }
 }

--- a/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingVoterJourneyTest.t.sol
+++ b/test/unit/mechanisms/allocation/QuadraticVotingMechanism/QuadraticVotingVoterJourneyTest.t.sol
@@ -2,9 +2,9 @@
 pragma solidity ^0.8.20;
 
 import "forge-std/console.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import {QuadraticVotingTestBase} from "../utils/QuadraticVotingTestBase.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import { QuadraticVotingTestBase } from "../utils/QuadraticVotingTestBase.sol";
 
 /// @title Voter Journey Integration Tests
 /// @notice Comprehensive tests for voter user journey with full branch coverage
@@ -18,7 +18,15 @@ contract QuadraticVotingVoterJourneyTest is QuadraticVotingTestBase {
 
     function setUp() public {
         _setUpQuadraticVoting(
-            "Voter Journey Test", "VJTEST", VOTING_DELAY, VOTING_PERIOD, QUORUM_REQUIREMENT, 1 days, 7 days, 50, 100
+            "Voter Journey Test",
+            "VJTEST",
+            VOTING_DELAY,
+            VOTING_PERIOD,
+            QUORUM_REQUIREMENT,
+            1 days,
+            7 days,
+            50,
+            100
         );
 
         // Mint tokens to test actors

--- a/test/unit/mechanisms/allocation/RecipientVerificationTest.t.sol
+++ b/test/unit/mechanisms/allocation/RecipientVerificationTest.t.sol
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import {QuadraticVotingTestBase} from "./utils/QuadraticVotingTestBase.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import { QuadraticVotingTestBase } from "./utils/QuadraticVotingTestBase.sol";
 
 /// @title Recipient Verification Tests
 /// @notice Tests for recipient verification functionality that prevents reorganization attacks
@@ -23,7 +23,15 @@ contract RecipientVerificationTest is QuadraticVotingTestBase {
 
     function setUp() public {
         _setUpQuadraticVoting(
-            "Recipient Verification Test", "RVTEST", VOTING_DELAY, VOTING_PERIOD, QUORUM_SHARES, 1 days, 7 days, 50, 100
+            "Recipient Verification Test",
+            "RVTEST",
+            VOTING_DELAY,
+            VOTING_PERIOD,
+            QUORUM_SHARES,
+            1 days,
+            7 days,
+            50,
+            100
         );
 
         // Fund test accounts
@@ -51,13 +59,12 @@ contract RecipientVerificationTest is QuadraticVotingTestBase {
             )
         );
         vm.prank(alice);
-        _tokenized()
-            .castVote(
-                pid,
-                TokenizedAllocationMechanism.VoteType.For,
-                10, // Small weight to minimize cost
-                recipientB // Wrong recipient - should cause mismatch
-            );
+        _tokenized().castVote(
+            pid,
+            TokenizedAllocationMechanism.VoteType.For,
+            10, // Small weight to minimize cost
+            recipientB // Wrong recipient - should cause mismatch
+        );
     }
 
     /// @notice Test valid recipient - voting with correct expected recipient should succeed
@@ -71,17 +78,20 @@ contract RecipientVerificationTest is QuadraticVotingTestBase {
 
         // Vote with correct expected recipient - should succeed
         vm.prank(alice);
-        _tokenized()
-            .castVote(
-                pid,
-                TokenizedAllocationMechanism.VoteType.For,
-                10, // weight=10, cost=100 (quadratic)
-                recipientA // Correct recipient - should succeed
-            );
+        _tokenized().castVote(
+            pid,
+            TokenizedAllocationMechanism.VoteType.For,
+            10, // weight=10, cost=100 (quadratic)
+            recipientA // Correct recipient - should succeed
+        );
 
         // Verify vote was recorded successfully
         uint256 alicePowerAfter = _tokenized().votingPower(alice);
-        assertEq(alicePowerBefore - alicePowerAfter, 100, "Voting power should be reduced by quadratic cost (10^2=100)");
+        assertEq(
+            alicePowerBefore - alicePowerAfter,
+            100,
+            "Voting power should be reduced by quadratic cost (10^2=100)"
+        );
     }
 
     /// @notice Test multiple proposals with different recipients
@@ -134,7 +144,10 @@ contract RecipientVerificationTest is QuadraticVotingTestBase {
         // Try to vote on pid1 expecting recipientB (from pid2) - should fail
         vm.expectRevert(
             abi.encodeWithSelector(
-                TokenizedAllocationMechanism.RecipientMismatch.selector, pid1, recipientB, recipientA
+                TokenizedAllocationMechanism.RecipientMismatch.selector,
+                pid1,
+                recipientB,
+                recipientA
             )
         );
         vm.prank(alice);
@@ -143,7 +156,10 @@ contract RecipientVerificationTest is QuadraticVotingTestBase {
         // Try to vote on pid2 expecting recipientC (from pid3) - should fail
         vm.expectRevert(
             abi.encodeWithSelector(
-                TokenizedAllocationMechanism.RecipientMismatch.selector, pid2, recipientC, recipientB
+                TokenizedAllocationMechanism.RecipientMismatch.selector,
+                pid2,
+                recipientC,
+                recipientB
             )
         );
         vm.prank(bob);
@@ -251,7 +267,10 @@ contract RecipientVerificationTest is QuadraticVotingTestBase {
         // Test failed vote with wrong recipient - use different user to avoid "already voted" error
         vm.expectRevert(
             abi.encodeWithSelector(
-                TokenizedAllocationMechanism.RecipientMismatch.selector, pid1, recipientB, recipientA
+                TokenizedAllocationMechanism.RecipientMismatch.selector,
+                pid1,
+                recipientB,
+                recipientA
             )
         );
         vm.prank(bob); // Bob hasn't voted on pid1 yet, so this tests recipient mismatch specifically
@@ -286,7 +305,10 @@ contract RecipientVerificationTest is QuadraticVotingTestBase {
         // This should FAIL due to recipient verification
         vm.expectRevert(
             abi.encodeWithSelector(
-                TokenizedAllocationMechanism.RecipientMismatch.selector, pid2, recipientA, recipientB
+                TokenizedAllocationMechanism.RecipientMismatch.selector,
+                pid2,
+                recipientA,
+                recipientB
             )
         );
         vm.prank(bob); // Bob tries to vote expecting recipientA but proposal is for recipientB

--- a/test/unit/mechanisms/allocation/RecipientVerificationTest.t.sol
+++ b/test/unit/mechanisms/allocation/RecipientVerificationTest.t.sol
@@ -1,28 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import "forge-std/Test.sol";
-import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
-import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
-import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import {QuadraticVotingTestBase} from "./utils/QuadraticVotingTestBase.sol";
 
 /// @title Recipient Verification Tests
 /// @notice Tests for recipient verification functionality that prevents reorganization attacks
 /// @dev Tests the core security feature that validates expected recipients match proposal recipients
-contract RecipientVerificationTest is Test {
-    // Test contracts
-    AllocationMechanismFactory factory;
-    ERC20Mock token;
-    QuadraticVotingMechanism mechanism;
-
-    // Test actors
-    address alice = address(0x1);
-    address bob = address(0x2);
-    address charlie = address(0x3);
-
+contract RecipientVerificationTest is QuadraticVotingTestBase {
     // Recipients for proposals
     address recipientA = address(0x100);
     address recipientB = address(0x200);
@@ -36,56 +22,14 @@ contract RecipientVerificationTest is Test {
     uint256 constant QUORUM_SHARES = 100 ether;
 
     function setUp() public {
-        // Deploy infrastructure
-        factory = new AllocationMechanismFactory();
-        token = new ERC20Mock();
+        _setUpQuadraticVoting(
+            "Recipient Verification Test", "RVTEST", VOTING_DELAY, VOTING_PERIOD, QUORUM_SHARES, 1 days, 7 days, 50, 100
+        );
 
         // Fund test accounts
         token.mint(alice, INITIAL_BALANCE);
         token.mint(bob, INITIAL_BALANCE);
         token.mint(charlie, INITIAL_BALANCE);
-
-        // Deploy mechanism
-        AllocationConfig memory config = AllocationConfig({
-            asset: IERC20(address(token)),
-            name: "Recipient Verification Test",
-            symbol: "RVTEST",
-            votingDelay: VOTING_DELAY,
-            votingPeriod: VOTING_PERIOD,
-            quorumShares: QUORUM_SHARES,
-            timelockDelay: 1 days,
-            gracePeriod: 7 days,
-            owner: address(this)
-        });
-
-        address mechanismAddr = factory.deployQuadraticVotingMechanism(config, 50, 100);
-        mechanism = QuadraticVotingMechanism(payable(mechanismAddr));
-    }
-
-    function _tokenized(address _mechanism) internal pure returns (TokenizedAllocationMechanism) {
-        return TokenizedAllocationMechanism(_mechanism);
-    }
-
-    /// @notice Helper function to sign up a user with specified deposit
-    function _signupUser(address user, uint256 depositAmount) internal {
-        vm.startPrank(user);
-        token.approve(address(mechanism), depositAmount);
-        _tokenized(address(mechanism)).signup(depositAmount);
-        vm.stopPrank();
-    }
-
-    /// @notice Helper function to create a proposal (only keeper/management can propose in QuadraticVoting)
-    function _createProposal(address recipient, string memory description) internal returns (uint256 pid) {
-        vm.prank(address(this)); // Test contract is keeper/management
-        pid = _tokenized(address(mechanism)).propose(recipient, description);
-    }
-
-    /// @notice Helper function to move to voting period
-    function _moveToVotingPeriod() internal {
-        uint256 deploymentTime = block.timestamp;
-        uint256 votingDelay = _tokenized(address(mechanism)).votingDelay();
-        uint256 votingStartTime = deploymentTime + votingDelay;
-        vm.warp(votingStartTime + 1);
     }
 
     // ============ Core Recipient Verification Tests ============
@@ -107,12 +51,13 @@ contract RecipientVerificationTest is Test {
             )
         );
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(
-            pid,
-            TokenizedAllocationMechanism.VoteType.For,
-            10, // Small weight to minimize cost
-            recipientB // Wrong recipient - should cause mismatch
-        );
+        _tokenized()
+            .castVote(
+                pid,
+                TokenizedAllocationMechanism.VoteType.For,
+                10, // Small weight to minimize cost
+                recipientB // Wrong recipient - should cause mismatch
+            );
     }
 
     /// @notice Test valid recipient - voting with correct expected recipient should succeed
@@ -122,24 +67,21 @@ contract RecipientVerificationTest is Test {
         uint256 pid = _createProposal(recipientA, "Fund Recipient A");
         _moveToVotingPeriod();
 
-        uint256 alicePowerBefore = _tokenized(address(mechanism)).votingPower(alice);
+        uint256 alicePowerBefore = _tokenized().votingPower(alice);
 
         // Vote with correct expected recipient - should succeed
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(
-            pid,
-            TokenizedAllocationMechanism.VoteType.For,
-            10, // weight=10, cost=100 (quadratic)
-            recipientA // Correct recipient - should succeed
-        );
+        _tokenized()
+            .castVote(
+                pid,
+                TokenizedAllocationMechanism.VoteType.For,
+                10, // weight=10, cost=100 (quadratic)
+                recipientA // Correct recipient - should succeed
+            );
 
         // Verify vote was recorded successfully
-        uint256 alicePowerAfter = _tokenized(address(mechanism)).votingPower(alice);
-        assertEq(
-            alicePowerBefore - alicePowerAfter,
-            100,
-            "Voting power should be reduced by quadratic cost (10^2=100)"
-        );
+        uint256 alicePowerAfter = _tokenized().votingPower(alice);
+        assertEq(alicePowerBefore - alicePowerAfter, 100, "Voting power should be reduced by quadratic cost (10^2=100)");
     }
 
     /// @notice Test multiple proposals with different recipients
@@ -154,7 +96,7 @@ contract RecipientVerificationTest is Test {
 
         // Vote on proposal 1 expecting recipient A - should succeed
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 10, recipientA);
+        _tokenized().castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 10, recipientA);
 
         // Try to vote on proposal 1 expecting recipient B - should fail
         vm.expectRevert(
@@ -166,15 +108,15 @@ contract RecipientVerificationTest is Test {
             )
         );
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
+        _tokenized().castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
 
         // Vote on proposal 2 expecting recipient B - should succeed
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
+        _tokenized().castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
 
         // Verify final voting powers (cost = weight^2)
-        assertEq(_tokenized(address(mechanism)).votingPower(alice), DEPOSIT_AMOUNT - 100); // 10^2
-        assertEq(_tokenized(address(mechanism)).votingPower(bob), DEPOSIT_AMOUNT - 100); // 10^2
+        assertEq(_tokenized().votingPower(alice), DEPOSIT_AMOUNT - 100); // 10^2
+        assertEq(_tokenized().votingPower(bob), DEPOSIT_AMOUNT - 100); // 10^2
     }
 
     /// @notice Test recipient verification across multiple proposals
@@ -192,41 +134,35 @@ contract RecipientVerificationTest is Test {
         // Try to vote on pid1 expecting recipientB (from pid2) - should fail
         vm.expectRevert(
             abi.encodeWithSelector(
-                TokenizedAllocationMechanism.RecipientMismatch.selector,
-                pid1,
-                recipientB,
-                recipientA
+                TokenizedAllocationMechanism.RecipientMismatch.selector, pid1, recipientB, recipientA
             )
         );
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
+        _tokenized().castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
 
         // Try to vote on pid2 expecting recipientC (from pid3) - should fail
         vm.expectRevert(
             abi.encodeWithSelector(
-                TokenizedAllocationMechanism.RecipientMismatch.selector,
-                pid2,
-                recipientC,
-                recipientB
+                TokenizedAllocationMechanism.RecipientMismatch.selector, pid2, recipientC, recipientB
             )
         );
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 10, recipientC);
+        _tokenized().castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 10, recipientC);
 
         // Now vote correctly on all proposals
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 10, recipientA);
+        _tokenized().castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 10, recipientA);
 
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
+        _tokenized().castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
 
         vm.prank(charlie);
-        _tokenized(address(mechanism)).castVote(pid3, TokenizedAllocationMechanism.VoteType.For, 10, recipientC);
+        _tokenized().castVote(pid3, TokenizedAllocationMechanism.VoteType.For, 10, recipientC);
 
         // Verify all votes were recorded (cost = weight^2)
-        assertEq(_tokenized(address(mechanism)).votingPower(alice), DEPOSIT_AMOUNT - 100); // 10^2
-        assertEq(_tokenized(address(mechanism)).votingPower(bob), DEPOSIT_AMOUNT - 100); // 10^2
-        assertEq(_tokenized(address(mechanism)).votingPower(charlie), DEPOSIT_AMOUNT - 100); // 10^2
+        assertEq(_tokenized().votingPower(alice), DEPOSIT_AMOUNT - 100); // 10^2
+        assertEq(_tokenized().votingPower(bob), DEPOSIT_AMOUNT - 100); // 10^2
+        assertEq(_tokenized().votingPower(charlie), DEPOSIT_AMOUNT - 100); // 10^2
     }
 
     // ============ Edge Cases and Security Tests ============
@@ -238,7 +174,7 @@ contract RecipientVerificationTest is Test {
         // Try to create proposal with zero address - should fail at creation
         vm.expectRevert(abi.encodeWithSelector(TokenizedAllocationMechanism.InvalidRecipient.selector, address(0)));
         vm.prank(address(this)); // Keeper/management role
-        _tokenized(address(mechanism)).propose(address(0), "Invalid proposal");
+        _tokenized().propose(address(0), "Invalid proposal");
     }
 
     /// @notice Test recipient verification with contract address (blocked at proposal creation)
@@ -250,7 +186,7 @@ contract RecipientVerificationTest is Test {
             abi.encodeWithSelector(TokenizedAllocationMechanism.InvalidRecipient.selector, address(mechanism))
         );
         vm.prank(address(this)); // Keeper/management role
-        _tokenized(address(mechanism)).propose(address(mechanism), "Self-proposal");
+        _tokenized().propose(address(mechanism), "Self-proposal");
     }
 
     /// @notice Test recipient verification preserves error message format
@@ -269,7 +205,7 @@ contract RecipientVerificationTest is Test {
             )
         );
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
     }
 
     /// @notice Test that only For votes are supported in QuadraticVoting
@@ -280,12 +216,12 @@ contract RecipientVerificationTest is Test {
 
         // For vote with correct recipient should work
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, recipientA);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.For, 10, recipientA);
 
         // Against vote should fail due to QuadraticVoting constraints
         vm.expectRevert(abi.encodeWithSelector(QuadraticVotingMechanism.OnlyForVotesSupported.selector));
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid, TokenizedAllocationMechanism.VoteType.Against, 5, recipientA);
+        _tokenized().castVote(pid, TokenizedAllocationMechanism.VoteType.Against, 5, recipientA);
     }
 
     /// @notice Comprehensive end-to-end test with multiple users and proposals
@@ -304,30 +240,27 @@ contract RecipientVerificationTest is Test {
 
         // Successful votes with correct recipients
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 10, recipientA);
+        _tokenized().castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 10, recipientA);
 
         vm.prank(bob);
-        _tokenized(address(mechanism)).castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
+        _tokenized().castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 10, recipientB);
 
         vm.prank(charlie);
-        _tokenized(address(mechanism)).castVote(pid3, TokenizedAllocationMechanism.VoteType.For, 10, recipientC);
+        _tokenized().castVote(pid3, TokenizedAllocationMechanism.VoteType.For, 10, recipientC);
 
         // Test failed vote with wrong recipient - use different user to avoid "already voted" error
         vm.expectRevert(
             abi.encodeWithSelector(
-                TokenizedAllocationMechanism.RecipientMismatch.selector,
-                pid1,
-                recipientB,
-                recipientA
+                TokenizedAllocationMechanism.RecipientMismatch.selector, pid1, recipientB, recipientA
             )
         );
         vm.prank(bob); // Bob hasn't voted on pid1 yet, so this tests recipient mismatch specifically
-        _tokenized(address(mechanism)).castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 5, recipientB);
+        _tokenized().castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 5, recipientB);
 
         // Verify final state - only successful votes should have reduced voting power
-        assertEq(_tokenized(address(mechanism)).votingPower(alice), DEPOSIT_AMOUNT - 100); // 10^2
-        assertEq(_tokenized(address(mechanism)).votingPower(bob), DEPOSIT_AMOUNT - 100); // 10^2 (only from pid2 vote)
-        assertEq(_tokenized(address(mechanism)).votingPower(charlie), DEPOSIT_AMOUNT - 100); // 10^2
+        assertEq(_tokenized().votingPower(alice), DEPOSIT_AMOUNT - 100); // 10^2
+        assertEq(_tokenized().votingPower(bob), DEPOSIT_AMOUNT - 100); // 10^2 (only from pid2 vote)
+        assertEq(_tokenized().votingPower(charlie), DEPOSIT_AMOUNT - 100); // 10^2
     }
 
     /// @notice Test the specific attack scenario that recipient verification prevents
@@ -345,7 +278,7 @@ contract RecipientVerificationTest is Test {
 
         // Alice votes for what she thinks is proposal 1 (recipientA)
         vm.prank(alice);
-        _tokenized(address(mechanism)).castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 20, recipientA);
+        _tokenized().castVote(pid1, TokenizedAllocationMechanism.VoteType.For, 20, recipientA);
 
         // Now imagine chain reorganization happens and proposal IDs get swapped
         // Alice tries to vote again thinking she's voting for the same project (recipientA)
@@ -353,21 +286,18 @@ contract RecipientVerificationTest is Test {
         // This should FAIL due to recipient verification
         vm.expectRevert(
             abi.encodeWithSelector(
-                TokenizedAllocationMechanism.RecipientMismatch.selector,
-                pid2,
-                recipientA,
-                recipientB
+                TokenizedAllocationMechanism.RecipientMismatch.selector, pid2, recipientA, recipientB
             )
         );
         vm.prank(bob); // Bob tries to vote expecting recipientA but proposal is for recipientB
-        _tokenized(address(mechanism)).castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 15, recipientA);
+        _tokenized().castVote(pid2, TokenizedAllocationMechanism.VoteType.For, 15, recipientA);
 
         // Without recipient verification, Bob's vote would have gone to recipientB
         // With recipient verification, the vote is rejected, protecting Bob from the attack
 
         // Verify only Alice's legitimate vote went through
-        assertEq(_tokenized(address(mechanism)).votingPower(alice), DEPOSIT_AMOUNT - 400); // 20^2
-        assertEq(_tokenized(address(mechanism)).votingPower(bob), DEPOSIT_AMOUNT); // No vote went through
+        assertEq(_tokenized().votingPower(alice), DEPOSIT_AMOUNT - 400); // 20^2
+        assertEq(_tokenized().votingPower(bob), DEPOSIT_AMOUNT); // No vote went through
     }
 
     /// @notice Test that zero address registration is blocked at core level
@@ -377,6 +307,6 @@ contract RecipientVerificationTest is Test {
 
         // Use vm.prank to simulate the call coming from address(0)
         vm.prank(address(0));
-        _tokenized(address(mechanism)).signup(0); // Zero deposit to avoid token transfer complications
+        _tokenized().signup(0); // Zero deposit to avoid token transfer complications
     }
 }

--- a/test/unit/mechanisms/allocation/utils/AllocationTestHelpers.sol
+++ b/test/unit/mechanisms/allocation/utils/AllocationTestHelpers.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {Test} from "forge-std/Test.sol";
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
-import {AllocationConfig} from "src/mechanisms/BaseAllocationMechanism.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { Test } from "forge-std/Test.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
+import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
 
 abstract contract AllocationTestHelpers is Test {
     function _tokenized(address mechanismAddress) internal pure returns (TokenizedAllocationMechanism) {
@@ -29,17 +29,18 @@ abstract contract AllocationTestHelpers is Test {
         uint256 gracePeriod,
         address owner
     ) internal pure returns (AllocationConfig memory) {
-        return AllocationConfig({
-            asset: asset,
-            name: name,
-            symbol: symbol,
-            votingDelay: votingDelay,
-            votingPeriod: votingPeriod,
-            quorumShares: quorumShares,
-            timelockDelay: timelockDelay,
-            gracePeriod: gracePeriod,
-            owner: owner
-        });
+        return
+            AllocationConfig({
+                asset: asset,
+                name: name,
+                symbol: symbol,
+                votingDelay: votingDelay,
+                votingPeriod: votingPeriod,
+                quorumShares: quorumShares,
+                timelockDelay: timelockDelay,
+                gracePeriod: gracePeriod,
+                owner: owner
+            });
     }
 
     function _deployQuadraticVoting(
@@ -48,23 +49,30 @@ abstract contract AllocationTestHelpers is Test {
         uint256 alphaNumerator,
         uint256 alphaDenominator
     ) internal returns (QuadraticVotingMechanism) {
-        return QuadraticVotingMechanism(
-            payable(factory.deployQuadraticVotingMechanism(allocationConfig, alphaNumerator, alphaDenominator))
-        );
+        return
+            QuadraticVotingMechanism(
+                payable(factory.deployQuadraticVotingMechanism(allocationConfig, alphaNumerator, alphaDenominator))
+            );
     }
 
-    function _signupUser(ERC20Mock token, QuadraticVotingMechanism mechanism, address user, uint256 depositAmount)
-        internal
-    {
+    function _signupUser(
+        ERC20Mock token,
+        QuadraticVotingMechanism mechanism,
+        address user,
+        uint256 depositAmount
+    ) internal {
         vm.startPrank(user);
         token.approve(address(mechanism), depositAmount);
         _tokenized(address(mechanism)).signup(depositAmount);
         vm.stopPrank();
     }
 
-    function _signupUser(IERC20 token, TokenizedAllocationMechanism mechanism, address user, uint256 depositAmount)
-        internal
-    {
+    function _signupUser(
+        IERC20 token,
+        TokenizedAllocationMechanism mechanism,
+        address user,
+        uint256 depositAmount
+    ) internal {
         vm.startPrank(user);
         token.approve(address(mechanism), depositAmount);
         mechanism.signup(depositAmount);

--- a/test/unit/mechanisms/allocation/utils/AllocationTestHelpers.sol
+++ b/test/unit/mechanisms/allocation/utils/AllocationTestHelpers.sol
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Test} from "forge-std/Test.sol";
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
+import {AllocationConfig} from "src/mechanisms/BaseAllocationMechanism.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+
+abstract contract AllocationTestHelpers is Test {
+    function _tokenized(address mechanismAddress) internal pure returns (TokenizedAllocationMechanism) {
+        return TokenizedAllocationMechanism(mechanismAddress);
+    }
+
+    function _tam(address mechanismAddress) internal pure returns (TokenizedAllocationMechanism) {
+        return TokenizedAllocationMechanism(mechanismAddress);
+    }
+
+    function _config(
+        IERC20 asset,
+        string memory name,
+        string memory symbol,
+        uint256 votingDelay,
+        uint256 votingPeriod,
+        uint256 quorumShares,
+        uint256 timelockDelay,
+        uint256 gracePeriod,
+        address owner
+    ) internal pure returns (AllocationConfig memory) {
+        return AllocationConfig({
+            asset: asset,
+            name: name,
+            symbol: symbol,
+            votingDelay: votingDelay,
+            votingPeriod: votingPeriod,
+            quorumShares: quorumShares,
+            timelockDelay: timelockDelay,
+            gracePeriod: gracePeriod,
+            owner: owner
+        });
+    }
+
+    function _deployQuadraticVoting(
+        AllocationMechanismFactory factory,
+        AllocationConfig memory allocationConfig,
+        uint256 alphaNumerator,
+        uint256 alphaDenominator
+    ) internal returns (QuadraticVotingMechanism) {
+        return QuadraticVotingMechanism(
+            payable(factory.deployQuadraticVotingMechanism(allocationConfig, alphaNumerator, alphaDenominator))
+        );
+    }
+
+    function _signupUser(ERC20Mock token, QuadraticVotingMechanism mechanism, address user, uint256 depositAmount)
+        internal
+    {
+        vm.startPrank(user);
+        token.approve(address(mechanism), depositAmount);
+        _tokenized(address(mechanism)).signup(depositAmount);
+        vm.stopPrank();
+    }
+
+    function _signupUser(IERC20 token, TokenizedAllocationMechanism mechanism, address user, uint256 depositAmount)
+        internal
+    {
+        vm.startPrank(user);
+        token.approve(address(mechanism), depositAmount);
+        mechanism.signup(depositAmount);
+        vm.stopPrank();
+    }
+
+    function _createProposal(
+        TokenizedAllocationMechanism mechanism,
+        address proposer,
+        address recipient,
+        string memory description
+    ) internal returns (uint256 pid) {
+        vm.prank(proposer);
+        pid = mechanism.propose(recipient, description);
+    }
+
+    function _createProposal(
+        QuadraticVotingMechanism mechanism,
+        address proposer,
+        address recipient,
+        string memory description
+    ) internal returns (uint256 pid) {
+        pid = _createProposal(_tokenized(address(mechanism)), proposer, recipient, description);
+    }
+
+    function _castVote(
+        TokenizedAllocationMechanism mechanism,
+        address voter,
+        uint256 pid,
+        uint256 weight,
+        address recipient
+    ) internal {
+        vm.prank(voter);
+        mechanism.castVote(pid, TokenizedAllocationMechanism.VoteType.For, weight, recipient);
+    }
+
+    function _castVote(
+        QuadraticVotingMechanism mechanism,
+        address voter,
+        uint256 pid,
+        uint256 weight,
+        address recipient
+    ) internal {
+        _castVote(_tokenized(address(mechanism)), voter, pid, weight, recipient);
+    }
+
+    function _warpToVotingPeriod(TokenizedAllocationMechanism mechanism) internal {
+        vm.warp(block.timestamp + mechanism.votingDelay() + 1);
+    }
+
+    function _warpPastVotingPeriod(TokenizedAllocationMechanism mechanism) internal {
+        vm.warp(block.timestamp + mechanism.votingDelay() + mechanism.votingPeriod() + 1);
+    }
+
+    function _finalizeVoteTally(TokenizedAllocationMechanism mechanism) internal {
+        mechanism.finalizeVoteTally();
+    }
+
+    function _queueProposal(TokenizedAllocationMechanism mechanism, uint256 pid) internal {
+        mechanism.queueProposal(pid);
+    }
+}

--- a/test/unit/mechanisms/allocation/utils/QuadraticVotingTestBase.sol
+++ b/test/unit/mechanisms/allocation/utils/QuadraticVotingTestBase.sol
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
+import {AllocationConfig} from "src/mechanisms/BaseAllocationMechanism.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import {AllocationTestHelpers} from "./AllocationTestHelpers.sol";
+
+abstract contract QuadraticVotingTestBase is AllocationTestHelpers {
+    AllocationMechanismFactory internal factory;
+    ERC20Mock internal token;
+    QuadraticVotingMechanism internal mechanism;
+
+    address internal alice = address(0x1);
+    address internal bob = address(0x2);
+    address internal charlie = address(0x3);
+    address internal dave = address(0x4);
+    address internal eve = address(0x5);
+    address internal frank = address(0x6);
+    address internal grace = address(0x7);
+    address internal henry = address(0x8);
+    address internal emergencyAdmin = address(0xa);
+    address internal recipient1 = address(0x101);
+    address internal recipient2 = address(0x102);
+    address internal recipient3 = address(0x103);
+
+    uint256 internal constant DEFAULT_VOTING_DELAY = 100;
+    uint256 internal constant DEFAULT_VOTING_PERIOD = 1000;
+    uint256 internal constant DEFAULT_QUORUM = 500;
+    uint256 internal constant DEFAULT_TIMELOCK_DELAY = 1 days;
+    uint256 internal constant DEFAULT_GRACE_PERIOD = 7 days;
+    uint256 internal constant DEFAULT_ALPHA_NUMERATOR = 50;
+    uint256 internal constant DEFAULT_ALPHA_DENOMINATOR = 100;
+
+    function _setUpQuadraticVoting() internal {
+        _setUpQuadraticVoting(_defaultConfig(), DEFAULT_ALPHA_NUMERATOR, DEFAULT_ALPHA_DENOMINATOR);
+    }
+
+    function _setUpQuadraticVoting(
+        string memory name,
+        string memory symbol,
+        uint256 votingDelay,
+        uint256 votingPeriod,
+        uint256 quorumShares,
+        uint256 timelockDelay,
+        uint256 gracePeriod,
+        uint256 alphaNumerator,
+        uint256 alphaDenominator
+    ) internal {
+        token = new ERC20Mock();
+        _setUpQuadraticVoting(
+            _config({
+                asset: IERC20(address(token)),
+                name: name,
+                symbol: symbol,
+                votingDelay: votingDelay,
+                votingPeriod: votingPeriod,
+                quorumShares: quorumShares,
+                timelockDelay: timelockDelay,
+                gracePeriod: gracePeriod,
+                owner: address(0)
+            }),
+            alphaNumerator,
+            alphaDenominator
+        );
+    }
+
+    function _setUpQuadraticVoting(
+        AllocationConfig memory allocationConfig,
+        uint256 alphaNumerator,
+        uint256 alphaDenominator
+    ) internal {
+        factory = new AllocationMechanismFactory();
+        token = ERC20Mock(address(allocationConfig.asset));
+        mechanism = _deployQuadraticVoting(factory, allocationConfig, alphaNumerator, alphaDenominator);
+    }
+
+    function _setUpQuadraticVotingWithFreshToken(
+        AllocationConfig memory allocationConfig,
+        uint256 alphaNumerator,
+        uint256 alphaDenominator
+    ) internal {
+        factory = new AllocationMechanismFactory();
+        token = new ERC20Mock();
+        allocationConfig.asset = IERC20(address(token));
+        mechanism = _deployQuadraticVoting(factory, allocationConfig, alphaNumerator, alphaDenominator);
+    }
+
+    function _defaultConfig() internal returns (AllocationConfig memory) {
+        token = new ERC20Mock();
+        return _config({
+            asset: IERC20(address(token)),
+            name: "Quadratic Voting Test",
+            symbol: "QVT",
+            votingDelay: DEFAULT_VOTING_DELAY,
+            votingPeriod: DEFAULT_VOTING_PERIOD,
+            quorumShares: DEFAULT_QUORUM,
+            timelockDelay: DEFAULT_TIMELOCK_DELAY,
+            gracePeriod: DEFAULT_GRACE_PERIOD,
+            owner: address(0)
+        });
+    }
+
+    function _standardConfig(
+        string memory name,
+        string memory symbol,
+        uint256 quorumShares,
+        uint256 timelockDelay,
+        uint256 gracePeriod
+    ) internal returns (AllocationConfig memory) {
+        token = new ERC20Mock();
+        return _config({
+            asset: IERC20(address(token)),
+            name: name,
+            symbol: symbol,
+            votingDelay: DEFAULT_VOTING_DELAY,
+            votingPeriod: DEFAULT_VOTING_PERIOD,
+            quorumShares: quorumShares,
+            timelockDelay: timelockDelay,
+            gracePeriod: gracePeriod,
+            owner: address(0)
+        });
+    }
+
+    function _setRoles(address keeper, address management) internal {
+        _tokenized(address(mechanism)).setKeeper(keeper);
+        _tokenized(address(mechanism)).setManagement(management);
+    }
+
+    function _fundUsers(uint256 amount) internal {
+        token.mint(alice, amount);
+        token.mint(bob, amount);
+        token.mint(charlie, amount);
+    }
+
+    function _fundUsers(uint256 aliceAmount, uint256 bobAmount, uint256 charlieAmount) internal {
+        token.mint(alice, aliceAmount);
+        token.mint(bob, bobAmount);
+        token.mint(charlie, charlieAmount);
+    }
+
+    function _fundMatchingPool(uint256 amount) internal {
+        token.mint(address(mechanism), amount);
+    }
+
+    function _signup(address user, uint256 depositAmount) internal {
+        _signupUser(token, mechanism, user, depositAmount);
+    }
+
+    function _signupUser(address user, uint256 depositAmount) internal {
+        _signup(user, depositAmount);
+    }
+
+    function _propose(address proposer, address recipient, string memory description) internal returns (uint256 pid) {
+        pid = _createProposal(mechanism, proposer, recipient, description);
+    }
+
+    function _createProposal(address proposer, address recipient, string memory description)
+        internal
+        returns (uint256 pid)
+    {
+        pid = _propose(proposer, recipient, description);
+    }
+
+    function _createProposal(address recipient, string memory description) internal returns (uint256 pid) {
+        pid = _propose(address(this), recipient, description);
+    }
+
+    function _vote(address voter, uint256 pid, uint256 weight, address recipient) internal {
+        _castVote(mechanism, voter, pid, weight, recipient);
+    }
+
+    function _castVote(address voter, uint256 pid, uint256 weight, address recipient)
+        internal
+        returns (uint256 previousPower, uint256 newPower)
+    {
+        previousPower = _tokenized().votingPower(voter);
+        _vote(voter, pid, weight, recipient);
+        newPower = _tokenized().votingPower(voter);
+    }
+
+    function _tokenized() internal view returns (TokenizedAllocationMechanism) {
+        return _tokenized(address(mechanism));
+    }
+
+    function _moveToVotingPeriod() internal {
+        _warpToVotingPeriod(_tokenized());
+    }
+}

--- a/test/unit/mechanisms/allocation/utils/QuadraticVotingTestBase.sol
+++ b/test/unit/mechanisms/allocation/utils/QuadraticVotingTestBase.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
-import {TokenizedAllocationMechanism} from "src/mechanisms/TokenizedAllocationMechanism.sol";
-import {QuadraticVotingMechanism} from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
-import {AllocationMechanismFactory} from "src/mechanisms/AllocationMechanismFactory.sol";
-import {AllocationConfig} from "src/mechanisms/BaseAllocationMechanism.sol";
-import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import {ERC20Mock} from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
-import {AllocationTestHelpers} from "./AllocationTestHelpers.sol";
+import { TokenizedAllocationMechanism } from "src/mechanisms/TokenizedAllocationMechanism.sol";
+import { QuadraticVotingMechanism } from "src/mechanisms/mechanism/QuadraticVotingMechanism.sol";
+import { AllocationMechanismFactory } from "src/mechanisms/AllocationMechanismFactory.sol";
+import { AllocationConfig } from "src/mechanisms/BaseAllocationMechanism.sol";
+import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import { ERC20Mock } from "@openzeppelin/contracts/mocks/token/ERC20Mock.sol";
+import { AllocationTestHelpers } from "./AllocationTestHelpers.sol";
 
 abstract contract QuadraticVotingTestBase is AllocationTestHelpers {
     AllocationMechanismFactory internal factory;
@@ -91,17 +91,18 @@ abstract contract QuadraticVotingTestBase is AllocationTestHelpers {
 
     function _defaultConfig() internal returns (AllocationConfig memory) {
         token = new ERC20Mock();
-        return _config({
-            asset: IERC20(address(token)),
-            name: "Quadratic Voting Test",
-            symbol: "QVT",
-            votingDelay: DEFAULT_VOTING_DELAY,
-            votingPeriod: DEFAULT_VOTING_PERIOD,
-            quorumShares: DEFAULT_QUORUM,
-            timelockDelay: DEFAULT_TIMELOCK_DELAY,
-            gracePeriod: DEFAULT_GRACE_PERIOD,
-            owner: address(0)
-        });
+        return
+            _config({
+                asset: IERC20(address(token)),
+                name: "Quadratic Voting Test",
+                symbol: "QVT",
+                votingDelay: DEFAULT_VOTING_DELAY,
+                votingPeriod: DEFAULT_VOTING_PERIOD,
+                quorumShares: DEFAULT_QUORUM,
+                timelockDelay: DEFAULT_TIMELOCK_DELAY,
+                gracePeriod: DEFAULT_GRACE_PERIOD,
+                owner: address(0)
+            });
     }
 
     function _standardConfig(
@@ -112,17 +113,18 @@ abstract contract QuadraticVotingTestBase is AllocationTestHelpers {
         uint256 gracePeriod
     ) internal returns (AllocationConfig memory) {
         token = new ERC20Mock();
-        return _config({
-            asset: IERC20(address(token)),
-            name: name,
-            symbol: symbol,
-            votingDelay: DEFAULT_VOTING_DELAY,
-            votingPeriod: DEFAULT_VOTING_PERIOD,
-            quorumShares: quorumShares,
-            timelockDelay: timelockDelay,
-            gracePeriod: gracePeriod,
-            owner: address(0)
-        });
+        return
+            _config({
+                asset: IERC20(address(token)),
+                name: name,
+                symbol: symbol,
+                votingDelay: DEFAULT_VOTING_DELAY,
+                votingPeriod: DEFAULT_VOTING_PERIOD,
+                quorumShares: quorumShares,
+                timelockDelay: timelockDelay,
+                gracePeriod: gracePeriod,
+                owner: address(0)
+            });
     }
 
     function _setRoles(address keeper, address management) internal {
@@ -158,10 +160,11 @@ abstract contract QuadraticVotingTestBase is AllocationTestHelpers {
         pid = _createProposal(mechanism, proposer, recipient, description);
     }
 
-    function _createProposal(address proposer, address recipient, string memory description)
-        internal
-        returns (uint256 pid)
-    {
+    function _createProposal(
+        address proposer,
+        address recipient,
+        string memory description
+    ) internal returns (uint256 pid) {
         pid = _propose(proposer, recipient, description);
     }
 
@@ -173,10 +176,12 @@ abstract contract QuadraticVotingTestBase is AllocationTestHelpers {
         _castVote(mechanism, voter, pid, weight, recipient);
     }
 
-    function _castVote(address voter, uint256 pid, uint256 weight, address recipient)
-        internal
-        returns (uint256 previousPower, uint256 newPower)
-    {
+    function _castVote(
+        address voter,
+        uint256 pid,
+        uint256 weight,
+        address recipient
+    ) internal returns (uint256 previousPower, uint256 newPower) {
         previousPower = _tokenized().votingPower(voter);
         _vote(voter, pid, weight, recipient);
         newPower = _tokenized().votingPower(voter);


### PR DESCRIPTION
## Summary
- add shared allocation and quadratic-voting test helpers for config, deployment, signup, proposal, vote, warp, finalize, and queue flows
- migrate the normal quadratic-voting journey/timelock/accounting/signature/decimal tests onto the helper layer
- leave bespoke branch-coverage, reentrancy, custom-distribution, and non-QV smoke harnesses local where their setup is intentionally specialized

## Tests
- `forge fmt --check` on touched allocation test files
- `forge test --match-path 'test/unit/mechanisms/allocation/**/*.sol'` (381 passed)
- `forge test` locally without `TEST_RPC_URL` reached 2315 passed, then stopped at 38 fork setup failures due missing `TEST_RPC_URL`
- `TEST_RPC_URL=https://ethereum-rpc.publicnode.com forge test --rerun` reached 2787 passed, then stopped at 13 archive-RPC failures
- `TEST_RPC_URL=https://eth-mainnet.public.blastapi.io forge test --rerun --threads 1` passed the remaining fork failures (136 passed)
