### PR TITLE
feat(scripts): deploy Spark, Aave V3 and Rocket Pool strategy factories

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,8 @@ ast = true
 fs_permissions = [
     { access = "read-write", path = "./cache/test-artifacts/" },
     { access = "read", path = "./out/" },
-    { access = "read-write", path = "./partners/" }
+    { access = "read-write", path = "./partners/" },
+    { access = "read-write", path = "./contract_addresses.txt" }
 ]
 build_info = true
 extra_output = ["storageLayout"]

--- a/script/README.md
+++ b/script/README.md
@@ -13,6 +13,25 @@ utilities (`.sh`) used by Octant v2. Node.js repository tooling lives under
 - `prod` - production deployment scripts
 - `verify` - contract verification scripts
 
+## Deployment entry points
+
+There are three distinct deployment paths. They deploy overlapping contract sets with
+different CREATE2 salts, so they produce **different addresses** — pick one per environment.
+
+| Path | Entry point | Deploys via |
+|---|---|---|
+| Production (Safe) | `prod/DeployProtocol.s.sol` — `phaseA_batch1..4`, `phaseB_*` | Nick's CREATE2 factory, salts suffixed by `SALT_TIMESTAMP` |
+| Staging / testbed (Safe) | `deploy/DeployNewStrategiesAndFactories.s.sol` — `run()` or `runBatch1..4()` | Nick's CREATE2 factory, pinned date salts |
+| Staging (EOA) | `deployment/staging/DeployProtocol.s.sol` — `run()` | Deployer EOA, composes the standalone `deploy/Deploy*Factory.sol` scripts |
+
+`deploy/DeployAllStrategiesAndFactories.s.sol` (salts `05112025`) and
+`deploy/DeployYieldSkimmingStrategiesAndFactories.s.sol` (salts `18012026`) cover subsets of the same
+contracts with their own salts. They are still live entry points, so take care not to mix them with the
+paths above in the same environment.
+
+Full instructions: [`deploy/DEPLOYMENT_GUIDE.md`](deploy/DEPLOYMENT_GUIDE.md).
+CI coverage for these scripts: `test/unit/script/DeploymentScripts.t.sol`.
+
 ## Shell utilities
 
 - `check-natspec.sh` - validates NatSpec documentation coverage on public/external functions

--- a/script/deploy/DEPLOYMENT_GUIDE.md
+++ b/script/deploy/DEPLOYMENT_GUIDE.md
@@ -1,118 +1,204 @@
 # Deployment Guide for Octant V2 Core Contracts
 
-This guide explains how to deploy all the tokenized strategies and factory contracts using a Gnosis Safe multisig wallet via the forge-safe integration.
+This guide explains how to deploy the tokenized strategy implementations, strategy factories, and
+RegenStaker infrastructure through a Gnosis Safe multisig using the forge-safe integration.
 
-## Overview
+## Which script do I run?
 
-The deployment script `DeployAllStrategiesAndFactories.s.sol` deploys the following contracts:
+| Target | Script | Notes |
+|---|---|---|
+| Production mainnet | `script/prod/DeployProtocol.s.sol` | 8 Safe transactions (Phase A: 4 factory batches, Phase B: 4 instance batches). Salts are parameterized by `SALT_TIMESTAMP`. Asserts every deployed address against its precomputation before proposing. |
+| Staging / testbed via Safe | `script/deploy/DeployNewStrategiesAndFactories.s.sol` | 4 Safe transactions. Salts are pinned date constants. |
+| Staging via EOA (no Safe) | `script/deployment/staging/DeployProtocol.s.sol` | Composes the standalone `Deploy*StrategyFactory` scripts and skips anything already listed in `script/helpers/DeployedAddresses.sol`. |
+| One factory only | `script/deploy/Deploy<Name>StrategyFactory.sol` | CREATE2 from the deployer EOA, not from Nick's factory — addresses differ from the Safe path by design. |
 
-### Tokenized Strategy Implementations
-1. **YieldDonatingTokenizedStrategy** - Base implementation for productive assets with discrete harvesting
+Two older Safe scripts overlap with the table above and have **not** been retired:
+`DeployAllStrategiesAndFactories.s.sol` (salts `05112025`) and
+`DeployYieldSkimmingStrategiesAndFactories.s.sol` (salts `18012026`). Because salts differ, running one
+of them alongside the canonical paths deploys a second on-chain copy of the same contracts at a
+different address. Pick one path per environment and record which addresses are canonical in
+`script/helpers/DeployedAddresses.sol`.
 
-### Factory Contracts
-1. **MorphoCompounderStrategyFactory** - Factory for deploying Morpho yield donating strategies
-2. **SkyCompounderStrategyFactory** - Factory for deploying Sky Compounder yield donating strategies
-3. **PaymentSplitterFactory** - Factory for deploying PaymentSplitter contracts with minimal proxies
-4. **YearnV3StrategyFactory** - Factory for deploying YearnV3 yield donating strategies
+## Contracts deployed by the Safe batches
+
+`DeployNewStrategiesAndFactories.s.sol` deploys 13 contracts. Batches exist because of the EIP-7825
+per-transaction gas limit of 16,777,216 gas (2^24), not for logical grouping.
+
+**Batch 1** (~12.9M gas of contract creation, measured — the tightest batch) — implementations plus
+the first factory group:
+
+1. `YieldSkimmingTokenizedStrategy` — implementation for rebasing/appreciating assets
+2. `YieldDonatingTokenizedStrategy` — implementation for productive assets with discrete harvesting
+3. `PaymentSplitterFactory` — PaymentSplitter contracts via minimal proxies
+4. `LidoStrategyFactory` — Lido (wstETH) yield skimming strategies
+5. `MorphoCompounderStrategyFactory` — Morpho yield donating strategies
+
+**Batch 2** — remaining yield donating factories:
+
+6. `SkyCompounderStrategyFactory` — Sky Compounder yield donating strategies
+7. `YearnV3StrategyFactory` — Yearn V3 yield donating strategies
+
+**Batch 3** (~3M gas) — RegenStaker infrastructure:
+
+8. `AddressSetFactory`
+9. `RegenEarningPowerCalculatorFactory`
+10. `RegenStakerFactory` — constructor takes the canonical RegenStaker bytecode hashes
+
+**Batch 4** (~6.8M gas of contract creation, measured) — Spark, Aave V3, and Rocket Pool factories:
+
+11. `SparkStrategyFactory` — Spark ERC4626 yield donating strategies with airdrop sweep
+12. `AaveV3StrategyFactory` — Aave V3 yield donating strategies
+13. `RocketPoolStrategyFactory` — Rocket Pool (rETH) yield skimming strategies
+
+All three batch 4 factories take no constructor arguments and receive the tokenized strategy
+implementation as a `createStrategy()` parameter, so batch 4 has no ordering dependency on batch 1.
 
 ## Prerequisites
 
-1. **Gnosis Safe**: You need a deployed Gnosis Safe multisig wallet
-2. **forge-safe**: The deployment uses forge-safe for batch transaction creation
-3. **Environment Setup**: Ensure you have the following:
-   - Foundry/Forge installed
-   - Access to the Safe transaction service API
-   - Private key for transaction submission (must be a Safe owner or delegate)
+1. **Gnosis Safe**: a deployed Safe multisig on the target chain
+2. **forge-safe**: used for batch transaction creation (requires `--ffi`)
+3. **Environment**: Foundry installed, access to the Safe transaction service API, and a private key
+   belonging to a Safe owner or delegate
 
-## Supported Chains
+## Deployment process
 
-The deployment script supports the following chains:
-- **Ethereum Mainnet** (chainId: 1)
-- **Polygon** (chainId: 137) 
-- **Goerli** (chainId: 5)
-- **Sepolia** (chainId: 11155111)
-- **Base** (chainId: 8453)
-- **Arbitrum** (chainId: 42161)
-- **Avalanche** (chainId: 43114)
-
-## Deployment Process
-
-### 1. Set Environment Variables
+### 1. Set environment variables
 
 ```bash
-# Required: Safe multisig address
-export SAFE_ADDRESS=0x... # Your Gnosis Safe address
-
-# Required: Private key for deployment
-export PRIVATE_KEY=0x...
-
-# Optional: RPC URL (defaults to chain's RPC from foundry.toml)
-export ETH_RPC_URL=https://eth-mainnet.alchemyapi.io/v2/YOUR_API_KEY
-
-# Optional: Etherscan API key for verification
-export ETHERSCAN_API_KEY=your_etherscan_api_key
+export SAFE_ADDRESS=0x...        # target Gnosis Safe
+export CHAIN=mainnet
+export WALLET_TYPE=local         # or ledger
+export PRIVATE_KEY=0x...         # required for WALLET_TYPE=local
+export SENDER=0x...              # must be a Safe owner or delegate
+export ETH_RPC_URL=https://...
+export SEND=true                 # omit to simulate only (see below)
 ```
 
-### 2. Run the Deployment Script
+If `SAFE_ADDRESS` is unset the script prompts for it.
+
+**Both Safe scripts simulate by default.** Without `SEND=true` a run executes the full batch against
+the fork — including every address assertion — and proposes nothing. Always do a simulation run
+first; a salt or bytecode drift fails there instead of producing a Safe payload with wrong addresses.
+
+### 2. Run the deployment
+
+Deploy all four batches — four Safe proposals in sequence at nonce N, N+1, N+2, N+3:
 
 ```bash
-# Send to Safe
-forge script script/deploy/DeployAllStrategiesAndFactories.s.sol:DeployAllStrategiesAndFactories \
-  --rpc-url $ETH_RPC_URL \
-  --private-key 0xYOUR_PRIVATE_KEY \
-  --ffi
+forge script script/deploy/DeployNewStrategiesAndFactories.s.sol \
+  --rpc-url $ETH_RPC_URL --ffi --sender $SENDER
 ```
 
-#### Example: Deploying on Ethereum
+Or propose one batch at a time:
 
 ```bash
-# Set up for Ethereum deployment
-export SAFE_ADDRESS=0x... # Your Safe on Ethereum
-export CHAIN=ethereum
-export ETH_RPC_URL=https://eth-mainnet.infura.io/v3/YOUR_PROJECT_ID
-export PRIVATE_KEY=0x...
-
-# Run deployment with explicit private key
-forge script script/deploy/DeployAllStrategiesAndFactories.s.sol:DeployAllStrategiesAndFactories \
-  --rpc-url $ETH_RPC_URL \
-  --private-key $PRIVATE_KEY \
-  --ffi
+forge script script/deploy/DeployNewStrategiesAndFactories.s.sol \
+  --sig "runBatch1()" --rpc-url $ETH_RPC_URL --ffi --sender $SENDER
+# ... likewise runBatch2(), runBatch3(), runBatch4()
 ```
 
-**Important**: The `--ffi` flag is required for the forge-safe integration to work.
+For production, use the prod script's phase entry points instead:
 
-If `SAFE_ADDRESS` is not set, the script will prompt you to enter it.
-The script signs the Safe transaction once and submits it to the Safe transaction service. It does not execute the Safe transaction on-chain.
+```bash
+forge script script/prod/DeployProtocol.s.sol:DeployProtocol \
+  --sig "phaseA_batch4()" --rpc-url $ETH_RPC_URL --ffi
+```
 
-### 3. Sign the Transaction in Safe
+The prod script simulates only by default; set `SEND=true` to submit to the Safe API.
 
-After running the script:
-1. The batch transaction will be sent to the Safe transaction service
-2. Safe owners will receive notifications (if configured)
-3. Navigate to the Safe web interface or use Safe CLI to sign the transaction
-4. Once enough signatures are collected, any owner can execute the transaction
+**Important**: `--ffi` is required for forge-safe. The script signs the Safe transaction once and
+submits it to the Safe transaction service — it does not execute it on-chain.
 
-## Deployment Addresses
+### 3. Sign and execute in Safe
 
-All contracts are deployed deterministically using CREATE2, which means they will have the same address across different networks if deployed with the same Safe address.
+1. The batch is sent to the Safe transaction service
+2. Safe owners sign via the Safe web interface or Safe CLI
+3. Once the threshold is met, any owner executes
+4. Execute batch 1, then 2, then 3, then 4 — nonces must land in order
 
-### Deployment Salts
-All salts use a date-based format (DDMMYYYY) for versioning:
-- YieldDonatingTokenizedStrategy: `keccak256("OCTANT_YIELD_DONATING_STRATEGY_05112025")`
-- MorphoCompounderStrategyFactory: `keccak256("MORPHO_COMPOUNDER_FACTORY_05112025")`
-- SkyCompounderStrategyFactory: `keccak256("SKY_COMPOUNDER_FACTORY_05112025")`
-- PaymentSplitterFactory: `keccak256("PAYMENT_SPLITTER_FACTORY_05112025")`
-- YearnV3StrategyFactory: `keccak256("YEARN_V3_STRATEGY_FACTORY_05112025")`
+Before signing, compare the addresses printed in the batch summary against
+`forge script ... --sig "computeAllAddresses()"` (prod script) output.
 
-## What the Script Does
+## Deterministic addresses
 
-1. **Calculates Expected Addresses**: Uses CREATE2 to compute deterministic addresses for all contracts (deployed by CREATE2 factory)
-2. **Creates MultiSend Transaction**: Bundles all CREATE2 factory calls into a single MultiSend transaction
-3. **Safe Execution Flow**:
-   - Safe calls `execTransaction` (once)
-   - `execTransaction` calls `MultiSendCallOnly`
-   - `MultiSendCallOnly` makes 5 calls to CREATE2 factory at `0x4e59b44847b379578588920cA78FbF26c0B4956C`
-   - Each call uses calldata format: `salt (32 bytes) + bytecode`
-   - CREATE2 factory deploys each contract deterministically
-4. **Sends to Safe Backend**: Submits the transaction to Safe's backend for owner signatures
-5. **Logs Deployment Info**: Outputs all expected contract addresses
+Every contract in the Safe batches is deployed through Nick's CREATE2 factory at
+`0x4e59b44847b379578588920cA78FbF26c0B4956C`, so the address depends only on the salt and the
+creation code — not on the Safe address or the nonce.
+
+### Salts
+
+`DeployNewStrategiesAndFactories.s.sol` uses pinned date-based constants (`DDMMYYYY`):
+
+| Contract | Salt preimage |
+|---|---|
+| YieldSkimmingTokenizedStrategy | `OCTANT_YIELD_SKIMMING_STRATEGY_11022026` |
+| YieldDonatingTokenizedStrategy | `OCTANT_YIELD_DONATING_STRATEGY_11022026` |
+| PaymentSplitterFactory | `PAYMENT_SPLITTER_FACTORY_11022026` |
+| LidoStrategyFactory | `LIDO_STRATEGY_FACTORY_11022026` |
+| MorphoCompounderStrategyFactory | `MORPHO_COMPOUNDER_FACTORY_11022026` |
+| SkyCompounderStrategyFactory | `SKY_COMPOUNDER_FACTORY_11022026` |
+| YearnV3StrategyFactory | `YEARN_V3_STRATEGY_FACTORY_11022026` |
+| AddressSetFactory | `ADDRESS_SET_FACTORY_11022026` |
+| RegenEarningPowerCalculatorFactory | `REGEN_EARNING_POWER_CALCULATOR_FACTORY_11022026` |
+| RegenStakerFactory | `REGEN_STAKER_FACTORY_11022026` |
+| SparkStrategyFactory | `SPARK_STRATEGY_FACTORY_07072026` |
+| AaveV3StrategyFactory | `AAVE_V3_STRATEGY_FACTORY_07072026` |
+| RocketPoolStrategyFactory | `ROCKET_POOL_STRATEGY_FACTORY_07072026` |
+
+`script/prod/DeployProtocol.s.sol` builds its salts from the **same preimage prefixes** with
+`SALT_TIMESTAMP` appended. The two scripts are therefore not isolated from each other:
+
+> ⚠️ Setting `SALT_TIMESTAMP=11022026` in the prod script reproduces byte-identical salts — and
+> therefore byte-identical addresses — for all ten batch-1..3 contracts above (likewise `07072026`
+> for batch 4). If those contracts are already deployed, every CREATE2 call reverts, and it reverts
+> only after the batch has been built and reviewed.
+
+In normal use the prod script auto-generates `SALT_TIMESTAMP` as `HH_DDMMYYYY`, which cannot collide
+with a `DDMMYYYY` constant, so the two paths produce different addresses. The collision is only
+reachable by pinning `SALT_TIMESTAMP` to one of the dates above — do not do that to "reproduce known
+addresses". To verify existing deployments, read them from `script/helpers/DeployedAddresses.sol`.
+
+Changing a contract's source changes its creation code and therefore its address. A salt may only be
+reused with byte-identical creation code; otherwise bump the date.
+
+### On-chain state of these salts (mainnet, checked 2026-07-20)
+
+Batches are not all unexecuted. Verify before proposing — a CREATE2 call against an occupied address
+reverts, and it reverts only after the whole batch has been built.
+
+| Salt target | Mainnet | Consequence |
+|---|---|---|
+| `YieldSkimmingTokenizedStrategy` → `0x64E0fC6899b38756A29F601cB148148347d49B4A` | **deployed** (runtime bytecode matches current source exactly) | `runBatch1()` reverts today |
+| `YieldDonatingTokenizedStrategy` → `0x21543116c58FCC8880bD7a7D9DaA5fCCfF8C8b8A` | empty | a separate YieldDonating implementation exists at `0xb27064A2C51b8C5b39A5Bb911AD34DB039C3aB9c` (see `DeployedAddresses.sol`) |
+| Batch 4: Spark / Aave V3 / Rocket Pool | all empty | batch 4 is proposable as-is |
+
+To re-check:
+
+```bash
+cast code <address> --rpc-url $ETH_RPC_URL   # "0x" means free
+```
+
+## What the Safe batch script does
+
+1. **Precomputes addresses** via CREATE2 for every contract in the batch
+2. **Queues each deployment** as a call to the CREATE2 factory with calldata `salt (32 bytes) + creation code`
+3. **Asserts** that each simulated deployment lands on the precomputed address, so signers never
+   approve a payload while reading an address that will not be produced
+4. **Bundles** the calls into one MultiSend transaction (`execTransaction` → `MultiSendCallOnly` → CREATE2 factory)
+5. **Submits** the batch to the Safe backend for signatures
+6. **Logs** a per-batch summary of every address
+
+## Tests
+
+`test/unit/script/DeploymentScripts.t.sol` guards these scripts in CI: salt uniqueness, address
+collision-freedom, that every contract in the batch actually deploys through Nick's factory, that the
+script's precomputed addresses match the real deployments, and that the standalone factory scripts and
+the staging orchestrator are wired correctly.
+
+```bash
+forge test --match-path "test/unit/script/DeploymentScripts.t.sol"
+```
+
+The prod script's own fork verification suite (`VerifyProtocolDeployment`) is excluded from the default
+profile; run it with `FOUNDRY_PROFILE=mainnet forge test --match-contract VerifyProtocolDeployment
+--fork-url <mainnet-rpc>`.

--- a/script/deploy/DeployAaveV3StrategyFactory.sol
+++ b/script/deploy/DeployAaveV3StrategyFactory.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
+
+contract DeployAaveV3StrategyFactory is Script {
+    // Salt for deterministic deployment
+    bytes32 public constant DEPLOYMENT_SALT = keccak256("OCTANT_AAVE_V3_FACTORY_V1");
+
+    AaveV3StrategyFactory public aaveV3StrategyFactory;
+
+    function deploy() public virtual returns (address) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        console.log("Deploying AaveV3StrategyFactory with CREATE2...");
+        console.log("Deployer:", vm.addr(deployerPrivateKey));
+
+        // Deploy using CREATE2 with salt
+        aaveV3StrategyFactory = new AaveV3StrategyFactory{ salt: DEPLOYMENT_SALT }();
+        address factoryAddress = address(aaveV3StrategyFactory);
+
+        console.log("AaveV3StrategyFactory deployed at:", factoryAddress);
+
+        vm.stopBroadcast();
+        return factoryAddress;
+    }
+}

--- a/script/deploy/DeployNewStrategiesAndFactories.s.sol
+++ b/script/deploy/DeployNewStrategiesAndFactories.s.sol
@@ -14,6 +14,9 @@ import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
 import { MorphoCompounderStrategyFactory } from "src/factories/MorphoCompounderStrategyFactory.sol";
 import { SkyCompounderStrategyFactory } from "src/factories/SkyCompounderStrategyFactory.sol";
 import { YearnV3StrategyFactory } from "src/factories/yieldDonating/YearnV3StrategyFactory.sol";
+import { SparkStrategyFactory } from "src/factories/SparkStrategyFactory.sol";
+import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
+import { RocketPoolStrategyFactory } from "src/factories/yieldSkimming/RocketPoolStrategyFactory.sol";
 
 // RegenStaker ecosystem
 import { AddressSetFactory } from "src/factories/AddressSetFactory.sol";
@@ -26,11 +29,12 @@ import { RegenStakerWithoutDelegateSurrogateVotes } from "src/regen/RegenStakerW
  * @title DeployNewStrategiesAndFactories
  * @author Golem Foundation
  * @notice Deploys new tokenized strategies, factories, and RegenStaker infrastructure via Safe multisig
- * @dev Due to the EIP-7825 per-transaction gas limit of 16,777,216 gas (2^24), all 10 contracts
+ * @dev Due to the EIP-7825 per-transaction gas limit of 16,777,216 gas (2^24), all 13 contracts
  *      cannot be deployed in a single transaction. The deployment is split
- *      into three Safe MultiSend batches:
+ *      into four Safe MultiSend batches:
  *
- *      Batch 1 (~12.4M gas): Implementations + PaymentSplitter + YieldSkimming factories (5 contracts)
+ *      Batch 1 (~12.9M gas of contract creation, measured): Implementations + PaymentSplitter
+ *      + YieldSkimming factories (5 contracts)
  *        - YieldSkimmingTokenizedStrategy
  *        - YieldDonatingTokenizedStrategy
  *        - PaymentSplitterFactory
@@ -46,6 +50,12 @@ import { RegenStakerWithoutDelegateSurrogateVotes } from "src/regen/RegenStakerW
  *        - RegenEarningPowerCalculatorFactory
  *        - RegenStakerFactory
  *
+ *      Batch 4 (~6.8M gas of contract creation, measured): Spark, Aave V3, and Rocket Pool
+ *      factories (3 contracts)
+ *        - SparkStrategyFactory
+ *        - AaveV3StrategyFactory
+ *        - RocketPoolStrategyFactory
+ *
  * Usage:
  * ```bash
  * export SAFE_ADDRESS=0x...
@@ -55,7 +65,11 @@ import { RegenStakerWithoutDelegateSurrogateVotes } from "src/regen/RegenStakerW
  * export SENDER=0x...       # must be a Safe owner or delegate
  * export ETH_RPC_URL=https://...
  *
- * # Deploy ALL (three batches, three Safe proposals in sequence: nonce N, N+1, N+2)
+ * # Simulation is the default. Every address assertion runs, but nothing is proposed
+ * # to the Safe transaction service unless SEND=true is set:
+ * export SEND=true
+ *
+ * # Deploy ALL (four batches, four Safe proposals in sequence: nonce N, N+1, N+2, N+3)
  * forge script script/deploy/DeployNewStrategiesAndFactories.s.sol \
  *   --rpc-url $ETH_RPC_URL --ffi --sender $SENDER
  *
@@ -68,6 +82,9 @@ import { RegenStakerWithoutDelegateSurrogateVotes } from "src/regen/RegenStakerW
  *
  * forge script script/deploy/DeployNewStrategiesAndFactories.s.sol \
  *   --sig "runBatch3()" --rpc-url $ETH_RPC_URL --ffi --sender $SENDER
+ *
+ * forge script script/deploy/DeployNewStrategiesAndFactories.s.sol \
+ *   --sig "runBatch4()" --rpc-url $ETH_RPC_URL --ffi --sender $SENDER
  * ```
  */
 contract DeployNewStrategiesAndFactories is Script, BatchScript {
@@ -92,6 +109,12 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
         keccak256("REGEN_EARNING_POWER_CALCULATOR_FACTORY_11022026");
     bytes32 public constant REGEN_STAKER_FACTORY_SALT = keccak256("REGEN_STAKER_FACTORY_11022026");
 
+    // Spark, Aave V3, and Rocket Pool factory salts.
+    // Dated 07072026, not 11022026: these were added after batches 1-3 were proposed.
+    bytes32 public constant SPARK_FACTORY_SALT = keccak256("SPARK_STRATEGY_FACTORY_07072026");
+    bytes32 public constant AAVE_V3_FACTORY_SALT = keccak256("AAVE_V3_STRATEGY_FACTORY_07072026");
+    bytes32 public constant ROCKET_POOL_FACTORY_SALT = keccak256("ROCKET_POOL_STRATEGY_FACTORY_07072026");
+
     // ═══════════════════════════════════════════════════════════════════════
     // DEPLOYED ADDRESSES (computed, logged after deployment)
     // ═══════════════════════════════════════════════════════════════════════
@@ -112,6 +135,11 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
     address public earningPowerCalculatorFactory;
     address public regenStakerFactory;
 
+    // Batch 4
+    address public sparkFactory;
+    address public aaveV3Factory;
+    address public rocketPoolFactory;
+
     address public safe;
 
     function setUp() public {
@@ -119,15 +147,29 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
         console.log("Using Safe:", safe);
     }
 
+    /// @dev SEND=true submits to the Safe API. Default is simulate-only.
+    function _shouldSend() internal view returns (bool) {
+        return vm.envOr("SEND", false);
+    }
+
+    /// @dev Never print "sent" after a simulation run.
+    function _logSendStatus() internal view {
+        if (_shouldSend()) {
+            console.log("Transaction sent to Safe for signing.\n");
+        } else {
+            console.log("SIMULATION ONLY -- nothing sent. Re-run with SEND=true to submit.\n");
+        }
+    }
+
     // ═══════════════════════════════════════════════════════════════════════
-    // RUN ALL: Proposes all batches as three Safe transactions (nonce N, N+1, N+2)
+    // RUN ALL: Proposes all batches as four Safe transactions (nonce N .. N+3)
     // ═══════════════════════════════════════════════════════════════════════
 
     function run() public isBatch(safe) {
         // --- Batch 1 ---
         _calculateBatch1Addresses();
         _addBatch1Deployments();
-        executeBatch(true);
+        executeBatch(_shouldSend());
         _logBatch1Summary();
 
         // Clear the transaction queue for batch 2
@@ -136,7 +178,7 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
         // --- Batch 2 ---
         _calculateBatch2Addresses();
         _addBatch2Deployments();
-        executeBatch(true);
+        executeBatch(_shouldSend());
         _logBatch2Summary();
 
         // Clear the transaction queue for batch 3
@@ -145,21 +187,30 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
         // --- Batch 3 ---
         _calculateBatch3Addresses();
         _addBatch3Deployments();
-        executeBatch(true);
+        executeBatch(_shouldSend());
         _logBatch3Summary();
+
+        // Clear the transaction queue for batch 4
+        delete encodedTxns;
+
+        // --- Batch 4 ---
+        _calculateBatch4Addresses();
+        _addBatch4Deployments();
+        executeBatch(_shouldSend());
+        _logBatch4Summary();
 
         _logFullSummary();
     }
 
     // ═══════════════════════════════════════════════════════════════════════
     // BATCH 1: Implementations + PaymentSplitter + YieldSkimming factories
-    // Estimated gas: ~12.4M (under 16.78M EIP-7825 limit)
+    // ~12.9M creation gas measured -- tightest batch. Safe overhead sits on top of it.
     // ═══════════════════════════════════════════════════════════════════════
 
     function runBatch1() external isBatch(safe) {
         _calculateBatch1Addresses();
         _addBatch1Deployments();
-        executeBatch(true);
+        executeBatch(_shouldSend());
         _logBatch1Summary();
     }
 
@@ -170,7 +221,7 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
     function runBatch2() external isBatch(safe) {
         _calculateBatch2Addresses();
         _addBatch2Deployments();
-        executeBatch(true);
+        executeBatch(_shouldSend());
         _logBatch2Summary();
     }
 
@@ -182,8 +233,19 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
     function runBatch3() external isBatch(safe) {
         _calculateBatch3Addresses();
         _addBatch3Deployments();
-        executeBatch(true);
+        executeBatch(_shouldSend());
         _logBatch3Summary();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // BATCH 4: Spark, Aave V3, and Rocket Pool factories
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function runBatch4() external isBatch(safe) {
+        _calculateBatch4Addresses();
+        _addBatch4Deployments();
+        executeBatch(_shouldSend());
+        _logBatch4Summary();
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -247,52 +309,96 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
         );
     }
 
+    function _calculateBatch4Addresses() internal {
+        sparkFactory = _computeCreate2AddressViaFactory(
+            SPARK_FACTORY_SALT,
+            keccak256(type(SparkStrategyFactory).creationCode)
+        );
+        aaveV3Factory = _computeCreate2AddressViaFactory(
+            AAVE_V3_FACTORY_SALT,
+            keccak256(type(AaveV3StrategyFactory).creationCode)
+        );
+        rocketPoolFactory = _computeCreate2AddressViaFactory(
+            ROCKET_POOL_FACTORY_SALT,
+            keccak256(type(RocketPoolStrategyFactory).creationCode)
+        );
+    }
+
     // ═══════════════════════════════════════════════════════════════════════
     // BATCH DEPLOYMENT LOGIC
     // ═══════════════════════════════════════════════════════════════════════
 
+    /// @dev Fails if the queued deployment lands anywhere other than the address
+    ///      _calculateBatchNAddresses() precomputed and the summary logs show.
+    function _addAndAssert(bytes32 salt, bytes memory creationCode, address expected, string memory label) internal {
+        address deployed = _addCreate2Deployment(salt, creationCode);
+        require(deployed == expected, string.concat(label, ": address mismatch"));
+        console.log(string.concat("- ", label, ":"), deployed);
+    }
+
     function _addBatch1Deployments() internal {
         console.log("\n=== BATCH 1: Implementations + YieldSkimming Factories ===\n");
 
-        _addCreate2Deployment(YIELD_SKIMMING_SALT, type(YieldSkimmingTokenizedStrategy).creationCode);
-        console.log("- YieldSkimmingTokenizedStrategy:", yieldSkimmingStrategy);
-
-        _addCreate2Deployment(YIELD_DONATING_SALT, type(YieldDonatingTokenizedStrategy).creationCode);
-        console.log("- YieldDonatingTokenizedStrategy:", yieldDonatingStrategy);
-
-        _addCreate2Deployment(PAYMENT_SPLITTER_FACTORY_SALT, type(PaymentSplitterFactory).creationCode);
-        console.log("- PaymentSplitterFactory:", paymentSplitterFactory);
-
-        _addCreate2Deployment(LIDO_FACTORY_SALT, type(LidoStrategyFactory).creationCode);
-        console.log("- LidoStrategyFactory:", lidoFactory);
-
-        _addCreate2Deployment(MORPHO_FACTORY_SALT, type(MorphoCompounderStrategyFactory).creationCode);
-        console.log("- MorphoCompounderStrategyFactory:", morphoFactory);
+        _addAndAssert(
+            YIELD_SKIMMING_SALT,
+            type(YieldSkimmingTokenizedStrategy).creationCode,
+            yieldSkimmingStrategy,
+            "YieldSkimmingTokenizedStrategy"
+        );
+        _addAndAssert(
+            YIELD_DONATING_SALT,
+            type(YieldDonatingTokenizedStrategy).creationCode,
+            yieldDonatingStrategy,
+            "YieldDonatingTokenizedStrategy"
+        );
+        _addAndAssert(
+            PAYMENT_SPLITTER_FACTORY_SALT,
+            type(PaymentSplitterFactory).creationCode,
+            paymentSplitterFactory,
+            "PaymentSplitterFactory"
+        );
+        _addAndAssert(LIDO_FACTORY_SALT, type(LidoStrategyFactory).creationCode, lidoFactory, "LidoStrategyFactory");
+        _addAndAssert(
+            MORPHO_FACTORY_SALT,
+            type(MorphoCompounderStrategyFactory).creationCode,
+            morphoFactory,
+            "MorphoCompounderStrategyFactory"
+        );
     }
 
     function _addBatch2Deployments() internal {
         console.log("\n=== BATCH 2: YieldDonating Factories ===\n");
 
-        _addCreate2Deployment(SKY_FACTORY_SALT, type(SkyCompounderStrategyFactory).creationCode);
-        console.log("- SkyCompounderStrategyFactory:", skyFactory);
-
-        _addCreate2Deployment(YEARN_V3_FACTORY_SALT, type(YearnV3StrategyFactory).creationCode);
-        console.log("- YearnV3StrategyFactory:", yearnV3Factory);
+        _addAndAssert(
+            SKY_FACTORY_SALT,
+            type(SkyCompounderStrategyFactory).creationCode,
+            skyFactory,
+            "SkyCompounderStrategyFactory"
+        );
+        _addAndAssert(
+            YEARN_V3_FACTORY_SALT,
+            type(YearnV3StrategyFactory).creationCode,
+            yearnV3Factory,
+            "YearnV3StrategyFactory"
+        );
     }
 
     function _addBatch3Deployments() internal {
         console.log("\n=== BATCH 3: RegenStaker Infrastructure ===\n");
 
-        _addCreate2Deployment(ADDRESS_SET_FACTORY_SALT, type(AddressSetFactory).creationCode);
-        console.log("- AddressSetFactory:", addressSetFactory);
-
-        _addCreate2Deployment(
-            EARNING_POWER_CALCULATOR_FACTORY_SALT,
-            type(RegenEarningPowerCalculatorFactory).creationCode
+        _addAndAssert(
+            ADDRESS_SET_FACTORY_SALT,
+            type(AddressSetFactory).creationCode,
+            addressSetFactory,
+            "AddressSetFactory"
         );
-        console.log("- RegenEarningPowerCalculatorFactory:", earningPowerCalculatorFactory);
-
-        _addCreate2Deployment(
+        _addAndAssert(
+            EARNING_POWER_CALCULATOR_FACTORY_SALT,
+            type(RegenEarningPowerCalculatorFactory).creationCode,
+            earningPowerCalculatorFactory,
+            "RegenEarningPowerCalculatorFactory"
+        );
+        _addAndAssert(
             REGEN_STAKER_FACTORY_SALT,
             abi.encodePacked(
                 type(RegenStakerFactory).creationCode,
@@ -300,9 +406,33 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
                     keccak256(type(RegenStaker).creationCode),
                     keccak256(type(RegenStakerWithoutDelegateSurrogateVotes).creationCode)
                 )
-            )
+            ),
+            regenStakerFactory,
+            "RegenStakerFactory"
         );
-        console.log("- RegenStakerFactory:", regenStakerFactory);
+    }
+
+    function _addBatch4Deployments() internal {
+        console.log("\n=== BATCH 4: Spark, Aave V3, and Rocket Pool Factories ===\n");
+
+        _addAndAssert(
+            SPARK_FACTORY_SALT,
+            type(SparkStrategyFactory).creationCode,
+            sparkFactory,
+            "SparkStrategyFactory"
+        );
+        _addAndAssert(
+            AAVE_V3_FACTORY_SALT,
+            type(AaveV3StrategyFactory).creationCode,
+            aaveV3Factory,
+            "AaveV3StrategyFactory"
+        );
+        _addAndAssert(
+            ROCKET_POOL_FACTORY_SALT,
+            type(RocketPoolStrategyFactory).creationCode,
+            rocketPoolFactory,
+            "RocketPoolStrategyFactory"
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -318,7 +448,7 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
         console.log("  PaymentSplitterFactory:", paymentSplitterFactory);
         console.log("  LidoStrategyFactory:", lidoFactory);
         console.log("  MorphoCompounderStrategyFactory:", morphoFactory);
-        console.log("Transaction sent to Safe for signing.\n");
+        _logSendStatus();
     }
 
     function _logBatch2Summary() internal view {
@@ -327,7 +457,7 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
         console.log("Contracts: 2 (nonce N+1)");
         console.log("  SkyCompounderStrategyFactory:", skyFactory);
         console.log("  YearnV3StrategyFactory:", yearnV3Factory);
-        console.log("Transaction sent to Safe for signing.\n");
+        _logSendStatus();
     }
 
     function _logBatch3Summary() internal view {
@@ -337,14 +467,28 @@ contract DeployNewStrategiesAndFactories is Script, BatchScript {
         console.log("  AddressSetFactory:", addressSetFactory);
         console.log("  RegenEarningPowerCalculatorFactory:", earningPowerCalculatorFactory);
         console.log("  RegenStakerFactory:", regenStakerFactory);
-        console.log("Transaction sent to Safe for signing.\n");
+        _logSendStatus();
     }
 
-    function _logFullSummary() internal pure {
+    function _logBatch4Summary() internal view {
+        console.log("\n=== BATCH 4 SUMMARY ===");
+        console.log("Safe Address:", safe);
+        console.log("Contracts: 3 (nonce N+3)");
+        console.log("  SparkStrategyFactory:", sparkFactory);
+        console.log("  AaveV3StrategyFactory:", aaveV3Factory);
+        console.log("  RocketPoolStrategyFactory:", rocketPoolFactory);
+        _logSendStatus();
+    }
+
+    function _logFullSummary() internal view {
         console.log("=== FULL DEPLOYMENT SUMMARY ===");
-        console.log("Total contracts: 10 across 3 Safe transactions");
-        console.log("All transactions proposed to Safe for signing.");
-        console.log("Execute batch 1, then batch 2, then batch 3.");
+        console.log("Total contracts: 13 across 4 Safe transactions");
+        console.log(
+            _shouldSend()
+                ? "All transactions proposed to Safe for signing."
+                : "SIMULATION ONLY -- nothing proposed. Re-run with SEND=true to submit."
+        );
+        console.log("Execute batch 1, then batch 2, then batch 3, then batch 4.");
         console.log("================================\n");
     }
 }

--- a/script/deploy/DeploySparkStrategyFactory.sol
+++ b/script/deploy/DeploySparkStrategyFactory.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import { Script } from "forge-std/Script.sol";
+import { console } from "forge-std/console.sol";
+import { SparkStrategyFactory } from "src/factories/SparkStrategyFactory.sol";
+
+contract DeploySparkStrategyFactory is Script {
+    // Salt for deterministic deployment
+    bytes32 public constant DEPLOYMENT_SALT = keccak256("OCTANT_SPARK_FACTORY_V1");
+
+    SparkStrategyFactory public sparkStrategyFactory;
+
+    function deploy() public virtual returns (address) {
+        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+        vm.startBroadcast(deployerPrivateKey);
+
+        console.log("Deploying SparkStrategyFactory with CREATE2...");
+        console.log("Deployer:", vm.addr(deployerPrivateKey));
+
+        // Deploy using CREATE2 with salt
+        sparkStrategyFactory = new SparkStrategyFactory{ salt: DEPLOYMENT_SALT }();
+        address factoryAddress = address(sparkStrategyFactory);
+
+        console.log("SparkStrategyFactory deployed at:", factoryAddress);
+
+        vm.stopBroadcast();
+        return factoryAddress;
+    }
+}

--- a/script/deployment/staging/DeployProtocol.s.sol
+++ b/script/deployment/staging/DeployProtocol.s.sol
@@ -11,6 +11,9 @@ import { DeployMorphoCompounderStrategyFactory } from "script/deploy/DeployMorph
 import { DeployAllocationMechanismFactory } from "script/deploy/DeployAllocationMechanismFactory.sol";
 import { DeployYearnV3StrategyFactory } from "script/deploy/DeployYearnV3StrategyFactory.s.sol";
 import { DeployLidoStrategyFactory } from "script/deploy/DeployLidoStrategyFactory.sol";
+import { DeploySparkStrategyFactory } from "script/deploy/DeploySparkStrategyFactory.sol";
+import { DeployAaveV3StrategyFactory } from "script/deploy/DeployAaveV3StrategyFactory.sol";
+import { DeployRocketPoolStrategyFactory } from "script/deploy/DeployRocketPoolStrategyFactory.sol";
 import { DeployedAddresses } from "script/helpers/DeployedAddresses.sol";
 
 /**
@@ -27,6 +30,9 @@ contract DeployProtocol is Script {
     DeployAllocationMechanismFactory public deployAllocationMechanismFactory;
     DeployYearnV3StrategyFactory public deployYearnV3StrategyFactory;
     DeployLidoStrategyFactory public deployLidoStrategyFactory;
+    DeploySparkStrategyFactory public deploySparkStrategyFactory;
+    DeployAaveV3StrategyFactory public deployAaveV3StrategyFactory;
+    DeployRocketPoolStrategyFactory public deployRocketPoolStrategyFactory;
 
     // Address registry for network-specific deployments
     DeployedAddresses public immutable deployedAddresses;
@@ -42,6 +48,9 @@ contract DeployProtocol is Script {
     address public yieldDonatingTokenizedStrategyAddress;
     address public yearnV3StrategyFactoryAddress;
     address public lidoStrategyFactoryAddress;
+    address public sparkStrategyFactoryAddress;
+    address public aaveV3StrategyFactoryAddress;
+    address public rocketPoolStrategyFactoryAddress;
 
     error DeploymentFailed();
 
@@ -62,6 +71,9 @@ contract DeployProtocol is Script {
         deployAllocationMechanismFactory = new DeployAllocationMechanismFactory();
         deployYearnV3StrategyFactory = new DeployYearnV3StrategyFactory();
         deployLidoStrategyFactory = new DeployLidoStrategyFactory();
+        deploySparkStrategyFactory = new DeploySparkStrategyFactory();
+        deployAaveV3StrategyFactory = new DeployAaveV3StrategyFactory();
+        deployRocketPoolStrategyFactory = new DeployRocketPoolStrategyFactory();
     }
 
     /**
@@ -82,6 +94,9 @@ contract DeployProtocol is Script {
         yieldDonatingTokenizedStrategyAddress = addresses.yieldDonatingTokenizedStrategy;
         yearnV3StrategyFactoryAddress = addresses.yearnV3StrategyFactory;
         lidoStrategyFactoryAddress = addresses.lidoStrategyFactory;
+        sparkStrategyFactoryAddress = addresses.sparkStrategyFactory;
+        aaveV3StrategyFactoryAddress = addresses.aaveV3StrategyFactory;
+        rocketPoolStrategyFactoryAddress = addresses.rocketPoolStrategyFactory;
     }
 
     // This entrypoint intentionally coordinates multiple conditional deployments.
@@ -151,6 +166,24 @@ contract DeployProtocol is Script {
             if (lidoStrategyFactoryAddress == address(0)) revert DeploymentFailed();
         }
 
+        // Deploy Spark Strategy Factory
+        if (sparkStrategyFactoryAddress == address(0)) {
+            sparkStrategyFactoryAddress = deploySparkStrategyFactory.deploy();
+            if (sparkStrategyFactoryAddress == address(0)) revert DeploymentFailed();
+        }
+
+        // Deploy Aave V3 Strategy Factory
+        if (aaveV3StrategyFactoryAddress == address(0)) {
+            aaveV3StrategyFactoryAddress = deployAaveV3StrategyFactory.deploy();
+            if (aaveV3StrategyFactoryAddress == address(0)) revert DeploymentFailed();
+        }
+
+        // Deploy Rocket Pool Strategy Factory
+        if (rocketPoolStrategyFactoryAddress == address(0)) {
+            rocketPoolStrategyFactoryAddress = deployRocketPoolStrategyFactory.deploy();
+            if (rocketPoolStrategyFactoryAddress == address(0)) revert DeploymentFailed();
+        }
+
         // Log deployment addresses
         console2.log("\nDeployment Summary:");
         console2.log("------------------");
@@ -163,6 +196,9 @@ contract DeployProtocol is Script {
         console2.log("Allocation Mechanism Factory:             ", allocationMechanismFactoryAddress);
         console2.log("Yearn V3 Strategy Factory:                ", yearnV3StrategyFactoryAddress);
         console2.log("Lido Strategy Factory:                    ", lidoStrategyFactoryAddress);
+        console2.log("Spark Strategy Factory:                   ", sparkStrategyFactoryAddress);
+        console2.log("Aave V3 Strategy Factory:                 ", aaveV3StrategyFactoryAddress);
+        console2.log("Rocket Pool Strategy Factory:             ", rocketPoolStrategyFactoryAddress);
         console2.log("------------------");
 
         string memory contractAddressFilename = "./contract_addresses.txt";
@@ -207,6 +243,18 @@ contract DeployProtocol is Script {
         vm.writeLine(
             contractAddressFilename,
             string.concat("LIDO_STRATEGY_FACTORY_ADDRESS=", vm.toString(lidoStrategyFactoryAddress))
+        );
+        vm.writeLine(
+            contractAddressFilename,
+            string.concat("SPARK_STRATEGY_FACTORY_ADDRESS=", vm.toString(sparkStrategyFactoryAddress))
+        );
+        vm.writeLine(
+            contractAddressFilename,
+            string.concat("AAVE_V3_STRATEGY_FACTORY_ADDRESS=", vm.toString(aaveV3StrategyFactoryAddress))
+        );
+        vm.writeLine(
+            contractAddressFilename,
+            string.concat("ROCKET_POOL_STRATEGY_FACTORY_ADDRESS=", vm.toString(rocketPoolStrategyFactoryAddress))
         );
     }
 }

--- a/script/deployment/staging/README.md
+++ b/script/deployment/staging/README.md
@@ -15,8 +15,21 @@ The DeployProtocol script handles the sequential deployment of:
 7. Payment Splitter Factory (conditional)
 8. Sky Compounder Strategy Factory (conditional)
 9. Morpho Compounder Strategy Factory (conditional)
-10. Regen Staker Factory
+10. Regen Staker Factory (must be pre-deployed via Safe; the script reverts otherwise)
 11. Allocation Mechanism Factory
+12. Yearn V3 Strategy Factory (conditional)
+13. Lido Strategy Factory (conditional)
+14. Spark Strategy Factory (conditional)
+15. Aave V3 Strategy Factory (conditional)
+16. Rocket Pool Strategy Factory (conditional)
+
+"Conditional" means the script deploys the contract only when its entry in
+`script/helpers/DeployedAddresses.sol` is `address(0)` for the selected network.
+Each address is appended to `./contract_addresses.txt` after the run.
+
+For the Safe-multisig deployment path (staging or production) see
+[`script/deploy/DEPLOYMENT_GUIDE.md`](../../deploy/DEPLOYMENT_GUIDE.md) — this script deploys
+from a plain EOA and produces different CREATE2 addresses than the Safe batches.
 
 ### Smart Deployment with Address Reuse
 

--- a/script/helpers/BatchScript.sol
+++ b/script/helpers/BatchScript.sol
@@ -176,6 +176,17 @@ abstract contract BatchScript is Script {
         if (success) {
             return data;
         } else {
+            // Nick's CREATE2 factory reverts with empty returndata when the target is
+            // already deployed, which would otherwise surface with no message at all.
+            if (data.length == 0) {
+                revert(
+                    string.concat(
+                        "BatchScript: call to ",
+                        vm.toString(to_),
+                        " reverted without a reason (for a CREATE2 deployment this usually means the target is already deployed)"
+                    )
+                );
+            }
             revert(string(data));
         }
     }

--- a/script/helpers/DeployedAddresses.sol
+++ b/script/helpers/DeployedAddresses.sol
@@ -38,6 +38,9 @@ contract DeployedAddresses is Script {
         address yieldDonatingTokenizedStrategy;
         address yearnV3StrategyFactory;
         address lidoStrategyFactory;
+        address sparkStrategyFactory;
+        address aaveV3StrategyFactory;
+        address rocketPoolStrategyFactory;
         // AddressSet Factory and Contracts (for allowlists/blocklists)
         address addressSetFactory;
         address stakerAllowset;
@@ -90,6 +93,9 @@ contract DeployedAddresses is Script {
                 yieldDonatingTokenizedStrategy: 0xb27064A2C51b8C5b39A5Bb911AD34DB039C3aB9c,
                 yearnV3StrategyFactory: 0x6D8c4E4A158083E30B53ba7df3cFB885fC096fF6,
                 lidoStrategyFactory: address(0),
+                sparkStrategyFactory: address(0),
+                aaveV3StrategyFactory: address(0),
+                rocketPoolStrategyFactory: address(0),
                 // AddressSet factory and contracts - to be deployed
                 addressSetFactory: 0x908FA1747a5E12708c0e575875F2685750CFEfD1,
                 stakerAllowset: 0x4FFAb2c015d9dCd5D20d489E644D99ae67a57270,
@@ -118,6 +124,9 @@ contract DeployedAddresses is Script {
                 yieldDonatingTokenizedStrategy: address(0),
                 yearnV3StrategyFactory: address(0),
                 lidoStrategyFactory: address(0),
+                sparkStrategyFactory: address(0),
+                aaveV3StrategyFactory: address(0),
+                rocketPoolStrategyFactory: address(0),
                 addressSetFactory: address(0),
                 stakerAllowset: address(0),
                 stakerBlockset: address(0),
@@ -147,6 +156,9 @@ contract DeployedAddresses is Script {
                 yieldDonatingTokenizedStrategy: 0xb27064A2C51b8C5b39A5Bb911AD34DB039C3aB9c,
                 yearnV3StrategyFactory: 0x6D8c4E4A158083E30B53ba7df3cFB885fC096fF6,
                 lidoStrategyFactory: address(0),
+                sparkStrategyFactory: address(0),
+                aaveV3StrategyFactory: address(0),
+                rocketPoolStrategyFactory: address(0),
                 // AddressSet factory and contracts - deploy fresh (protocol-specific)
                 addressSetFactory: 0x908FA1747a5E12708c0e575875F2685750CFEfD1,
                 stakerAllowset: address(0),
@@ -175,6 +187,9 @@ contract DeployedAddresses is Script {
                 yieldDonatingTokenizedStrategy: address(0),
                 yearnV3StrategyFactory: address(0),
                 lidoStrategyFactory: address(0),
+                sparkStrategyFactory: address(0),
+                aaveV3StrategyFactory: address(0),
+                rocketPoolStrategyFactory: address(0),
                 addressSetFactory: address(0),
                 stakerAllowset: address(0),
                 stakerBlockset: address(0),

--- a/script/prod/DeployProtocol.s.sol
+++ b/script/prod/DeployProtocol.s.sol
@@ -18,6 +18,9 @@ import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
 import { MorphoCompounderStrategyFactory } from "src/factories/MorphoCompounderStrategyFactory.sol";
 import { SkyCompounderStrategyFactory } from "src/factories/SkyCompounderStrategyFactory.sol";
 import { YearnV3StrategyFactory } from "src/factories/yieldDonating/YearnV3StrategyFactory.sol";
+import { SparkStrategyFactory } from "src/factories/SparkStrategyFactory.sol";
+import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
+import { RocketPoolStrategyFactory } from "src/factories/yieldSkimming/RocketPoolStrategyFactory.sol";
 import { AddressSetFactory } from "src/factories/AddressSetFactory.sol";
 import { RegenEarningPowerCalculatorFactory } from "src/factories/RegenEarningPowerCalculatorFactory.sol";
 import { RegenStakerFactory } from "src/factories/RegenStakerFactory.sol";
@@ -67,14 +70,14 @@ uint256 constant REWARD_DURATION = 30 days;
 ///         resolved at runtime:
 ///           - SAFE_ADDRESS (env var, required) -- target Gnosis Safe
 ///           - SALT_TIMESTAMP (env var, optional) -- suffix for CREATE2 salts
-///             Auto-generated via `date -u +%H%d%m%Y` if not set.
+///             Auto-generated via `date -u +%H_%d%m%Y` if not set.
 ///           - Expected addresses computed from salts + safe at runtime.
 ///
-///         The deployment is structured as 7 Gnosis Safe transactions:
-///           Phase A (Tx 1-3): 10 factory/implementation contracts via Nick's CREATE2
-///           Phase B (Tx 4-7): 3 address sets + calculator + staker + staker access set assignment
+///         The deployment is structured as 8 Gnosis Safe transactions:
+///           Phase A (Tx 1-4): 13 factory/implementation contracts via Nick's CREATE2
+///           Phase B (Tx 5-8): 3 address sets + calculator + staker + staker access set assignment
 ///                             Staker is constructed with address(0) for allowset/blockset,
-///                             then assigned post-construction via admin setters in Tx 7
+///                             then assigned post-construction via admin setters in Tx 8
 ///                             (accessMode=NONE, so they are initially inactive).
 ///
 ///         Replay on a fork (simulation only, default):
@@ -101,6 +104,9 @@ contract DeployProtocol is Script, BatchScript {
     bytes32 internal _morphoFactorySalt;
     bytes32 internal _skyFactorySalt;
     bytes32 internal _yearnV3FactorySalt;
+    bytes32 internal _sparkFactorySalt;
+    bytes32 internal _aaveV3FactorySalt;
+    bytes32 internal _rocketPoolFactorySalt;
     bytes32 internal _addressSetFactorySalt;
     bytes32 internal _calcFactorySalt;
     bytes32 internal _stakerFactorySalt;
@@ -116,7 +122,7 @@ contract DeployProtocol is Script, BatchScript {
     //  INITIALIZATION
     // ═════════════════════════════════════════════════════════════════════════
 
-    /// @dev Resolves SAFE_ADDRESS and SALT_TIMESTAMP from env, computes all 15
+    /// @dev Resolves SAFE_ADDRESS and SALT_TIMESTAMP from env, computes all 18
     ///      salts, and logs the full deployment configuration. Guarded by
     ///      _initialized to run exactly once.
     function _initialize() internal {
@@ -139,6 +145,9 @@ contract DeployProtocol is Script, BatchScript {
         _morphoFactorySalt = keccak256(abi.encodePacked("MORPHO_COMPOUNDER_FACTORY_", _saltTimestamp));
         _skyFactorySalt = keccak256(abi.encodePacked("SKY_COMPOUNDER_FACTORY_", _saltTimestamp));
         _yearnV3FactorySalt = keccak256(abi.encodePacked("YEARN_V3_STRATEGY_FACTORY_", _saltTimestamp));
+        _sparkFactorySalt = keccak256(abi.encodePacked("SPARK_STRATEGY_FACTORY_", _saltTimestamp));
+        _aaveV3FactorySalt = keccak256(abi.encodePacked("AAVE_V3_STRATEGY_FACTORY_", _saltTimestamp));
+        _rocketPoolFactorySalt = keccak256(abi.encodePacked("ROCKET_POOL_STRATEGY_FACTORY_", _saltTimestamp));
         _addressSetFactorySalt = keccak256(abi.encodePacked("ADDRESS_SET_FACTORY_", _saltTimestamp));
         _calcFactorySalt = keccak256(abi.encodePacked("REGEN_EARNING_POWER_CALCULATOR_FACTORY_", _saltTimestamp));
         _stakerFactorySalt = keccak256(abi.encodePacked("REGEN_STAKER_FACTORY_", _saltTimestamp));
@@ -190,6 +199,61 @@ contract DeployProtocol is Script, BatchScript {
     ///      (simulation only). Set SEND=true for production Safe API submission.
     function _shouldSend() internal view returns (bool) {
         return vm.envOr("SEND", false);
+    }
+
+    /// @dev `expected` must come from the same helper _logPhaseAAddresses() prints, so the
+    ///      address an operator reviews is the address the batch deploys.
+    function _addAndAssert(bytes32 salt, bytes memory creationCode, address expected, string memory label) internal {
+        address deployed = _addCreate2Deployment(salt, creationCode);
+        require(deployed == expected, string.concat(label, ": address mismatch"));
+        console.log(string.concat(label, ":"), deployed);
+    }
+
+    // --- Phase A deterministic addresses (single source of truth per contract) ---
+
+    function _yieldSkimmingAddress() internal view returns (address) {
+        return _computeCreate2AddressViaFactory(_yieldSkimmingSalt, type(YieldSkimmingTokenizedStrategy).creationCode);
+    }
+
+    function _yieldDonatingAddress() internal view returns (address) {
+        return _computeCreate2AddressViaFactory(_yieldDonatingSalt, type(YieldDonatingTokenizedStrategy).creationCode);
+    }
+
+    function _paymentSplitterFactoryAddress() internal view returns (address) {
+        return _computeCreate2AddressViaFactory(_paymentSplitterFactorySalt, type(PaymentSplitterFactory).creationCode);
+    }
+
+    function _lidoFactoryAddress() internal view returns (address) {
+        return _computeCreate2AddressViaFactory(_lidoFactorySalt, type(LidoStrategyFactory).creationCode);
+    }
+
+    function _morphoFactoryAddress() internal view returns (address) {
+        return _computeCreate2AddressViaFactory(_morphoFactorySalt, type(MorphoCompounderStrategyFactory).creationCode);
+    }
+
+    function _skyFactoryAddress() internal view returns (address) {
+        return _computeCreate2AddressViaFactory(_skyFactorySalt, type(SkyCompounderStrategyFactory).creationCode);
+    }
+
+    function _yearnV3FactoryAddress() internal view returns (address) {
+        return _computeCreate2AddressViaFactory(_yearnV3FactorySalt, type(YearnV3StrategyFactory).creationCode);
+    }
+
+    function _sparkFactoryAddress() internal view returns (address) {
+        return _computeCreate2AddressViaFactory(_sparkFactorySalt, type(SparkStrategyFactory).creationCode);
+    }
+
+    function _aaveV3FactoryAddress() internal view returns (address) {
+        return _computeCreate2AddressViaFactory(_aaveV3FactorySalt, type(AaveV3StrategyFactory).creationCode);
+    }
+
+    function _rocketPoolFactoryAddress() internal view returns (address) {
+        return _computeCreate2AddressViaFactory(_rocketPoolFactorySalt, type(RocketPoolStrategyFactory).creationCode);
+    }
+
+    function _calcFactoryAddress() internal view returns (address) {
+        return
+            _computeCreate2AddressViaFactory(_calcFactorySalt, type(RegenEarningPowerCalculatorFactory).creationCode);
     }
 
     /// @dev Computes the deterministic AddressSetFactory address from Phase A.
@@ -263,7 +327,7 @@ contract DeployProtocol is Script, BatchScript {
         return address(uint160(uint256(hash)));
     }
 
-    /// @notice Compute and log all 15 deterministic addresses from CREATE2 math.
+    /// @notice Compute and log all 18 deterministic addresses from CREATE2 math.
     ///         Requires SAFE_ADDRESS env var. Uses SALT_TIMESTAMP if set,
     ///         otherwise auto-generates via FFI.
     ///
@@ -275,39 +339,18 @@ contract DeployProtocol is Script, BatchScript {
     }
 
     function _logPhaseAAddresses() internal view {
-        console.log(
-            "EXPECTED_YIELD_SKIMMING:",
-            _computeCreate2AddressViaFactory(_yieldSkimmingSalt, type(YieldSkimmingTokenizedStrategy).creationCode)
-        );
-        console.log(
-            "EXPECTED_YIELD_DONATING:",
-            _computeCreate2AddressViaFactory(_yieldDonatingSalt, type(YieldDonatingTokenizedStrategy).creationCode)
-        );
-        console.log(
-            "EXPECTED_PAYMENT_SPLITTER_FACTORY:",
-            _computeCreate2AddressViaFactory(_paymentSplitterFactorySalt, type(PaymentSplitterFactory).creationCode)
-        );
-        console.log(
-            "EXPECTED_LIDO_FACTORY:",
-            _computeCreate2AddressViaFactory(_lidoFactorySalt, type(LidoStrategyFactory).creationCode)
-        );
-        console.log(
-            "EXPECTED_MORPHO_FACTORY:",
-            _computeCreate2AddressViaFactory(_morphoFactorySalt, type(MorphoCompounderStrategyFactory).creationCode)
-        );
-        console.log(
-            "EXPECTED_SKY_FACTORY:",
-            _computeCreate2AddressViaFactory(_skyFactorySalt, type(SkyCompounderStrategyFactory).creationCode)
-        );
-        console.log(
-            "EXPECTED_YEARN_FACTORY:",
-            _computeCreate2AddressViaFactory(_yearnV3FactorySalt, type(YearnV3StrategyFactory).creationCode)
-        );
+        console.log("EXPECTED_YIELD_SKIMMING:", _yieldSkimmingAddress());
+        console.log("EXPECTED_YIELD_DONATING:", _yieldDonatingAddress());
+        console.log("EXPECTED_PAYMENT_SPLITTER_FACTORY:", _paymentSplitterFactoryAddress());
+        console.log("EXPECTED_LIDO_FACTORY:", _lidoFactoryAddress());
+        console.log("EXPECTED_MORPHO_FACTORY:", _morphoFactoryAddress());
+        console.log("EXPECTED_SKY_FACTORY:", _skyFactoryAddress());
+        console.log("EXPECTED_YEARN_FACTORY:", _yearnV3FactoryAddress());
+        console.log("EXPECTED_SPARK_FACTORY:", _sparkFactoryAddress());
+        console.log("EXPECTED_AAVE_V3_FACTORY:", _aaveV3FactoryAddress());
+        console.log("EXPECTED_ROCKET_POOL_FACTORY:", _rocketPoolFactoryAddress());
         console.log("EXPECTED_ADDRESS_SET_FACTORY:", _addressSetFactoryAddress());
-        console.log(
-            "EXPECTED_CALC_FACTORY:",
-            _computeCreate2AddressViaFactory(_calcFactorySalt, type(RegenEarningPowerCalculatorFactory).creationCode)
-        );
+        console.log("EXPECTED_CALC_FACTORY:", _calcFactoryAddress());
         console.log("EXPECTED_STAKER_FACTORY:", _stakerFactoryAddress());
     }
 
@@ -321,58 +364,49 @@ contract DeployProtocol is Script, BatchScript {
     }
 
     // ═════════════════════════════════════════════════════════════════════════
-    //  PHASE A: Factory Deployment (3 Safe Transactions)
+    //  PHASE A: Factory Deployment (4 Safe Transactions)
     //
-    //  All 10 contracts deployed via Nick's CREATE2 factory (0x4e59b44...56C).
-    //  Split into 3 batches due to the EIP-7825 per-tx gas limit of ~16.78M.
+    //  All 13 contracts deployed via Nick's CREATE2 factory (0x4e59b44...56C).
+    //  Split into 4 batches due to the EIP-7825 per-tx gas limit of ~16.78M.
     // ═════════════════════════════════════════════════════════════════════════
 
-    /// @notice Tx 1 (~12.4M gas): 5 contracts
+    /// @notice Tx 1 (~12.9M gas of contract creation, measured -- the tightest batch): 5 contracts
     ///         - YieldSkimmingTokenizedStrategy
     ///         - YieldDonatingTokenizedStrategy
     ///         - PaymentSplitterFactory
     ///         - LidoStrategyFactory
     ///         - MorphoCompounderStrategyFactory
     function phaseA_batch1() external isBatch(_initAndGetSafe()) {
-        address deployed;
-        address expected;
-
-        deployed = _addCreate2Deployment(_yieldSkimmingSalt, type(YieldSkimmingTokenizedStrategy).creationCode);
-        expected = _computeCreate2AddressViaFactory(
+        _addAndAssert(
             _yieldSkimmingSalt,
-            type(YieldSkimmingTokenizedStrategy).creationCode
+            type(YieldSkimmingTokenizedStrategy).creationCode,
+            _yieldSkimmingAddress(),
+            "YieldSkimmingTokenizedStrategy"
         );
-        require(deployed == expected, "YieldSkimming address mismatch");
-        console.log("YieldSkimmingTokenizedStrategy:", deployed);
-
-        deployed = _addCreate2Deployment(_yieldDonatingSalt, type(YieldDonatingTokenizedStrategy).creationCode);
-        expected = _computeCreate2AddressViaFactory(
+        _addAndAssert(
             _yieldDonatingSalt,
-            type(YieldDonatingTokenizedStrategy).creationCode
+            type(YieldDonatingTokenizedStrategy).creationCode,
+            _yieldDonatingAddress(),
+            "YieldDonatingTokenizedStrategy"
         );
-        require(deployed == expected, "YieldDonating address mismatch");
-        console.log("YieldDonatingTokenizedStrategy:", deployed);
-
-        deployed = _addCreate2Deployment(_paymentSplitterFactorySalt, type(PaymentSplitterFactory).creationCode);
-        expected = _computeCreate2AddressViaFactory(
+        _addAndAssert(
             _paymentSplitterFactorySalt,
-            type(PaymentSplitterFactory).creationCode
+            type(PaymentSplitterFactory).creationCode,
+            _paymentSplitterFactoryAddress(),
+            "PaymentSplitterFactory"
         );
-        require(deployed == expected, "PaymentSplitterFactory address mismatch");
-        console.log("PaymentSplitterFactory:", deployed);
-
-        deployed = _addCreate2Deployment(_lidoFactorySalt, type(LidoStrategyFactory).creationCode);
-        expected = _computeCreate2AddressViaFactory(_lidoFactorySalt, type(LidoStrategyFactory).creationCode);
-        require(deployed == expected, "LidoStrategyFactory address mismatch");
-        console.log("LidoStrategyFactory:", deployed);
-
-        deployed = _addCreate2Deployment(_morphoFactorySalt, type(MorphoCompounderStrategyFactory).creationCode);
-        expected = _computeCreate2AddressViaFactory(
+        _addAndAssert(
+            _lidoFactorySalt,
+            type(LidoStrategyFactory).creationCode,
+            _lidoFactoryAddress(),
+            "LidoStrategyFactory"
+        );
+        _addAndAssert(
             _morphoFactorySalt,
-            type(MorphoCompounderStrategyFactory).creationCode
+            type(MorphoCompounderStrategyFactory).creationCode,
+            _morphoFactoryAddress(),
+            "MorphoCompounderStrategyFactory"
         );
-        require(deployed == expected, "MorphoCompounderStrategyFactory address mismatch");
-        console.log("MorphoCompounderStrategyFactory:", deployed);
 
         executeBatch(_shouldSend());
     }
@@ -381,18 +415,18 @@ contract DeployProtocol is Script, BatchScript {
     ///         - SkyCompounderStrategyFactory
     ///         - YearnV3StrategyFactory
     function phaseA_batch2() external isBatch(_initAndGetSafe()) {
-        address deployed;
-        address expected;
-
-        deployed = _addCreate2Deployment(_skyFactorySalt, type(SkyCompounderStrategyFactory).creationCode);
-        expected = _computeCreate2AddressViaFactory(_skyFactorySalt, type(SkyCompounderStrategyFactory).creationCode);
-        require(deployed == expected, "SkyFactory address mismatch");
-        console.log("SkyCompounderStrategyFactory:", deployed);
-
-        deployed = _addCreate2Deployment(_yearnV3FactorySalt, type(YearnV3StrategyFactory).creationCode);
-        expected = _computeCreate2AddressViaFactory(_yearnV3FactorySalt, type(YearnV3StrategyFactory).creationCode);
-        require(deployed == expected, "YearnFactory address mismatch");
-        console.log("YearnV3StrategyFactory:", deployed);
+        _addAndAssert(
+            _skyFactorySalt,
+            type(SkyCompounderStrategyFactory).creationCode,
+            _skyFactoryAddress(),
+            "SkyCompounderStrategyFactory"
+        );
+        _addAndAssert(
+            _yearnV3FactorySalt,
+            type(YearnV3StrategyFactory).creationCode,
+            _yearnV3FactoryAddress(),
+            "YearnV3StrategyFactory"
+        );
 
         executeBatch(_shouldSend());
     }
@@ -402,23 +436,19 @@ contract DeployProtocol is Script, BatchScript {
     ///         - RegenEarningPowerCalculatorFactory
     ///         - RegenStakerFactory (constructor: canonical bytecode hashes)
     function phaseA_batch3() external isBatch(_initAndGetSafe()) {
-        address deployed;
-        address expected;
-
-        deployed = _addCreate2Deployment(_addressSetFactorySalt, type(AddressSetFactory).creationCode);
-        expected = _addressSetFactoryAddress();
-        require(deployed == expected, "AddressSetFactory address mismatch");
-        console.log("AddressSetFactory:", deployed);
-
-        deployed = _addCreate2Deployment(_calcFactorySalt, type(RegenEarningPowerCalculatorFactory).creationCode);
-        expected = _computeCreate2AddressViaFactory(
-            _calcFactorySalt,
-            type(RegenEarningPowerCalculatorFactory).creationCode
+        _addAndAssert(
+            _addressSetFactorySalt,
+            type(AddressSetFactory).creationCode,
+            _addressSetFactoryAddress(),
+            "AddressSetFactory"
         );
-        require(deployed == expected, "CalcFactory address mismatch");
-        console.log("RegenEarningPowerCalculatorFactory:", deployed);
-
-        deployed = _addCreate2Deployment(
+        _addAndAssert(
+            _calcFactorySalt,
+            type(RegenEarningPowerCalculatorFactory).creationCode,
+            _calcFactoryAddress(),
+            "RegenEarningPowerCalculatorFactory"
+        );
+        _addAndAssert(
             _stakerFactorySalt,
             abi.encodePacked(
                 type(RegenStakerFactory).creationCode,
@@ -426,11 +456,36 @@ contract DeployProtocol is Script, BatchScript {
                     keccak256(REGEN_STAKER_V1_CREATION_CODE),
                     keccak256(REGEN_STAKER_WITHOUT_DELEGATION_V1_CREATION_CODE)
                 )
-            )
+            ),
+            _stakerFactoryAddress(),
+            "RegenStakerFactory"
         );
-        expected = _stakerFactoryAddress();
-        require(deployed == expected, "StakerFactory address mismatch");
-        console.log("RegenStakerFactory:", deployed);
+
+        executeBatch(_shouldSend());
+    }
+
+    /// @notice Tx 4 (~6.8M gas): SparkStrategyFactory, AaveV3StrategyFactory,
+    ///         RocketPoolStrategyFactory. No constructor args and the tokenized strategy
+    ///         is a createStrategy() parameter, so this batch does not depend on batch 1.
+    function phaseA_batch4() external isBatch(_initAndGetSafe()) {
+        _addAndAssert(
+            _sparkFactorySalt,
+            type(SparkStrategyFactory).creationCode,
+            _sparkFactoryAddress(),
+            "SparkStrategyFactory"
+        );
+        _addAndAssert(
+            _aaveV3FactorySalt,
+            type(AaveV3StrategyFactory).creationCode,
+            _aaveV3FactoryAddress(),
+            "AaveV3StrategyFactory"
+        );
+        _addAndAssert(
+            _rocketPoolFactorySalt,
+            type(RocketPoolStrategyFactory).creationCode,
+            _rocketPoolFactoryAddress(),
+            "RocketPoolStrategyFactory"
+        );
 
         executeBatch(_shouldSend());
     }
@@ -441,10 +496,10 @@ contract DeployProtocol is Script, BatchScript {
     //  Requires Phase A factories to be deployed and executed on-chain first.
     //  Deploys 3 address sets, the earning power calculator, and the staker.
     //  The staker is constructed with address(0) for allowset/blockset, then
-    //  assigned post-construction via admin setters in Tx 7.
+    //  assigned post-construction via admin setters in Tx 8.
     // ═════════════════════════════════════════════════════════════════════════
 
-    /// @notice Tx 4: Deploy all 3 address sets via AddressSetFactory
+    /// @notice Tx 5: Deploy all 3 address sets via AddressSetFactory
     ///         - allocationMechanismAllowset
     ///         - stakerAllowset
     ///         - stakerBlockset
@@ -490,7 +545,7 @@ contract DeployProtocol is Script, BatchScript {
         executeBatch(_shouldSend());
     }
 
-    /// @notice Tx 5: Deploy RegenEarningPowerCalculator via Nick's CREATE2 factory
+    /// @notice Tx 6: Deploy RegenEarningPowerCalculator via Nick's CREATE2 factory
     ///         Constructor args: owner=Safe, allowset=0, blockset=0, accessMode=NONE
     ///         Batched as a single Safe transaction. Address assertion runs before
     ///         the batch is submitted.
@@ -508,9 +563,9 @@ contract DeployProtocol is Script, BatchScript {
         executeBatch(_shouldSend());
     }
 
-    /// @notice Tx 6: Deploy RegenStaker (WITHOUT delegation) via RegenStakerFactory
+    /// @notice Tx 7: Deploy RegenStaker (WITHOUT delegation) via RegenStakerFactory
     ///         Staker is constructed with address(0) for stakerAllowset and
-    ///         stakerBlockset. These are assigned post-construction in Tx 7.
+    ///         stakerBlockset. These are assigned post-construction in Tx 8.
     ///         accessMode is set to NONE so the sets are initially inactive.
     ///         Batched as a single Safe transaction. Address assertion runs
     ///         before the batch is submitted.
@@ -547,9 +602,9 @@ contract DeployProtocol is Script, BatchScript {
         executeBatch(_shouldSend());
     }
 
-    /// @notice Tx 7: Assign staker allowset and blockset via admin setters.
+    /// @notice Tx 8: Assign staker allowset and blockset via admin setters.
     ///         Batched into a single Safe MultiSend transaction.
-    ///         Requires Tx 6 (staker deployment) to have been executed on-chain.
+    ///         Requires Tx 7 (staker deployment) to have been executed on-chain.
     function phaseB_stakerAccessSets() external isBatch(_initAndGetSafe()) {
         address stakerAddr = _stakerAddress();
         require(stakerAddr.code.length > 0, "Staker not deployed -- run phaseB_staker first");
@@ -584,7 +639,7 @@ contract DeployProtocol is Script, BatchScript {
 // ═════════════════════════════════════════════════════════════════════════════
 
 /// @title VerifyProtocolSourceCode
-/// @notice Verifies all 15 Octant v2 protocol contracts on Etherscan and Sourcify.
+/// @notice Verifies all 18 Octant v2 protocol contracts on Etherscan and Sourcify.
 ///         Uses deterministic addresses computed at runtime from SAFE_ADDRESS and
 ///         SALT_TIMESTAMP env vars, reusing DeployProtocol address-computation helpers.
 ///
@@ -613,6 +668,10 @@ contract VerifyProtocolSourceCode is DeployProtocol {
     string constant SKY_FACTORY_PATH = "src/factories/SkyCompounderStrategyFactory.sol:SkyCompounderStrategyFactory";
     string constant YEARN_FACTORY_PATH =
         "src/factories/yieldDonating/YearnV3StrategyFactory.sol:YearnV3StrategyFactory";
+    string constant SPARK_FACTORY_PATH = "src/factories/SparkStrategyFactory.sol:SparkStrategyFactory";
+    string constant AAVE_V3_FACTORY_PATH = "src/factories/AaveV3StrategyFactory.sol:AaveV3StrategyFactory";
+    string constant ROCKET_POOL_FACTORY_PATH =
+        "src/factories/yieldSkimming/RocketPoolStrategyFactory.sol:RocketPoolStrategyFactory";
     string constant ADDRESS_SET_FACTORY_PATH = "src/factories/AddressSetFactory.sol:AddressSetFactory";
     string constant CALC_FACTORY_PATH =
         "src/factories/RegenEarningPowerCalculatorFactory.sol:RegenEarningPowerCalculatorFactory";
@@ -626,13 +685,13 @@ contract VerifyProtocolSourceCode is DeployProtocol {
     //  ENTRY POINTS
     // ═════════════════════════════════════════════════════════════════════════
 
-    /// @notice Verify all 15 contracts on Etherscan. Requires ETHERSCAN_API_KEY env var.
+    /// @notice Verify all 18 contracts on Etherscan. Requires ETHERSCAN_API_KEY env var.
     function verifyEtherscan() external {
         _initialize();
         _verifyAll("etherscan");
     }
 
-    /// @notice Verify all 15 contracts on Sourcify. No API key needed.
+    /// @notice Verify all 18 contracts on Sourcify. No API key needed.
     function verifySourcify() external {
         _initialize();
         _verifyAll("sourcify");
@@ -643,7 +702,7 @@ contract VerifyProtocolSourceCode is DeployProtocol {
     // ═════════════════════════════════════════════════════════════════════════
 
     function _verifyAll(string memory verifier) internal {
-        console.log("=== VERIFYING ALL 15 PROTOCOL CONTRACTS ===");
+        console.log("=== VERIFYING ALL 18 PROTOCOL CONTRACTS ===");
         console.log("Verifier:", verifier);
         console.log("");
 
@@ -656,55 +715,23 @@ contract VerifyProtocolSourceCode is DeployProtocol {
     }
 
     function _verifyPhaseANoArgs(string memory verifier) internal {
+        _verifyNoArgs(_yieldSkimmingAddress(), YIELD_SKIMMING_PATH, "YieldSkimmingTokenizedStrategy", verifier);
+        _verifyNoArgs(_yieldDonatingAddress(), YIELD_DONATING_PATH, "YieldDonatingTokenizedStrategy", verifier);
         _verifyNoArgs(
-            _computeCreate2AddressViaFactory(_yieldSkimmingSalt, type(YieldSkimmingTokenizedStrategy).creationCode),
-            YIELD_SKIMMING_PATH,
-            "YieldSkimmingTokenizedStrategy",
-            verifier
-        );
-        _verifyNoArgs(
-            _computeCreate2AddressViaFactory(_yieldDonatingSalt, type(YieldDonatingTokenizedStrategy).creationCode),
-            YIELD_DONATING_PATH,
-            "YieldDonatingTokenizedStrategy",
-            verifier
-        );
-        _verifyNoArgs(
-            _computeCreate2AddressViaFactory(_paymentSplitterFactorySalt, type(PaymentSplitterFactory).creationCode),
+            _paymentSplitterFactoryAddress(),
             PAYMENT_SPLITTER_FACTORY_PATH,
             "PaymentSplitterFactory",
             verifier
         );
-        _verifyNoArgs(
-            _computeCreate2AddressViaFactory(_lidoFactorySalt, type(LidoStrategyFactory).creationCode),
-            LIDO_FACTORY_PATH,
-            "LidoStrategyFactory",
-            verifier
-        );
-        _verifyNoArgs(
-            _computeCreate2AddressViaFactory(_morphoFactorySalt, type(MorphoCompounderStrategyFactory).creationCode),
-            MORPHO_FACTORY_PATH,
-            "MorphoCompounderStrategyFactory",
-            verifier
-        );
-        _verifyNoArgs(
-            _computeCreate2AddressViaFactory(_skyFactorySalt, type(SkyCompounderStrategyFactory).creationCode),
-            SKY_FACTORY_PATH,
-            "SkyCompounderStrategyFactory",
-            verifier
-        );
-        _verifyNoArgs(
-            _computeCreate2AddressViaFactory(_yearnV3FactorySalt, type(YearnV3StrategyFactory).creationCode),
-            YEARN_FACTORY_PATH,
-            "YearnV3StrategyFactory",
-            verifier
-        );
+        _verifyNoArgs(_lidoFactoryAddress(), LIDO_FACTORY_PATH, "LidoStrategyFactory", verifier);
+        _verifyNoArgs(_morphoFactoryAddress(), MORPHO_FACTORY_PATH, "MorphoCompounderStrategyFactory", verifier);
+        _verifyNoArgs(_skyFactoryAddress(), SKY_FACTORY_PATH, "SkyCompounderStrategyFactory", verifier);
+        _verifyNoArgs(_yearnV3FactoryAddress(), YEARN_FACTORY_PATH, "YearnV3StrategyFactory", verifier);
+        _verifyNoArgs(_sparkFactoryAddress(), SPARK_FACTORY_PATH, "SparkStrategyFactory", verifier);
+        _verifyNoArgs(_aaveV3FactoryAddress(), AAVE_V3_FACTORY_PATH, "AaveV3StrategyFactory", verifier);
+        _verifyNoArgs(_rocketPoolFactoryAddress(), ROCKET_POOL_FACTORY_PATH, "RocketPoolStrategyFactory", verifier);
         _verifyNoArgs(_addressSetFactoryAddress(), ADDRESS_SET_FACTORY_PATH, "AddressSetFactory", verifier);
-        _verifyNoArgs(
-            _computeCreate2AddressViaFactory(_calcFactorySalt, type(RegenEarningPowerCalculatorFactory).creationCode),
-            CALC_FACTORY_PATH,
-            "RegenEarningPowerCalculatorFactory",
-            verifier
-        );
+        _verifyNoArgs(_calcFactoryAddress(), CALC_FACTORY_PATH, "RegenEarningPowerCalculatorFactory", verifier);
     }
 
     function _verifyPhaseAWithArgs(string memory verifier) internal {
@@ -892,6 +919,12 @@ contract VerifyProtocolDeployment is Test {
     RegenEarningPowerCalculatorFactory internal calculatorFactory;
     RegenStakerFactory internal regenStakerFactory;
 
+    // Not yet on mainnet, so no production defaults. Supply EXPECTED_SPARK_FACTORY /
+    // EXPECTED_AAVE_V3_FACTORY / EXPECTED_ROCKET_POOL_FACTORY to verify them.
+    SparkStrategyFactory internal sparkFactory;
+    AaveV3StrategyFactory internal aaveV3Factory;
+    RocketPoolStrategyFactory internal rocketPoolFactory;
+
     // Phase B
     AddressSet internal allowSet;
     RegenEarningPowerCalculator internal calculator;
@@ -908,6 +941,10 @@ contract VerifyProtocolDeployment is Test {
 
     // --- All deployed addresses for code-existence check ---
     address[] internal allContracts;
+
+    // --- Batch 4 addresses, populated only when configured via env ---
+    address[] internal batch4Contracts;
+    string[] internal batch4Names;
 
     address internal testUser = makeAddr("testUser");
 
@@ -981,10 +1018,29 @@ contract VerifyProtocolDeployment is Test {
         allContracts.push(address(staker));
         allContracts.push(address(stakerAllowset));
         allContracts.push(address(stakerBlockset));
+
+        // Batch 4 factories are opt-in: only addresses supplied via env are verified.
+        sparkFactory = SparkStrategyFactory(vm.envOr("EXPECTED_SPARK_FACTORY", address(0)));
+        aaveV3Factory = AaveV3StrategyFactory(vm.envOr("EXPECTED_AAVE_V3_FACTORY", address(0)));
+        rocketPoolFactory = RocketPoolStrategyFactory(vm.envOr("EXPECTED_ROCKET_POOL_FACTORY", address(0)));
+
+        _registerBatch4(address(sparkFactory), "SparkStrategyFactory");
+        _registerBatch4(address(aaveV3Factory), "AaveV3StrategyFactory");
+        _registerBatch4(address(rocketPoolFactory), "RocketPoolStrategyFactory");
+    }
+
+    /// @dev Reports unconfigured factories instead of silently dropping them.
+    function _registerBatch4(address factory, string memory name) internal {
+        if (factory == address(0)) {
+            console.log("[NOT CONFIGURED] %s -- set EXPECTED_* env var to verify it", name);
+            return;
+        }
+        batch4Contracts.push(factory);
+        batch4Names.push(name);
     }
 
     // -----------------------------------------------------------------------
-    // Test 1: All 15 contracts have code on-chain
+    // Test 1: All 15 core contracts have code on-chain
     // -----------------------------------------------------------------------
 
     function test_allContractsHaveCode() public view {
@@ -1063,7 +1119,57 @@ contract VerifyProtocolDeployment is Test {
     }
 
     // -----------------------------------------------------------------------
-    // Test 3: AllowSet ownership and initial state
+    // Test 3: Batch 4 factories (Spark / Aave V3 / Rocket Pool), when configured
+    // -----------------------------------------------------------------------
+
+    /// @dev Skips rather than passing vacuously when no EXPECTED_* vars are set.
+    function test_batch4FactoriesHaveCode() public {
+        vm.skip(batch4Contracts.length == 0);
+
+        for (uint256 i = 0; i < batch4Contracts.length; i++) {
+            assertTrue(
+                batch4Contracts[i].code.length > 0,
+                string.concat("No code for ", batch4Names[i], " at ", vm.toString(batch4Contracts[i]))
+            );
+        }
+    }
+
+    function test_batch4FactoryInterfaces() public {
+        vm.skip(batch4Contracts.length == 0);
+
+        if (address(sparkFactory) != address(0)) {
+            // No protocol constants to check, so assert identity via runtime bytecode.
+            assertEq(
+                keccak256(address(sparkFactory).code),
+                keccak256(type(SparkStrategyFactory).runtimeCode),
+                "SparkFactory: runtime bytecode does not match SparkStrategyFactory"
+            );
+        }
+
+        if (address(aaveV3Factory) != address(0)) {
+            assertEq(
+                aaveV3Factory.AAVE_ADDRESSES_PROVIDER(),
+                0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e,
+                "AaveV3Factory: wrong AAVE_ADDRESSES_PROVIDER"
+            );
+            assertEq(
+                aaveV3Factory.AAVE_REWARDS_CONTROLLER(),
+                0x8164Cc65827dcFe994AB23944CBC90e0aa80bFcb,
+                "AaveV3Factory: wrong AAVE_REWARDS_CONTROLLER"
+            );
+        }
+
+        if (address(rocketPoolFactory) != address(0)) {
+            assertEq(
+                rocketPoolFactory.R_ETH(),
+                0xae78736Cd615f374D3085123A210448E74Fc6393,
+                "RocketPoolFactory: wrong R_ETH"
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Test 4: AllowSet ownership and initial state
     // -----------------------------------------------------------------------
 
     function test_allowSetOwnership() public view {
@@ -1072,7 +1178,7 @@ contract VerifyProtocolDeployment is Test {
     }
 
     // -----------------------------------------------------------------------
-    // Test 4: AllowSet add/remove functionality
+    // Test 5: AllowSet add/remove functionality
     // -----------------------------------------------------------------------
 
     function test_allowSetFunctionality() public {
@@ -1094,7 +1200,7 @@ contract VerifyProtocolDeployment is Test {
     }
 
     // -----------------------------------------------------------------------
-    // Test 5: AddressSetFactory determinism (all 3 AddressSets match predictions)
+    // Test 6: AddressSetFactory determinism (all 3 AddressSets match predictions)
     // -----------------------------------------------------------------------
 
     function test_addressSetFactoryDeterminism() public view {
@@ -1122,7 +1228,7 @@ contract VerifyProtocolDeployment is Test {
     }
 
     // -----------------------------------------------------------------------
-    // Test 6: Staker AddressSet ownership and initial state
+    // Test 7: Staker AddressSet ownership and initial state
     // -----------------------------------------------------------------------
 
     function test_stakerAddressSetsOwnership() public view {
@@ -1133,7 +1239,7 @@ contract VerifyProtocolDeployment is Test {
     }
 
     // -----------------------------------------------------------------------
-    // Test 7: Calculator parameters
+    // Test 8: Calculator parameters
     // -----------------------------------------------------------------------
 
     function test_calculatorParameters() public view {
@@ -1144,7 +1250,7 @@ contract VerifyProtocolDeployment is Test {
     }
 
     // -----------------------------------------------------------------------
-    // Test 8: Calculator earning power computation
+    // Test 9: Calculator earning power computation
     // -----------------------------------------------------------------------
 
     function test_calculatorEarningPower() public view {
@@ -1164,7 +1270,7 @@ contract VerifyProtocolDeployment is Test {
     }
 
     // -----------------------------------------------------------------------
-    // Test 9: Staker parameters
+    // Test 10: Staker parameters
     // -----------------------------------------------------------------------
 
     function test_stakerParameters() public view {
@@ -1196,7 +1302,7 @@ contract VerifyProtocolDeployment is Test {
     }
 
     // -----------------------------------------------------------------------
-    // Test 10: Staker stake and withdraw cycle
+    // Test 11: Staker stake and withdraw cycle
     // -----------------------------------------------------------------------
 
     function test_stakerStakeAndWithdraw() public {
@@ -1220,7 +1326,7 @@ contract VerifyProtocolDeployment is Test {
     }
 
     // -----------------------------------------------------------------------
-    // Test 11: Cross-contract integration (stake -> earning power via calculator)
+    // Test 12: Cross-contract integration (stake -> earning power via calculator)
     // -----------------------------------------------------------------------
 
     function test_crossContractIntegration() public {

--- a/script/prod/README.md
+++ b/script/prod/README.md
@@ -1,84 +1,114 @@
-# Dragon Protocol Deployment Guide
+# Octant v2 Production Deployment
 
-This guide explains how to deploy the Dragon Protocol core components in a Development environment or in your own Tenderly Sepolia Testnet (look at the end).
+`DeployProtocol.s.sol` encodes the complete Octant v2 mainnet deployment as a sequence of Gnosis Safe
+transactions. Every contract is deployed through Nick's CREATE2 factory
+(`0x4e59b44847b379578588920cA78FbF26c0B4956C`), so addresses depend only on the salt and the creation
+code — never on the Safe nonce.
 
-## Overview
+The script does not broadcast. It simulates, asserts each deployment lands on its precomputed address,
+and (with `SEND=true`) proposes the batch to the Safe transaction service for owner signatures.
 
-The DeployProtocol script handles the sequential deployment of:
+## Structure — 8 Safe transactions
 
-1. Safe (1/1 multisig)
-2. Module Proxy Factory
-3. Hats Protocol & Dragon Hatter
-4. Dragon Tokenized Strategy Implementation
-5. Dragon Router
-6. Mock Strategy (for testing)
+**Phase A — 13 factory/implementation contracts.** Split into four batches only because of the
+EIP-7825 per-transaction gas limit of ~16.78M.
 
-## Prerequisites
+| Tx | Entry point | Contracts |
+|---|---|---|
+| 1 | `phaseA_batch1()` | YieldSkimmingTokenizedStrategy, YieldDonatingTokenizedStrategy, PaymentSplitterFactory, LidoStrategyFactory, MorphoCompounderStrategyFactory |
+| 2 | `phaseA_batch2()` | SkyCompounderStrategyFactory, YearnV3StrategyFactory |
+| 3 | `phaseA_batch3()` | AddressSetFactory, RegenEarningPowerCalculatorFactory, RegenStakerFactory |
+| 4 | `phaseA_batch4()` | SparkStrategyFactory, AaveV3StrategyFactory, RocketPoolStrategyFactory |
 
-- Access to an RPC endpoint for your target network
-- Private key with sufficient native tokens for deployment
-- Environment file (.env) setup
+**Phase B — 5 instance contracts.** Requires Phase A to be executed on-chain first.
 
-## Environment Setup
+| Tx | Entry point | Contracts |
+|---|---|---|
+| 5 | `phaseB_addressSets()` | allocationMechanismAllowset, stakerAllowset, stakerBlockset |
+| 6 | `phaseB_calculator()` | RegenEarningPowerCalculator |
+| 7 | `phaseB_staker()` | RegenStakerWithoutDelegateSurrogateVotes |
+| 8 | `phaseB_stakerAccessSets()` | Assigns the staker's allowset/blockset via admin setters |
 
-Your .env file should contain:
+The staker is constructed with `address(0)` for its allowset and blockset and `accessMode = NONE`, so
+the sets are inactive until Tx 8 assigns them.
 
-```
-PRIVATE_KEY - Your deployment private key
-RPC_URL - URL for your target network
-ETHERSCAN_API_KEY - For contract verification
-```
-
-## Running the Deployment
-
-1. First dry run the deployment:
-   ```forge script script/prod/DeployProtocol.s.sol:DeployProtocol -vvvv --rpc-url $RPC_URL```
-
-2. If the dry run succeeds, execute the actual deployment:
-   ```forge script script/prod/DeployProtocol.s.sol:DeployProtocol --rpc-url $RPC_URL --broadcast --verify```
-
-## Post Deployment
-
-The script will output a deployment summary with all contract addresses. Save these addresses for future reference.
-
-The script performs automatic verification of:
-- Safe configuration
-- Owner permissions
-- Strategy enablement
-- Component connections
-
-## Security Considerations
-
-- The initial Safe is deployed as 1/1 for simplicity but should be upgraded to a proper multisig after deployment
-- All contract ownership and admin roles are initially assigned to the deployer
-- Additional owners and permissions should be configured after successful deployment
-- Verify all addresses and permissions manually after deployment
-
-## Next Steps
-
-After successful deployment:
-1. Configure multisig owners
-2. Set up etra permissions on hats protocol
-4. Deposit into strategy and mint undelying asset token
-## How to create your own Sepolia Virtual TestNet in Tenderly and deploy V2 contracts there:
-
-1. Create your own Virtual TestNet in Tenderly (Sepolia, sync on) (https://docs.tenderly.co/virtual-testnets/quickstart)
-2. Create Tenderly Personal accessToken (https://docs.tenderly.co/account/projects/how-to-generate-api-access-token#personal-account-access-tokens)
-3. Send some SepoliaETH (your own Sepolia TestNet RPC) to your deployer address (ex. MetaMask account) (https://docs.tenderly.co/virtual-testnets/unlimited-faucet)
-4. Set required ENVs
+## Environment
 
 ```
-SENDER=(deployer address ex. MetaMask account)PRIVATE_KEY=(deployer private key ex. MetaMask account)
-THRESHOLD=1 # Safe threshold (default is 5)
-TENDERLY_VIRTUAL_TESTNET_RPC_URL=(your own Sepolia TestNet RPC)
-TENDERLY_VERIFIER_URL=$TENDERLY_VIRTUAL_TESTNET_RPC_URL/verify/etherscan
-TENDERLY_ACCESS_TOKEN=(your Personal Tenderly accessToken)
-MAX_OPEX_SPLIT=5 # to confirm
-MIN_METAPOOL_SPLIT=0 # to confirm
-GOVERNANCE=$SENDER # to confirm
+SAFE_ADDRESS     required  -- target Gnosis Safe
+SALT_TIMESTAMP   optional  -- suffix for all CREATE2 salts; auto-generated as HH_DDMMYYYY via FFI
+SEND             optional  -- set to true to submit to the Safe API (default: simulate only)
+CHAIN            e.g. mainnet
+WALLET_TYPE      local | ledger
+PRIVATE_KEY      required for WALLET_TYPE=local
 ```
 
-3. Run script in terminal (repo root)
-    1. `source .env`
-    2. ```forge script script/prod/DeployProtocol.s.sol --slow --verify --verifier-url $TENDERLY_VERIFIER_URL --sender $SENDER --rpc-url $TENDERLY_VIRTUAL_TESTNET_RPC_URL --private-key $PRIVATE_KEY --etherscan-api-key $TENDERLY_ACCESS_TOKEN -vvvv --broadcast``` // Deploy V2 Contracts
-    3. ```forge script dependencies/hats-protocol-1.0/script/Hats.s.sol:DeployHats --slow --verify --verifier-url $TENDERLY_VERIFIER_URL --rpc-url $TENDERLY_VIRTUAL_TESTNET_RPC_URL --private-key $PRIVATE_KEY --etherscan-api-key $TENDERLY_ACCESS_TOKEN -vvvv --broadcast``` // Deploy Hats Protocol
+Reusing the same `SALT_TIMESTAMP` reproduces the same addresses; changing it produces a fresh set.
+Pin it explicitly when replaying a deployment across the hour boundary.
+
+> ⚠️ The salt preimage prefixes here are identical to the pinned constants in
+> `script/deploy/DeployNewStrategiesAndFactories.s.sol`. Pinning `SALT_TIMESTAMP=11022026` (or
+> `07072026`) reproduces that script's exact addresses, so every CREATE2 reverts if those contracts
+> already exist. Let the timestamp auto-generate as `HH_DDMMYYYY` unless you are deliberately
+> replaying an in-flight deployment.
+
+## Running
+
+Preview all 18 deterministic addresses without proposing anything:
+
+```bash
+SAFE_ADDRESS=0x... forge script script/prod/DeployProtocol.s.sol:DeployProtocol \
+  --sig "computeAllAddresses()" --ffi
+```
+
+Simulate one batch against a fork:
+
+```bash
+CHAIN=mainnet WALLET_TYPE=local PRIVATE_KEY=0x... SAFE_ADDRESS=0x... \
+forge script script/prod/DeployProtocol.s.sol:DeployProtocol \
+  --sig "phaseA_batch4()" --rpc-url $FORK_RPC --ffi
+```
+
+Propose to the Safe by adding `SEND=true`. Run the batches in order and let each one execute on-chain
+before proposing the next — Phase B reads addresses that Phase A must have produced.
+
+Before signing, diff the addresses in the batch output against the `computeAllAddresses()` output.
+
+## Source verification
+
+```bash
+SAFE_ADDRESS=0x... SALT_TIMESTAMP=... ETHERSCAN_API_KEY=... \
+forge script script/prod/DeployProtocol.s.sol:VerifyProtocolSourceCode --sig "verifyEtherscan()" --ffi
+
+SAFE_ADDRESS=0x... SALT_TIMESTAMP=... \
+forge script script/prod/DeployProtocol.s.sol:VerifyProtocolSourceCode --sig "verifySourcify()" --ffi
+```
+
+## Post-deployment verification
+
+`VerifyProtocolDeployment` is a fork test suite covering all deployed contracts: code existence,
+factory constants, ownership, address-set determinism, calculator behaviour, and a staker
+stake/withdraw cycle. It is excluded from the default Foundry profile.
+
+```bash
+FOUNDRY_PROFILE=mainnet forge test --match-contract VerifyProtocolDeployment --fork-url <mainnet-rpc>
+```
+
+Addresses default to the production deployment and can each be overridden via `EXPECTED_*` env vars to
+verify a testbed instead. The batch 4 factories (Spark, Aave V3, Rocket Pool) have no production
+default yet: supply `EXPECTED_SPARK_FACTORY`, `EXPECTED_AAVE_V3_FACTORY`, and
+`EXPECTED_ROCKET_POOL_FACTORY` to bring them under verification. The suite logs
+`[NOT CONFIGURED]` for any it skips.
+
+## Security notes
+
+- All ownership and admin roles are assigned to the Safe, never to the deploying EOA
+- Address assertions run before a batch is proposed, so a salt or bytecode drift fails locally rather
+  than producing a Safe payload whose logged addresses are wrong
+- Verify all addresses and permissions manually after execution
+
+## Related
+
+- Staging / testbed Safe path and salt tables: [`../deploy/DEPLOYMENT_GUIDE.md`](../deploy/DEPLOYMENT_GUIDE.md)
+- EOA staging path: [`../deployment/staging/README.md`](../deployment/staging/README.md)
+- CI coverage for the deployment scripts: `test/unit/script/DeploymentScripts.t.sol`

--- a/test/unit/script/DeploymentScripts.t.sol
+++ b/test/unit/script/DeploymentScripts.t.sol
@@ -1,0 +1,425 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { Test } from "forge-std/Test.sol";
+
+import { DeployNewStrategiesAndFactories } from "script/deploy/DeployNewStrategiesAndFactories.s.sol";
+import { DeployLidoStrategyFactory } from "script/deploy/DeployLidoStrategyFactory.sol";
+import { DeployRocketPoolStrategyFactory } from "script/deploy/DeployRocketPoolStrategyFactory.sol";
+import { DeploySparkStrategyFactory } from "script/deploy/DeploySparkStrategyFactory.sol";
+import { DeployAaveV3StrategyFactory } from "script/deploy/DeployAaveV3StrategyFactory.sol";
+import { DeployProtocol } from "script/deployment/staging/DeployProtocol.s.sol";
+import { DeployedAddresses } from "script/helpers/DeployedAddresses.sol";
+
+import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+import { PaymentSplitterFactory } from "src/factories/PaymentSplitterFactory.sol";
+import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
+import { MorphoCompounderStrategyFactory } from "src/factories/MorphoCompounderStrategyFactory.sol";
+import { SkyCompounderStrategyFactory } from "src/factories/SkyCompounderStrategyFactory.sol";
+import { YearnV3StrategyFactory } from "src/factories/yieldDonating/YearnV3StrategyFactory.sol";
+import { SparkStrategyFactory } from "src/factories/SparkStrategyFactory.sol";
+import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
+import { RocketPoolStrategyFactory } from "src/factories/yieldSkimming/RocketPoolStrategyFactory.sol";
+import { AddressSetFactory } from "src/factories/AddressSetFactory.sol";
+import { RegenEarningPowerCalculatorFactory } from "src/factories/RegenEarningPowerCalculatorFactory.sol";
+import { RegenStakerFactory } from "src/factories/RegenStakerFactory.sol";
+import { RegenStaker } from "src/regen/RegenStaker.sol";
+import { RegenStakerWithoutDelegateSurrogateVotes } from "src/regen/RegenStakerWithoutDelegateSurrogateVotes.sol";
+
+/// @notice Exposes the script's internal address precomputation so tests assert against the
+///         values the script itself logs, not against a re-derivation that could drift.
+contract BatchScriptHarness is DeployNewStrategiesAndFactories {
+    function calculateAllAddresses() external {
+        _calculateBatch1Addresses();
+        _calculateBatch2Addresses();
+        _calculateBatch3Addresses();
+        _calculateBatch4Addresses();
+    }
+
+    /// @dev Deploys against a deliberately wrong expected address to exercise the guard.
+    function queueWithWrongExpectedAddress() external {
+        _addAndAssert(
+            SPARK_FACTORY_SALT,
+            type(SparkStrategyFactory).creationCode,
+            address(0xdead),
+            "SparkStrategyFactory"
+        );
+    }
+}
+
+/**
+ * @title DeploymentScriptsTest
+ * @author Golem Foundation
+ * @notice Guards the deployment scripts themselves: CREATE2 salt hygiene, address
+ *         predictability, and the wiring of the standalone factory scripts.
+ * @dev Deployments go through Nick's CREATE2 factory exactly as the Safe batches do, so a bad
+ *      salt or a reverting constructor fails here instead of in front of a Safe signer.
+ *
+ *      LIMIT: runs on a fresh EVM and cannot see whether a target is already occupied on the
+ *      target chain. Green here does not mean a batch is proposable -- batch 1's
+ *      YieldSkimmingTokenizedStrategy already exists on mainnet, so runBatch1() reverts there
+ *      while these still pass. Check occupancy with `cast code` or a fork simulation.
+ */
+contract DeploymentScriptsTest is Test {
+    /// @dev One entry per contract queued by DeployNewStrategiesAndFactories.
+    struct Deployment {
+        string label;
+        bytes32 salt;
+        bytes creationCode;
+    }
+
+    DeployNewStrategiesAndFactories internal batchScript;
+    Deployment[] internal deployments;
+
+    function setUp() public {
+        batchScript = new DeployNewStrategiesAndFactories();
+
+        // Batch 1
+        _register(
+            "YieldSkimmingTokenizedStrategy",
+            batchScript.YIELD_SKIMMING_SALT(),
+            type(YieldSkimmingTokenizedStrategy).creationCode
+        );
+        _register(
+            "YieldDonatingTokenizedStrategy",
+            batchScript.YIELD_DONATING_SALT(),
+            type(YieldDonatingTokenizedStrategy).creationCode
+        );
+        _register(
+            "PaymentSplitterFactory",
+            batchScript.PAYMENT_SPLITTER_FACTORY_SALT(),
+            type(PaymentSplitterFactory).creationCode
+        );
+        _register("LidoStrategyFactory", batchScript.LIDO_FACTORY_SALT(), type(LidoStrategyFactory).creationCode);
+        _register(
+            "MorphoCompounderStrategyFactory",
+            batchScript.MORPHO_FACTORY_SALT(),
+            type(MorphoCompounderStrategyFactory).creationCode
+        );
+
+        // Batch 2
+        _register(
+            "SkyCompounderStrategyFactory",
+            batchScript.SKY_FACTORY_SALT(),
+            type(SkyCompounderStrategyFactory).creationCode
+        );
+        _register(
+            "YearnV3StrategyFactory",
+            batchScript.YEARN_V3_FACTORY_SALT(),
+            type(YearnV3StrategyFactory).creationCode
+        );
+
+        // Batch 3
+        _register("AddressSetFactory", batchScript.ADDRESS_SET_FACTORY_SALT(), type(AddressSetFactory).creationCode);
+        _register(
+            "RegenEarningPowerCalculatorFactory",
+            batchScript.EARNING_POWER_CALCULATOR_FACTORY_SALT(),
+            type(RegenEarningPowerCalculatorFactory).creationCode
+        );
+        _register(
+            "RegenStakerFactory",
+            batchScript.REGEN_STAKER_FACTORY_SALT(),
+            abi.encodePacked(
+                type(RegenStakerFactory).creationCode,
+                abi.encode(
+                    keccak256(type(RegenStaker).creationCode),
+                    keccak256(type(RegenStakerWithoutDelegateSurrogateVotes).creationCode)
+                )
+            )
+        );
+
+        // Batch 4
+        _register("SparkStrategyFactory", batchScript.SPARK_FACTORY_SALT(), type(SparkStrategyFactory).creationCode);
+        _register(
+            "AaveV3StrategyFactory",
+            batchScript.AAVE_V3_FACTORY_SALT(),
+            type(AaveV3StrategyFactory).creationCode
+        );
+        _register(
+            "RocketPoolStrategyFactory",
+            batchScript.ROCKET_POOL_FACTORY_SALT(),
+            type(RocketPoolStrategyFactory).creationCode
+        );
+    }
+
+    function _register(string memory label, bytes32 salt, bytes memory creationCode) internal {
+        deployments.push(Deployment({ label: label, salt: salt, creationCode: creationCode }));
+    }
+
+    /// @dev Mirrors BatchScript._computeCreate2AddressViaFactory.
+    function _predict(bytes32 salt, bytes memory creationCode) internal pure returns (address) {
+        return
+            address(
+                uint160(uint256(keccak256(abi.encodePacked(hex"ff", CREATE2_FACTORY, salt, keccak256(creationCode)))))
+            );
+    }
+
+    /// @dev Deploys through Nick's CREATE2 factory the same way a Safe batch does.
+    function _deployViaCreate2Factory(bytes32 salt, bytes memory creationCode) internal returns (address deployed) {
+        (bool success, bytes memory result) = CREATE2_FACTORY.call(abi.encodePacked(salt, creationCode));
+        require(success, "CREATE2 deployment reverted");
+        deployed = address(uint160(bytes20(result)));
+    }
+
+    // -----------------------------------------------------------------------
+    // Salt hygiene
+    // -----------------------------------------------------------------------
+
+    /// @notice Every salt must be distinct -- a duplicate is always a copy-paste bug.
+    function test_saltsAreUnique() public view {
+        for (uint256 i = 0; i < deployments.length; i++) {
+            for (uint256 j = i + 1; j < deployments.length; j++) {
+                assertTrue(
+                    deployments[i].salt != deployments[j].salt,
+                    string.concat("Duplicate salt: ", deployments[i].label, " / ", deployments[j].label)
+                );
+            }
+        }
+    }
+
+    /// @notice An address collision would make the second deployment a silent no-op.
+    function test_predictedAddressesAreUnique() public view {
+        address[] memory predicted = new address[](deployments.length);
+        for (uint256 i = 0; i < deployments.length; i++) {
+            predicted[i] = _predict(deployments[i].salt, deployments[i].creationCode);
+        }
+
+        for (uint256 i = 0; i < predicted.length; i++) {
+            for (uint256 j = i + 1; j < predicted.length; j++) {
+                assertTrue(
+                    predicted[i] != predicted[j],
+                    string.concat("Address collision: ", deployments[i].label, " / ", deployments[j].label)
+                );
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // CREATE2 predictability -- the addresses logged for Safe signers are real
+    // -----------------------------------------------------------------------
+
+    /// @notice Catches a constructor that reverts or bytecode over the EIP-170 24KB limit.
+    function test_everyBatchContractDeploysAtPredictedAddress() public {
+        for (uint256 i = 0; i < deployments.length; i++) {
+            Deployment memory d = deployments[i];
+
+            address predicted = _predict(d.salt, d.creationCode);
+            address deployed = _deployViaCreate2Factory(d.salt, d.creationCode);
+
+            assertEq(deployed, predicted, string.concat(d.label, ": deployed address != predicted address"));
+            assertTrue(deployed.code.length > 0, string.concat(d.label, ": no code after deployment"));
+        }
+    }
+
+    /// @notice Fails if a _calculateBatchNAddresses() entry uses the wrong salt or contract --
+    ///         the case where signers approve a payload while reading a bogus address.
+    function test_scriptPrecomputedAddressesMatchRealDeployments() public {
+        BatchScriptHarness harness = new BatchScriptHarness();
+        harness.calculateAllAddresses();
+
+        address[13] memory precomputed = [
+            harness.yieldSkimmingStrategy(),
+            harness.yieldDonatingStrategy(),
+            harness.paymentSplitterFactory(),
+            harness.lidoFactory(),
+            harness.morphoFactory(),
+            harness.skyFactory(),
+            harness.yearnV3Factory(),
+            harness.addressSetFactory(),
+            harness.earningPowerCalculatorFactory(),
+            harness.regenStakerFactory(),
+            harness.sparkFactory(),
+            harness.aaveV3Factory(),
+            harness.rocketPoolFactory()
+        ];
+
+        assertEq(precomputed.length, deployments.length, "Harness and test registry disagree on contract count");
+
+        for (uint256 i = 0; i < deployments.length; i++) {
+            Deployment memory d = deployments[i];
+            address deployed = _deployViaCreate2Factory(d.salt, d.creationCode);
+
+            assertEq(deployed, precomputed[i], string.concat(d.label, ": script precomputed the wrong address"));
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Standalone factory scripts (the path used by staging DeployProtocol)
+    // -----------------------------------------------------------------------
+
+    function test_standaloneSparkScriptDeploysWorkingFactory() public {
+        vm.setEnv("PRIVATE_KEY", vm.toString(uint256(keccak256("deployer"))));
+
+        DeploySparkStrategyFactory script = new DeploySparkStrategyFactory();
+        address factory = script.deploy();
+
+        // No protocol constants to check, so assert identity via runtime bytecode.
+        assertEq(
+            keccak256(factory.code),
+            keccak256(type(SparkStrategyFactory).runtimeCode),
+            "SparkStrategyFactory: runtime bytecode mismatch"
+        );
+        // A salted CREATE2 collides with itself; dropping the salt would silently fall back to
+        // nonce-based CREATE and deploy twice. Asserting the exact address is not sound here --
+        // vm.startBroadcast attributes the creation differently in a test than in a real run.
+        vm.expectRevert();
+        script.deploy();
+    }
+
+    function test_standaloneAaveV3ScriptDeploysWorkingFactory() public {
+        vm.setEnv("PRIVATE_KEY", vm.toString(uint256(keccak256("deployer"))));
+
+        DeployAaveV3StrategyFactory script = new DeployAaveV3StrategyFactory();
+        address factory = script.deploy();
+
+        assertTrue(factory.code.length > 0, "AaveV3StrategyFactory: no code");
+        assertEq(
+            AaveV3StrategyFactory(factory).AAVE_ADDRESSES_PROVIDER(),
+            0x2f39d218133AFaB8F2B819B1066c7E434Ad94E9e,
+            "AaveV3StrategyFactory: wrong AAVE_ADDRESSES_PROVIDER"
+        );
+        // A salted CREATE2 collides with itself; dropping the salt would silently fall back to
+        // nonce-based CREATE and deploy twice. Asserting the exact address is not sound here --
+        // vm.startBroadcast attributes the creation differently in a test than in a real run.
+        vm.expectRevert();
+        script.deploy();
+    }
+
+    function test_standaloneRocketPoolScriptDeploysWorkingFactory() public {
+        vm.setEnv("PRIVATE_KEY", vm.toString(uint256(keccak256("deployer"))));
+
+        DeployRocketPoolStrategyFactory script = new DeployRocketPoolStrategyFactory();
+        address factory = script.deploy();
+
+        assertTrue(factory.code.length > 0, "RocketPoolStrategyFactory: no code");
+        assertEq(
+            RocketPoolStrategyFactory(factory).R_ETH(),
+            0xae78736Cd615f374D3085123A210448E74Fc6393,
+            "RocketPoolStrategyFactory: wrong R_ETH"
+        );
+        // A salted CREATE2 collides with itself; dropping the salt would silently fall back to
+        // nonce-based CREATE and deploy twice. Asserting the exact address is not sound here --
+        // vm.startBroadcast attributes the creation differently in a test than in a real run.
+        vm.expectRevert();
+        script.deploy();
+    }
+
+    function test_standaloneLidoScriptDeploysWorkingFactory() public {
+        vm.setEnv("PRIVATE_KEY", vm.toString(uint256(keccak256("deployer"))));
+
+        DeployLidoStrategyFactory script = new DeployLidoStrategyFactory();
+        address factory = script.deploy();
+
+        assertTrue(factory.code.length > 0, "LidoStrategyFactory: no code");
+        assertEq(
+            LidoStrategyFactory(factory).WSTETH(),
+            0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0,
+            "LidoStrategyFactory: wrong WSTETH"
+        );
+        // A salted CREATE2 collides with itself; dropping the salt would silently fall back to
+        // nonce-based CREATE and deploy twice. Asserting the exact address is not sound here --
+        // vm.startBroadcast attributes the creation differently in a test than in a real run.
+        vm.expectRevert();
+        script.deploy();
+    }
+
+    /// @notice The four standalone scripts must declare distinct salts.
+    function test_standaloneScriptSaltsAreDistinct() public {
+        bytes32[4] memory salts = [
+            new DeployLidoStrategyFactory().DEPLOYMENT_SALT(),
+            new DeployRocketPoolStrategyFactory().DEPLOYMENT_SALT(),
+            new DeploySparkStrategyFactory().DEPLOYMENT_SALT(),
+            new DeployAaveV3StrategyFactory().DEPLOYMENT_SALT()
+        ];
+
+        for (uint256 i = 0; i < salts.length; i++) {
+            for (uint256 j = i + 1; j < salts.length; j++) {
+                assertTrue(salts[i] != salts[j], "Standalone deploy scripts share a salt");
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Staging orchestrator wiring
+    // -----------------------------------------------------------------------
+
+    /// @notice DeployProtocol.setUp() must instantiate a deployer for every factory it
+    ///         claims to deploy. A missing `new Deploy...()` would otherwise surface as a
+    ///         call to address(0) halfway through a staging deployment.
+    function test_stagingDeployProtocolWiresEveryFactoryDeployer() public {
+        DeployProtocol protocol = new DeployProtocol();
+        protocol.setUp();
+
+        assertTrue(address(protocol.deploySparkStrategyFactory()) != address(0), "Spark deployer not wired");
+        assertTrue(address(protocol.deployAaveV3StrategyFactory()) != address(0), "Aave V3 deployer not wired");
+        assertTrue(address(protocol.deployRocketPoolStrategyFactory()) != address(0), "Rocket Pool deployer not wired");
+        assertTrue(address(protocol.deployLidoStrategyFactory()) != address(0), "Lido deployer not wired");
+    }
+
+    /// @notice Anvil deploys fresh; staging, a mainnet fork, must reuse mainnet's addresses.
+    ///         Catches a factory redeployed in the mainnet profile but forgotten in staging.
+    /// @dev One test on purpose: vm.setEnv mutates shared process state, so two tests both
+    ///      setting DEPLOYMENT_NETWORK would race and read each other's value.
+    function test_deployedAddressesNetworkProfiles() public {
+        DeployedAddresses registry = new DeployedAddresses();
+
+        vm.setEnv("DEPLOYMENT_NETWORK", "anvil");
+        DeployedAddresses.ContractAddresses memory anvil = registry.getAddressesByEnv();
+        assertEq(anvil.sparkStrategyFactory, address(0), "anvil: spark should deploy fresh");
+        assertEq(anvil.aaveV3StrategyFactory, address(0), "anvil: aave should deploy fresh");
+        assertEq(anvil.rocketPoolStrategyFactory, address(0), "anvil: rocket pool should deploy fresh");
+        assertEq(anvil.lidoStrategyFactory, address(0), "anvil: lido should deploy fresh");
+
+        vm.setEnv("DEPLOYMENT_NETWORK", "mainnet");
+        DeployedAddresses.ContractAddresses memory mainnet = registry.getAddressesByEnv();
+
+        vm.setEnv("DEPLOYMENT_NETWORK", "staging");
+        DeployedAddresses.ContractAddresses memory staging = registry.getAddressesByEnv();
+
+        assertEq(staging.paymentSplitterFactory, mainnet.paymentSplitterFactory, "paymentSplitterFactory drifted");
+        assertEq(
+            staging.skyCompounderStrategyFactory,
+            mainnet.skyCompounderStrategyFactory,
+            "skyCompounderStrategyFactory drifted"
+        );
+        assertEq(
+            staging.morphoCompounderStrategyFactory,
+            mainnet.morphoCompounderStrategyFactory,
+            "morphoCompounderStrategyFactory drifted"
+        );
+        assertEq(
+            staging.yieldDonatingTokenizedStrategy,
+            mainnet.yieldDonatingTokenizedStrategy,
+            "yieldDonatingTokenizedStrategy drifted"
+        );
+        assertEq(staging.yearnV3StrategyFactory, mainnet.yearnV3StrategyFactory, "yearnV3StrategyFactory drifted");
+        assertEq(staging.lidoStrategyFactory, mainnet.lidoStrategyFactory, "lidoStrategyFactory drifted");
+        assertEq(staging.sparkStrategyFactory, mainnet.sparkStrategyFactory, "sparkStrategyFactory drifted");
+        assertEq(staging.aaveV3StrategyFactory, mainnet.aaveV3StrategyFactory, "aaveV3StrategyFactory drifted");
+        assertEq(
+            staging.rocketPoolStrategyFactory,
+            mainnet.rocketPoolStrategyFactory,
+            "rocketPoolStrategyFactory drifted"
+        );
+        assertEq(staging.addressSetFactory, mainnet.addressSetFactory, "addressSetFactory drifted");
+        assertEq(
+            staging.regenEarningPowerCalculatorFactory,
+            mainnet.regenEarningPowerCalculatorFactory,
+            "regenEarningPowerCalculatorFactory drifted"
+        );
+        assertEq(staging.regenStakerFactory, mainnet.regenStakerFactory, "regenStakerFactory drifted");
+    }
+
+    // -----------------------------------------------------------------------
+    // Negative case: the address assertion must actually reject a mismatch
+    // -----------------------------------------------------------------------
+
+    /// @notice Without this, the tests above would all still pass if the require were deleted.
+    function test_addAndAssertRevertsOnAddressMismatch() public {
+        BatchScriptHarness harness = new BatchScriptHarness();
+
+        vm.expectRevert(bytes("SparkStrategyFactory: address mismatch"));
+        harness.queueWithWrongExpectedAddress();
+    }
+}


### PR DESCRIPTION
## What

Spark, Aave V3 and Rocket Pool strategy factories can now be deployed through every path that already deploys Lido, Sky, Morpho and Yearn — instead of a separate one-off script.

## Where they were added

```
                        standalone   deploy/ Safe   prod/ Safe   staging   DeployedAddresses
Lido                        ok           b1            b1          ok            ok
Sky / Morpho / Yearn        ok         b1, b2        b1, b2        ok            ok
                        ----------------------------------------------------------------
Spark            NEW      added        batch 4      phaseA_b4     added         added
Aave V3          NEW      added        batch 4      phaseA_b4     added         added
Rocket Pool               (had)        batch 4      phaseA_b4     added         added
```

`prod/DeployProtocol.s.sol` had **none** of the three. Phase A goes from 3 to 4 Safe transactions.

## Batch 4

```
Safe execTransaction ──> MultiSendCallOnly ──> CREATE2 factory (0x4e59b448...)
                                                 ├── SparkStrategyFactory
                                                 ├── AaveV3StrategyFactory
                                                 └── RocketPoolStrategyFactory
```

No constructor arguments, and the tokenized strategy implementation is a `createStrategy()`
parameter — so batch 4 does not depend on batch 1.

Gas: **6.8M** measured against the 16.78M EIP-7825 limit (batch 1 is the tight one at ~12.9M).

## Three fixes found along the way

**1. The staging script could not write its output file.** `staging/DeployProtocol.s.sol` ends by
writing every deployed address to `contract_addresses.txt`, but that path was missing from
`fs_permissions`, so Foundry reverted the final step. With `--broadcast` that meant contracts
deployed on-chain and no address file for CD. Pre-existing; separate commit.

**2. The Safe batch script could not be dry-run.** `deploy/DeployNewStrategiesAndFactories.s.sol`
had `executeBatch(true)` hardcoded in all 8 call sites — any run attempted a real Safe proposal.
Now it simulates by default, matching the prod script; `SEND=true` submits.

**3. Address assertions were missing.** The batch script discarded the return of
`_addCreate2Deployment`, so a salt or bytecode drift would have produced a Safe payload whose
logged addresses were never going to be deployed. Every queued deployment now asserts
`deployed == precomputed`.

## Before proposing: on-chain state

Checked on mainnet with `cast code`. **Batches are not all unexecuted:**

| Target | Mainnet | Consequence |
|---|---|---|
| `YieldSkimmingTokenizedStrategy` → `0x64E0fC68…` | deployed (bytecode matches current source exactly) | **`runBatch1()` reverts today** |
| `YieldDonatingTokenizedStrategy` → `0x21543116…` | empty | a different implementation lives at `0xb27064A2…` |
| Spark / Aave V3 / Rocket Pool | all empty | **batch 4 is proposable as-is** |

## Tests

12 new tests — previously **zero** covered any deployment script.

- salt uniqueness + CREATE2 collision-freedom across all 13 contracts
- every contract actually deploys through the CREATE2 factory (catches a reverting constructor
  or bytecode over the EIP-170 limit)
- the addresses the script precomputes and logs match what deployment produces
- the address assertion itself reverts on mismatch — deleting the `require` fails CI
- standalone scripts use salted CREATE2, not plain CREATE
- staging reuses mainnet's recorded addresses

They run on a fresh EVM and cannot see whether a target is already occupied on a given chain —
that is what the fork simulation below is for.

## Verification

```
forge build (default + mainnet profiles)   ok
forge test --match-path "test/unit/**"     2082 passed, 0 failed
yarn lint                                  0 errors
computeAllAddresses()                      18 addresses identical before/after the refactor
```

Batch 4 simulated against a mainnet fork — no `--broadcast`, no `SEND`:

```
== Logs ==
  Using Safe: 0x4B55fA101Dfa399af2FCDa83bB9e77bCa0009418

  === BATCH 4: Spark, Aave V3, and Rocket Pool Factories ===
  - SparkStrategyFactory: 0xE21e97F68dD64EA505039abdFc6A507A8AaB974D
  - AaveV3StrategyFactory: 0x9788464d8aA84130dB7dF35f41620C8d1272E9c1
  - RocketPoolStrategyFactory: 0x0f4D398503F4272C5c8dA4B2E7B5E3aB6A2AdFf8

  === BATCH 4 SUMMARY ===
  Safe Address: 0x4B55fA101Dfa399af2FCDa83bB9e77bCa0009418
  Contracts: 3 (nonce N+3)
    SparkStrategyFactory: 0xE21e97F68dD64EA505039abdFc6A507A8AaB974D
    AaveV3StrategyFactory: 0x9788464d8aA84130dB7dF35f41620C8d1272E9c1
    RocketPoolStrategyFactory: 0x0f4D398503F4272C5c8dA4B2E7B5E3aB6A2AdFf8
  SIMULATION ONLY -- nothing sent. Re-run with SEND=true to submit.
```

## Known, not addressed here

- `DeployedAddresses.sol` lists Lido/Spark/Aave/Rocket Pool as `address(0)` on every network. Correct
  for a first deployment, but the real addresses must be written back afterwards or staging
  redeploys them each run.
- `VerifyProtocolDeployment`'s hardcoded mainnet defaults for both tokenized strategy
  implementations point at addresses with no code on mainnet, so that fork suite cannot run green
  against production today. Pre-existing.
- `DeployAllStrategiesAndFactories.s.sol` (salts `05112025`) no longer reproduces the recorded
  mainnet addresses and is not covered by this PR. Left untouched pending a decision.
