### PR TITLE
feat(script): deploy AaveV3, Spark, Lido and RocketPool factories in one Safe transaction

### DIFF
--- a/doc/adr/ADR-001-unified-production-registry.md
+++ b/doc/adr/ADR-001-unified-production-registry.md
@@ -1,0 +1,83 @@
+# ADR-001: Use One Canonical Production Registry
+
+## Status
+
+Proposed
+
+## Context
+
+Octant deployment tooling needs an on-chain source of truth for production contract
+addresses. The registry must support deterministic Safe deployment batches, factory
+replacement, lifecycle signaling, auditability, and reliable off-chain export.
+
+The initial design split these responsibilities between:
+
+- `OctantRegistry`, which stored the latest address for each key; and
+- `ReleaseRegistry`, which stored append-only factory release history.
+
+That split made every factory deployment update two independently administered contracts.
+The two registries could disagree after a partial or incorrectly ordered transaction, their
+version concepts overlapped, and consumers needed policy knowledge to decide which registry
+was authoritative.
+
+Three alternatives were considered:
+
+1. Keep the two-registry design and enforce coordination only in deployment scripts.
+2. Store an unbounded array of every revision for every key in one contract.
+3. Store canonical current state in one contract and use events for complete history.
+
+## Decision
+
+Use one non-upgradeable `OctantRegistry` as the canonical production discovery registry.
+
+An owner publication is an atomic `publishBatch` call with:
+
+- the expected current epoch;
+- one or more typed entry updates;
+- a human-readable release label.
+
+Every successful batch increments one global epoch. Each entry records its current address,
+immutable semantic type, lifecycle status, per-key bump, latest epoch, optional API
+compatibility version, and observed runtime code hash. Known keys are append-only.
+`DEPRECATED` represents an intentionally superseded entry, while `DISABLED` represents one
+that is explicitly unsupported or unsafe. These statuses affect discovery only.
+
+Current state is queryable on-chain. Complete history is emitted through
+`EntryPublished` and `BatchPublished` events rather than duplicated in unbounded storage.
+Inactive entries remain inspectable but do not resolve through the active-address getters.
+The registry computes publication manifests itself using a versioned domain that binds the
+chain ID, registry address, expected epoch, release-label hash, and complete ordered update
+array. Callers cannot supply or substitute the digest.
+
+The registry is intentionally not a proxy. A validated, one-time successor pointer provides
+an explicit migration path and permanently freezes the superseded registry.
+
+## Consequences
+
+Positive consequences:
+
+- A deployment and all of its discovery updates have one atomic consistency boundary.
+- There is one authority, one key namespace, and one lifecycle model.
+- Stale Safe proposals fail through optimistic epoch concurrency control.
+- Event history remains complete without making publication cost grow with history length.
+- Runtime code hashes and manifest hashes make off-chain verification deterministic.
+- Factory and non-factory contracts use the same discovery and deprecation semantics.
+
+Trade-offs:
+
+- Contracts cannot enumerate historical revisions without reading logs or an indexer.
+- Event availability is part of the operational archival model.
+- Consumers that require immutable historical proofs must pin a block and retain receipts.
+- Migrating the registry changes its address and requires consumers to follow the explicit
+  successor pointer.
+
+The repository release label is metadata only. Entry compatibility versions must describe
+the registered contract API and must not be inferred from the repository package version.
+The canonical exporter reads finalized state by default, verifies the pinned height's block
+hash before and after all calls, writes atomically, and rejects superseded registry instances
+to prevent inconsistent or stale artifact generation.
+
+## References
+
+- [Pull request #468](https://github.com/golemfoundation/octant-v2-core/pull/468)
+- [Registry design review](https://github.com/golemfoundation/octant-v2-core/pull/468#pullrequestreview-4753930432)

--- a/foundry.toml
+++ b/foundry.toml
@@ -15,7 +15,8 @@ ast = true
 fs_permissions = [
     { access = "read-write", path = "./cache/test-artifacts/" },
     { access = "read", path = "./out/" },
-    { access = "read-write", path = "./partners/" }
+    { access = "read-write", path = "./partners/" },
+    { access = "read", path = "./package.json" }
 ]
 build_info = true
 extra_output = ["storageLayout"]

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "slither:setup": "python3 -m venv .venv && .venv/bin/pip3 install slither-analyzer",
     "slither": ".venv/bin/slither . --print human-summary",
     "slither:ci": "bash script/slither-ci.sh",
+    "registry:export": "node scripts/export-registry.mjs",
+    "registry:test": "node --test scripts/export-registry.test.mjs",
     "semver:diff": "node scripts/sol-semver.mjs diff",
     "semver:check": "node scripts/sol-semver.mjs check",
     "init": "husky && shx chmod +x .husky/*",

--- a/script/deploy/DEPLOYMENT_GUIDE.md
+++ b/script/deploy/DEPLOYMENT_GUIDE.md
@@ -7,9 +7,11 @@ This guide explains how to deploy all the tokenized strategies and factory contr
 The deployment script `DeployAllStrategiesAndFactories.s.sol` deploys the following contracts:
 
 ### Tokenized Strategy Implementations
+
 1. **YieldDonatingTokenizedStrategy** - Base implementation for productive assets with discrete harvesting
 
 ### Factory Contracts
+
 1. **MorphoCompounderStrategyFactory** - Factory for deploying Morpho yield donating strategies
 2. **SkyCompounderStrategyFactory** - Factory for deploying Sky Compounder yield donating strategies
 3. **PaymentSplitterFactory** - Factory for deploying PaymentSplitter contracts with minimal proxies
@@ -27,8 +29,9 @@ The deployment script `DeployAllStrategiesAndFactories.s.sol` deploys the follow
 ## Supported Chains
 
 The deployment script supports the following chains:
+
 - **Ethereum Mainnet** (chainId: 1)
-- **Polygon** (chainId: 137) 
+- **Polygon** (chainId: 137)
 - **Goerli** (chainId: 5)
 - **Sepolia** (chainId: 11155111)
 - **Base** (chainId: 8453)
@@ -87,6 +90,7 @@ The script signs the Safe transaction once and submits it to the Safe transactio
 ### 3. Sign the Transaction in Safe
 
 After running the script:
+
 1. The batch transaction will be sent to the Safe transaction service
 2. Safe owners will receive notifications (if configured)
 3. Navigate to the Safe web interface or use Safe CLI to sign the transaction
@@ -97,7 +101,9 @@ After running the script:
 All contracts are deployed deterministically using CREATE2, which means they will have the same address across different networks if deployed with the same Safe address.
 
 ### Deployment Salts
+
 All salts use a date-based format (DDMMYYYY) for versioning:
+
 - YieldDonatingTokenizedStrategy: `keccak256("OCTANT_YIELD_DONATING_STRATEGY_05112025")`
 - MorphoCompounderStrategyFactory: `keccak256("MORPHO_COMPOUNDER_FACTORY_05112025")`
 - SkyCompounderStrategyFactory: `keccak256("SKY_COMPOUNDER_FACTORY_05112025")`
@@ -116,3 +122,116 @@ All salts use a date-based format (DDMMYYYY) for versioning:
    - CREATE2 factory deploys each contract deterministically
 4. **Sends to Safe Backend**: Submits the transaction to Safe's backend for owner signatures
 5. **Logs Deployment Info**: Outputs all expected contract addresses
+
+## Registry
+
+The on-chain **OctantRegistry** (`src/registry/OctantRegistry.sol`) is the source of truth for
+production contract addresses. `script/helpers/DeployedAddresses.sol` and any
+`deployments/<chainId>.json` file are caches derived from it.
+
+### Atomic register-on-deploy rule
+
+Every Safe deploy batch MUST register the contracts it deploys in the same Safe transaction.
+Because all deployments are CREATE2-precomputed, the batch can call
+`OctantRegistry.publishBatch(expectedEpoch, updates, releaseLabel)` with the
+precomputed addresses right after the deploy calls. Use the `BatchScript` helper:
+
+- `_addRegistryPublication(registry, expectedEpoch, updates, releaseLabel)` —
+  appends one atomic registry publication to the batch
+- `_startNewBatch()` — clears staged calls so one script run can propose several
+  sequential Safe transactions (consecutive nonces, fetched once). Use this when a single
+  transaction would exceed the EIP-7825 gas cap (16,777,216): split into multiple batches,
+  each pairing its deployments with its own `publishBatch` at the next expected epoch, so
+  every batch stays internally atomic and out-of-order execution reverts on the epoch check.
+
+Deploy scripts must assert (against the simulated batch state, before proposing) that every
+deployed address resolves in the registry — see `_assertRegistrations()` in
+`DeployAaveSparkLidoFactories.s.sol` for the reference pattern. A batch that deploys without
+registering must fail the script.
+
+`expectedEpoch` protects a prepared Safe proposal from silently overwriting a newer
+publication. The registry computes its manifest hash internally with `RegistryManifest.hash`,
+which domain-separates the digest and commits to the chain ID, registry address, expected
+epoch, release-label hash, and complete ordered update array. Callers cannot substitute an
+unrelated digest. Deploy scripts may compute the same hash before execution for assertions and
+review. A successful publication increments the global epoch exactly once and emits one
+`EntryPublished` event per update followed by `BatchPublished`.
+
+### Key naming convention
+
+Registry keys are `bytes32` **short-strings** (readable on Etherscan), equal to the CREATE2
+salt name WITHOUT the date suffix:
+
+| Salt                                | Registry key                                   |
+| ----------------------------------- | ---------------------------------------------- |
+| `AAVE_V3_STRATEGY_FACTORY_21072026` | `AAVE_V3_STRATEGY_FACTORY`                     |
+| `LIDO_STRATEGY_FACTORY_21072026`    | `LIDO_STRATEGY_FACTORY`                        |
+| `OCTANT_REGISTRY_22072026`          | — (the registry itself is not self-registered) |
+
+Keys must fit in 32 bytes. If a salt base name is longer (e.g.
+`REGEN_EARNING_POWER_CALCULATOR_FACTORY`, 38 chars), shorten it deterministically and document
+the mapping in `src/registry/RegistryKeys.sol` (registered as
+`EARNING_POWER_CALCULATOR_FACTORY`). Deploy scripts MUST use the constants from
+`RegistryKeys` instead of declaring local key literals.
+
+Keys use uppercase ASCII letters, digits, and underscores with right-zero padding. They are
+append-only: a key can be deprecated, disabled, or reactivated, but is never deleted.
+
+### Registry deployment and ownership
+
+The registry is deployed through the same Arachnid CREATE2 factory inside the Safe batch
+(salt convention: `OCTANT_REGISTRY_<DDMMYYYY>`). Its CREATE2 address commits to the
+constructor arg (`initialOwner`, the Safe). On a future chain where the Safe address differs,
+deploy with the configured owner and hand over via `Ownable2Step`
+(`transferOwnership` + `acceptOwnership`), keeping the salt/init-code scheme so the address
+stays reproducible.
+
+Ownership cannot be renounced. If the registry must be replaced, the owner calls
+`setSuccessorOnce(expectedEpoch, successor)`. The successor must implement
+`IOctantRegistry`, must itself be current, and setting it permanently freezes publications
+on the old registry.
+
+### Entry lifecycle and versioning
+
+Each key stores its current address, semantic type, lifecycle status, per-key bump, last
+publication epoch, optional compatibility version, and observed runtime code hash.
+
+- `ACTIVE` entries resolve through `getAddress` and `tryGetAddress`.
+- `DEPRECATED` means intentionally superseded; `DISABLED` means explicitly unsupported or
+  unsafe. Both retain their address and history but do not resolve as active dependencies.
+- Status is a discovery signal only. Disabling an entry does not pause, revoke, or otherwise
+  control the registered contract.
+- An entry's type (`CONTRACT`, `FACTORY`, or `REGISTRY`) is fixed by its first publication.
+- The optional `compatibilityVersion` describes the registered contract's public API. It is
+  not the repository package version.
+- **Generations**: the canonical key always points at the **latest** deployment of each kind.
+  Superseded generations keep versioned keys (`*_V1`, `*_V2`, … in deployment order) so the
+  registry reflects the complete production history. Because new keys must start `ACTIVE`,
+  a legacy entry registers ACTIVE in the epoch that introduces it and is flipped to
+  `DEPRECATED` in a later epoch (see the two-batch flow in
+  `DeployAaveSparkLidoFactories.s.sol`).
+
+The `releaseLabel` is human-readable deployment metadata (normally the `package.json`
+version). The contract-computed `manifestHash` is the deterministic publication commitment.
+Historical state is reconstructed from `EntryPublished` and `BatchPublished` events; only
+current state is stored on-chain.
+
+### Regenerating off-chain views
+
+```bash
+REGISTRY_ADDRESS=0x... ETH_RPC_URL=https://... yarn registry:export
+```
+
+The exporter selects the `finalized` block by default, pins every call to its numeric height,
+and verifies the block hash again after all reads. If the height was replaced, it aborts
+without overwriting the existing artifact. Set `REGISTRY_SNAPSHOT=safe`, `latest`, or an
+explicit block only when fresher state is required; the before/after hash check still applies.
+The artifact is written through an atomic rename after verification.
+
+The exporter records the snapshot tag, number, and hash. It exports canonical hexadecimal
+keys alongside their decoded labels, complete entry metadata, global epoch, manifest hash,
+release label, and registry API version. It fails if the selected registry has a successor so
+an obsolete frozen registry cannot overwrite the canonical artifact. Never hand-edit
+`deployments/<chainId>.json`; re-run the generator after every deploy batch.
+`DeployedAddresses.sol` remains hand-maintained for script convenience, but the on-chain
+registry always wins on conflict.

--- a/script/deploy/DeployAaveSparkLidoFactories.s.sol
+++ b/script/deploy/DeployAaveSparkLidoFactories.s.sol
@@ -8,18 +8,20 @@ import { BatchScript } from "../helpers/BatchScript.sol";
 import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
 import { SparkStrategyFactory } from "src/factories/SparkStrategyFactory.sol";
 import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
+import { RocketPoolStrategyFactory } from "src/factories/yieldSkimming/RocketPoolStrategyFactory.sol";
 
 /**
  * @title DeployAaveSparkLidoFactories
  * @author Golem Foundation
- * @notice Deploys the AaveV3, Spark, and Lido strategy factories in ONE Safe transaction
- * @dev Safe calls MultiSendCallOnly which makes three calls to the CREATE2 factory.
+ * @notice Deploys the AaveV3, Spark, Lido, and RocketPool strategy factories in ONE Safe transaction
+ * @dev Safe calls MultiSendCallOnly which makes four calls to the CREATE2 factory.
  *
  *      Gas budget (EIP-7825 per-transaction cap: 16,777,216):
- *        - AaveV3StrategyFactory: ~15.3KB runtime -> ~3.4M gas
- *        - SparkStrategyFactory:  ~10.5KB runtime -> ~2.4M gas
- *        - LidoStrategyFactory:    ~7.9KB runtime -> ~1.8M gas
- *      Total ~8M gas including Safe/MultiSend overhead - fits in a single transaction.
+ *        - AaveV3StrategyFactory:     ~15.3KB runtime -> ~3.1M gas
+ *        - SparkStrategyFactory:      ~10.5KB runtime -> ~2.1M gas
+ *        - LidoStrategyFactory:        ~7.9KB runtime -> ~1.6M gas
+ *        - RocketPoolStrategyFactory:  ~7.9KB runtime -> ~1.6M gas
+ *      Total ~9.5M gas including calldata and Safe/MultiSend overhead - fits in a single transaction.
  *
  *      The factories embed their strategy creation code and hardcode Ethereum mainnet
  *      protocol addresses (Aave AddressesProvider, wstETH, USDC), so this script targets
@@ -46,11 +48,13 @@ contract DeployAaveSparkLidoFactories is Script, BatchScript {
     bytes32 public constant AAVE_V3_FACTORY_SALT = keccak256("AAVE_V3_STRATEGY_FACTORY_21072026");
     bytes32 public constant SPARK_FACTORY_SALT = keccak256("SPARK_STRATEGY_FACTORY_21072026");
     bytes32 public constant LIDO_FACTORY_SALT = keccak256("LIDO_STRATEGY_FACTORY_21072026");
+    bytes32 public constant ROCKET_POOL_FACTORY_SALT = keccak256("ROCKET_POOL_STRATEGY_FACTORY_21072026");
 
     // Deployed addresses (computed, logged after proposal)
     address public aaveV3Factory;
     address public sparkFactory;
     address public lidoFactory;
+    address public rocketPoolFactory;
 
     address public safe;
 
@@ -86,6 +90,10 @@ contract DeployAaveSparkLidoFactories is Script, BatchScript {
             LIDO_FACTORY_SALT,
             keccak256(type(LidoStrategyFactory).creationCode)
         );
+        rocketPoolFactory = _computeCreate2AddressViaFactory(
+            ROCKET_POOL_FACTORY_SALT,
+            keccak256(type(RocketPoolStrategyFactory).creationCode)
+        );
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -93,7 +101,7 @@ contract DeployAaveSparkLidoFactories is Script, BatchScript {
     // ═══════════════════════════════════════════════════════════════════════
 
     function _addFactoryDeployments() internal {
-        console.log("\n=== SINGLE BATCH: AaveV3 + Spark + Lido Factories ===\n");
+        console.log("\n=== SINGLE BATCH: AaveV3 + Spark + Lido + RocketPool Factories ===\n");
 
         _addCreate2Deployment(AAVE_V3_FACTORY_SALT, type(AaveV3StrategyFactory).creationCode);
         console.log("- AaveV3StrategyFactory:", aaveV3Factory);
@@ -103,6 +111,9 @@ contract DeployAaveSparkLidoFactories is Script, BatchScript {
 
         _addCreate2Deployment(LIDO_FACTORY_SALT, type(LidoStrategyFactory).creationCode);
         console.log("- LidoStrategyFactory:", lidoFactory);
+
+        _addCreate2Deployment(ROCKET_POOL_FACTORY_SALT, type(RocketPoolStrategyFactory).creationCode);
+        console.log("- RocketPoolStrategyFactory:", rocketPoolFactory);
     }
 
     // ═══════════════════════════════════════════════════════════════════════
@@ -112,14 +123,15 @@ contract DeployAaveSparkLidoFactories is Script, BatchScript {
     function _logDeploymentSummary() internal view {
         console.log("\n=== DEPLOYMENT SUMMARY ===");
         console.log("Safe Address:", safe);
-        console.log("Contracts: 3 (one Safe transaction)");
+        console.log("Contracts: 4 (one Safe transaction)");
         console.log("  AaveV3StrategyFactory:", aaveV3Factory);
         console.log("  SparkStrategyFactory:", sparkFactory);
         console.log("  LidoStrategyFactory:", lidoFactory);
+        console.log("  RocketPoolStrategyFactory:", rocketPoolFactory);
         console.log("\nBatch transaction created:");
         console.log("- Safe will call execTransaction once");
         console.log("- execTransaction calls MultiSendCallOnly");
-        console.log("- MultiSendCallOnly makes 3 calls to the CREATE2 factory");
+        console.log("- MultiSendCallOnly makes 4 calls to the CREATE2 factory");
         console.log("- CREATE2 factory deploys each contract deterministically");
         console.log("\nTransaction sent to Safe for signing.");
         console.log("==========================\n");

--- a/script/deploy/DeployAaveSparkLidoFactories.s.sol
+++ b/script/deploy/DeployAaveSparkLidoFactories.s.sol
@@ -1,83 +1,145 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.25;
 
 import "forge-std/Script.sol";
 import { BatchScript } from "../helpers/BatchScript.sol";
+import { DeployedAddresses } from "../helpers/DeployedAddresses.sol";
 
-// Factory contracts
+import { OctantRegistry } from "src/registry/OctantRegistry.sol";
+import { RegistryKeys } from "src/registry/RegistryKeys.sol";
+import { RegistryManifest } from "src/registry/RegistryManifest.sol";
+import { IOctantRegistry } from "src/interfaces/IOctantRegistry.sol";
 import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
 import { SparkStrategyFactory } from "src/factories/SparkStrategyFactory.sol";
 import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
 import { RocketPoolStrategyFactory } from "src/factories/yieldSkimming/RocketPoolStrategyFactory.sol";
+import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
 
 /**
  * @title DeployAaveSparkLidoFactories
  * @author Golem Foundation
- * @notice Deploys the AaveV3, Spark, Lido, and RocketPool strategy factories in ONE Safe transaction
- * @dev Safe calls MultiSendCallOnly which makes four calls to the CREATE2 factory.
+ * @notice Deploys OctantRegistry, four strategy factories, and the fresh 1.1.0 YieldSkimming
+ *         and YieldDonating singletons across two Safe transactions with sequential nonces
+ * @dev Each batch deploys through CREATE2 and atomically publishes the deployed addresses,
+ *      with a deterministic manifest hash binding the chain, registry, expected epoch,
+ *      release label, and updates.
  *
- *      Gas budget (EIP-7825 per-transaction cap: 16,777,216):
- *        - AaveV3StrategyFactory:     ~15.3KB runtime -> ~3.1M gas
- *        - SparkStrategyFactory:      ~10.5KB runtime -> ~2.1M gas
- *        - LidoStrategyFactory:        ~7.9KB runtime -> ~1.6M gas
- *        - RocketPoolStrategyFactory:  ~7.9KB runtime -> ~1.6M gas
- *      Total ~9.5M gas including calldata and Safe/MultiSend overhead - fits in a single transaction.
+ *      Generation model: canonical keys always point at the LATEST deployment of each kind;
+ *      superseded generations keep versioned keys (*_V1, *_V2 in deployment order) so the
+ *      registry reflects the complete production history. Legacy entries register ACTIVE in
+ *      epoch 1 (new keys must start ACTIVE) and are flipped to DEPRECATED in epoch 2 - a
+ *      discovery signal only; the contracts themselves are untouched.
  *
- *      The factories embed their strategy creation code and hardcode Ethereum mainnet
- *      protocol addresses (Aave AddressesProvider, wstETH, USDC), so this script targets
- *      Ethereum mainnet (or a mainnet fork such as Tenderly staging).
+ *      Two batches because of the EIP-7825 per-transaction gas cap (16,777,216): code
+ *      deposits alone are ~16.9M across the seven contracts, so one transaction carrying
+ *      all deployments plus the publications cannot fit.
+ *        - Batch 1 (~13.5M): OctantRegistry + 4 factories + publishBatch epoch 0->1
+ *          (22 entries: new factories, latest 11022026-generation backfill, and the
+ *          superseded generations under *_V1 / *_V2 keys)
+ *        - Batch 2 (~8.6M): fresh 1.1.0 YieldSkimming (~20KB) and YieldDonating (~16KB)
+ *          singletons + publishBatch epoch 1->2 (canonical singleton keys with
+ *          compatibility "1.1.0", plus DEPRECATED flips for all 7 legacy entries)
+ *      Batch 2's expectedEpoch=1 means it can only execute after batch 1 - out-of-order
+ *      execution reverts. Both proposals are created in one script run.
  *
- *      TokenizedStrategy implementations (YieldDonating / YieldSkimming) are NOT deployed
- *      here - factories receive the implementation address as a parameter at
- *      createStrategy() time. Use the addresses from the 11022026 deployment.
- *
- * Usage:
- * ```bash
- * export SAFE_ADDRESS=0x...
- * export WALLET_TYPE=local  # or ledger
- * export PRIVATE_KEY=0x...  # required for WALLET_TYPE=local
- * export SENDER=0x...       # must be a Safe owner or delegate
- * export ETH_RPC_URL=https://...
- *
- * forge script script/deploy/DeployAaveSparkLidoFactories.s.sol \
- *   --rpc-url $ETH_RPC_URL --ffi --sender $SENDER
- * ```
+ *      The factories embed Ethereum mainnet protocol addresses, so execution is restricted
+ *      to chain id 1. Mainnet forks retain chain id 1 and remain supported for simulation.
  */
-contract DeployAaveSparkLidoFactories is Script, BatchScript {
-    // Deployment salts for deterministic addresses (date-based: DDMMYYYY format)
+contract DeployAaveSparkLidoFactories is DeployedAddresses, BatchScript {
+    bytes32 public constant OCTANT_REGISTRY_SALT = keccak256("OCTANT_REGISTRY_22072026");
     bytes32 public constant AAVE_V3_FACTORY_SALT = keccak256("AAVE_V3_STRATEGY_FACTORY_21072026");
     bytes32 public constant SPARK_FACTORY_SALT = keccak256("SPARK_STRATEGY_FACTORY_21072026");
     bytes32 public constant LIDO_FACTORY_SALT = keccak256("LIDO_STRATEGY_FACTORY_21072026");
     bytes32 public constant ROCKET_POOL_FACTORY_SALT = keccak256("ROCKET_POOL_STRATEGY_FACTORY_21072026");
+    bytes32 public constant YIELD_SKIMMING_SINGLETON_SALT = keccak256("OCTANT_YIELD_SKIMMING_STRATEGY_07082026");
+    bytes32 public constant YIELD_DONATING_SINGLETON_SALT = keccak256("OCTANT_YIELD_DONATING_STRATEGY_07082026");
+    uint64 internal constant INITIAL_REGISTRY_EPOCH = 0;
+    uint64 internal constant SINGLETON_REGISTRY_EPOCH = INITIAL_REGISTRY_EPOCH + 1;
 
-    // Deployed addresses (computed, logged after proposal)
+    /// @dev apiVersion() of the already-deployed 1.0.0-era singletons (mainnet backfill)
+    bytes32 internal constant COMPAT_VERSION_1_0_0 = "1.0.0";
+    /// @dev apiVersion() of the singletons deployed by this batch (v2-core release 1.3.0)
+    bytes32 internal constant COMPAT_VERSION_1_1_0 = "1.1.0";
+
+    // First-generation mainnet deployments (05112025 batch, block 23784110). Superseded by
+    // the 11022026 batch now held in DeployedAddresses, but registered under *_V1 keys so
+    // the registry reflects the complete production history.
+    address internal constant LEGACY_V1_PAYMENT_SPLITTER_FACTORY = 0x5711765E0756B45224fc1FdA1B41ab344682bBcb;
+    address internal constant LEGACY_V1_SKY_COMPOUNDER_FACTORY = 0xbe5352d0eCdB13D9f74c244B634FdD729480Bb6F;
+    address internal constant LEGACY_V1_MORPHO_COMPOUNDER_FACTORY = 0x052d20B0e0b141988bD32772C735085e45F357c1;
+    address internal constant LEGACY_V1_YEARN_V3_STRATEGY_FACTORY = 0x6D8c4E4A158083E30B53ba7df3cFB885fC096fF6;
+    address internal constant LEGACY_V1_YIELD_DONATING_STRATEGY = 0xb27064A2C51b8C5b39A5Bb911AD34DB039C3aB9c;
+
+    address public octantRegistry;
     address public aaveV3Factory;
     address public sparkFactory;
     address public lidoFactory;
     address public rocketPoolFactory;
-
+    address public yieldSkimmingSingleton;
+    address public yieldDonatingSingleton;
     address public safe;
+
+    string public registryReleaseLabel;
+    bytes32 public registryManifestHash;
+    bytes32 public singletonManifestHash;
+
+    bytes32[] internal registeredKeys;
+    address[] internal registeredAddrs;
+    IOctantRegistry.EntryType[] internal registeredTypes;
+    bytes32[] internal registeredCompatVersions;
+
+    // Superseded-generation entries: registered ACTIVE in epoch 1 (new keys must start
+    // ACTIVE), then flipped to DEPRECATED by the epoch-2 publication in batch 2.
+    bytes32[] internal legacyKeys;
+    address[] internal legacyAddrs;
+    IOctantRegistry.EntryType[] internal legacyTypes;
+    bytes32[] internal legacyCompatVersions;
+
+    error DeployFactories__UnsupportedChain(uint256 chainId);
+    error DeployFactories__FactoriesNotStaged();
+    error DeployFactories__RegistryEntryMismatch(bytes32 key);
+    error DeployFactories__RegistryMetadataMismatch(bytes32 key);
+    error DeployFactories__RegistryEpochMismatch();
+    error DeployFactories__RegistryManifestMismatch();
+    error DeployFactories__RegistryReleaseLabelMismatch();
 
     function setUp() public {
         safe = _loadSafeAddress();
+        registryReleaseLabel = vm.parseJsonString(vm.readFile("package.json"), ".version");
+
         console.log("Using Safe:", safe);
+        console.log("Registry release label:", registryReleaseLabel);
     }
 
     function run() public isBatch(safe) {
-        _calculateExpectedAddresses();
-        _addFactoryDeployments();
+        require(block.chainid == 1, DeployFactories__UnsupportedChain(block.chainid));
 
-        // Propose the single batch transaction to the Safe backend
+        _calculateExpectedAddresses();
+
+        // Safe transaction 1 (nonce n): registry + factories + epoch-1 publication.
+        // Adding the ~36KB of singleton runtime code here would push the transaction
+        // past the EIP-7825 16,777,216 gas cap, hence the second batch below.
+        _addRegistryDeployment();
+        _addFactoryDeployments();
+        _addRegistryPublication();
+        _assertRegistrations();
+        executeBatch(true);
+
+        // Safe transaction 2 (nonce n+1): fresh 1.1.0 singletons + epoch-2 publication.
+        // Internally atomic like batch 1; expectedEpoch = 1 makes it executable only
+        // after batch 1, so out-of-order execution reverts instead of corrupting state.
+        _startNewBatch();
+        _addSingletonDeployment();
+        _addSingletonPublication();
+        _assertSingletonRegistration();
         executeBatch(true);
 
         _logDeploymentSummary();
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // ADDRESS PRECOMPUTATION
-    // ═══════════════════════════════════════════════════════════════════════
-
     function _calculateExpectedAddresses() internal {
+        octantRegistry = _computeCreate2AddressViaFactory(OCTANT_REGISTRY_SALT, keccak256(_registryCreationCode()));
         aaveV3Factory = _computeCreate2AddressViaFactory(
             AAVE_V3_FACTORY_SALT,
             keccak256(type(AaveV3StrategyFactory).creationCode)
@@ -94,46 +156,331 @@ contract DeployAaveSparkLidoFactories is Script, BatchScript {
             ROCKET_POOL_FACTORY_SALT,
             keccak256(type(RocketPoolStrategyFactory).creationCode)
         );
+        yieldSkimmingSingleton = _computeCreate2AddressViaFactory(
+            YIELD_SKIMMING_SINGLETON_SALT,
+            keccak256(type(YieldSkimmingTokenizedStrategy).creationCode)
+        );
+        yieldDonatingSingleton = _computeCreate2AddressViaFactory(
+            YIELD_DONATING_SINGLETON_SALT,
+            keccak256(type(YieldDonatingTokenizedStrategy).creationCode)
+        );
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // BATCH DEPLOYMENT LOGIC
-    // ═══════════════════════════════════════════════════════════════════════
+    function _registryCreationCode() internal view returns (bytes memory) {
+        return abi.encodePacked(type(OctantRegistry).creationCode, abi.encode(safe));
+    }
+
+    function _addRegistryDeployment() internal {
+        console.log("\n=== SINGLE BATCH: Registry + AaveV3/Spark/Lido/RocketPool Factories ===\n");
+        _addCreate2Deployment(OCTANT_REGISTRY_SALT, _registryCreationCode());
+        console.log("- OctantRegistry:", octantRegistry);
+    }
 
     function _addFactoryDeployments() internal {
-        console.log("\n=== SINGLE BATCH: AaveV3 + Spark + Lido + RocketPool Factories ===\n");
-
         _addCreate2Deployment(AAVE_V3_FACTORY_SALT, type(AaveV3StrategyFactory).creationCode);
-        console.log("- AaveV3StrategyFactory:", aaveV3Factory);
-
         _addCreate2Deployment(SPARK_FACTORY_SALT, type(SparkStrategyFactory).creationCode);
-        console.log("- SparkStrategyFactory:", sparkFactory);
-
         _addCreate2Deployment(LIDO_FACTORY_SALT, type(LidoStrategyFactory).creationCode);
-        console.log("- LidoStrategyFactory:", lidoFactory);
-
         _addCreate2Deployment(ROCKET_POOL_FACTORY_SALT, type(RocketPoolStrategyFactory).creationCode);
+
+        console.log("- AaveV3StrategyFactory:", aaveV3Factory);
+        console.log("- SparkStrategyFactory:", sparkFactory);
+        console.log("- LidoStrategyFactory:", lidoFactory);
         console.log("- RocketPoolStrategyFactory:", rocketPoolFactory);
     }
 
-    // ═══════════════════════════════════════════════════════════════════════
-    // LOGGING
-    // ═══════════════════════════════════════════════════════════════════════
+    function _addRegistryPublication() internal {
+        _stageEntry(RegistryKeys.AAVE_V3_STRATEGY_FACTORY, aaveV3Factory, IOctantRegistry.EntryType.FACTORY);
+        _stageEntry(RegistryKeys.SPARK_STRATEGY_FACTORY, sparkFactory, IOctantRegistry.EntryType.FACTORY);
+        _stageEntry(RegistryKeys.LIDO_STRATEGY_FACTORY, lidoFactory, IOctantRegistry.EntryType.FACTORY);
+        _stageEntry(RegistryKeys.ROCKET_POOL_STRATEGY_FACTORY, rocketPoolFactory, IOctantRegistry.EntryType.FACTORY);
+
+        ContractAddresses memory production = getMainnetAddresses();
+        _stageEntry(
+            RegistryKeys.PAYMENT_SPLITTER_FACTORY,
+            production.paymentSplitterFactory,
+            IOctantRegistry.EntryType.FACTORY
+        );
+        _stageEntry(
+            RegistryKeys.SKY_COMPOUNDER_FACTORY,
+            production.skyCompounderStrategyFactory,
+            IOctantRegistry.EntryType.FACTORY
+        );
+        _stageEntry(
+            RegistryKeys.MORPHO_COMPOUNDER_FACTORY,
+            production.morphoCompounderStrategyFactory,
+            IOctantRegistry.EntryType.FACTORY
+        );
+        _stageEntry(
+            RegistryKeys.EARNING_POWER_CALCULATOR_FACTORY,
+            production.regenEarningPowerCalculatorFactory,
+            IOctantRegistry.EntryType.FACTORY
+        );
+        _stageEntry(
+            RegistryKeys.REGEN_STAKER_FACTORY,
+            production.regenStakerFactory,
+            IOctantRegistry.EntryType.FACTORY
+        );
+        // Deployed 1.0.0-era YieldDonating singletons keep versioned keys so batch 2 can
+        // hand the canonical key to the fresh 1.1.0 deployment: V1 = 05112025 batch,
+        // V2 = 11022026 batch (the latest existing implementation).
+        _stageLegacyEntry(
+            RegistryKeys.YIELD_DONATING_STRATEGY_V1,
+            LEGACY_V1_YIELD_DONATING_STRATEGY,
+            IOctantRegistry.EntryType.CONTRACT,
+            COMPAT_VERSION_1_0_0
+        );
+        _stageLegacyEntry(
+            RegistryKeys.YIELD_DONATING_STRATEGY_V2,
+            production.yieldDonatingTokenizedStrategy,
+            IOctantRegistry.EntryType.CONTRACT,
+            COMPAT_VERSION_1_0_0
+        );
+
+        // First-generation factories (05112025 batch) and the superseded 11022026 Lido
+        // factory keep *_V1 keys; canonical keys carry the latest generation.
+        _stageLegacyEntry(
+            RegistryKeys.PAYMENT_SPLITTER_FACTORY_V1,
+            LEGACY_V1_PAYMENT_SPLITTER_FACTORY,
+            IOctantRegistry.EntryType.FACTORY,
+            bytes32(0)
+        );
+        _stageLegacyEntry(
+            RegistryKeys.SKY_COMPOUNDER_FACTORY_V1,
+            LEGACY_V1_SKY_COMPOUNDER_FACTORY,
+            IOctantRegistry.EntryType.FACTORY,
+            bytes32(0)
+        );
+        _stageLegacyEntry(
+            RegistryKeys.MORPHO_COMPOUNDER_FACTORY_V1,
+            LEGACY_V1_MORPHO_COMPOUNDER_FACTORY,
+            IOctantRegistry.EntryType.FACTORY,
+            bytes32(0)
+        );
+        _stageLegacyEntry(
+            RegistryKeys.YEARN_V3_STRATEGY_FACTORY_V1,
+            LEGACY_V1_YEARN_V3_STRATEGY_FACTORY,
+            IOctantRegistry.EntryType.FACTORY,
+            bytes32(0)
+        );
+        _stageLegacyEntry(
+            RegistryKeys.LIDO_STRATEGY_FACTORY_V1,
+            production.lidoStrategyFactory,
+            IOctantRegistry.EntryType.FACTORY,
+            bytes32(0)
+        );
+        _stageEntry(
+            RegistryKeys.YEARN_V3_STRATEGY_FACTORY,
+            production.yearnV3StrategyFactory,
+            IOctantRegistry.EntryType.FACTORY
+        );
+        _stageEntry(RegistryKeys.ADDRESS_SET_FACTORY, production.addressSetFactory, IOctantRegistry.EntryType.FACTORY);
+        _stageEntry(RegistryKeys.STAKER_ALLOWSET, production.stakerAllowset, IOctantRegistry.EntryType.CONTRACT);
+        _stageEntry(RegistryKeys.STAKER_BLOCKSET, production.stakerBlockset, IOctantRegistry.EntryType.CONTRACT);
+        _stageEntry(
+            RegistryKeys.ALLOCATION_MECHANISM_ALLOWSET,
+            production.allocationMechanismAllowset,
+            IOctantRegistry.EntryType.CONTRACT
+        );
+        _stageEntry(
+            RegistryKeys.REGEN_EARNING_POWER_CALCULATOR,
+            production.regenEarningPowerCalculator,
+            IOctantRegistry.EntryType.CONTRACT
+        );
+
+        IOctantRegistry.Update[] memory updates = _buildRegistryUpdates();
+        registryManifestHash = RegistryManifest.hash(
+            block.chainid,
+            octantRegistry,
+            INITIAL_REGISTRY_EPOCH,
+            updates,
+            registryReleaseLabel
+        );
+        _addRegistryPublication(octantRegistry, INITIAL_REGISTRY_EPOCH, updates, registryReleaseLabel);
+
+        console.log("- Registry entries staged:", registeredKeys.length);
+        console.logBytes32(registryManifestHash);
+    }
+
+    function _stageEntry(bytes32 key, address addr, IOctantRegistry.EntryType entryType) internal {
+        _stageEntry(key, addr, entryType, bytes32(0));
+    }
+
+    /// @dev Stages a superseded-generation entry: published ACTIVE in epoch 1 and recorded
+    ///      for the epoch-2 DEPRECATED flip in batch 2. Skips zero addresses.
+    function _stageLegacyEntry(
+        bytes32 key,
+        address addr,
+        IOctantRegistry.EntryType entryType,
+        bytes32 compatibilityVersion
+    ) internal {
+        if (addr == address(0)) return;
+
+        _stageEntry(key, addr, entryType, compatibilityVersion);
+        legacyKeys.push(key);
+        legacyAddrs.push(addr);
+        legacyTypes.push(entryType);
+        legacyCompatVersions.push(compatibilityVersion);
+    }
+
+    function _stageEntry(
+        bytes32 key,
+        address addr,
+        IOctantRegistry.EntryType entryType,
+        bytes32 compatibilityVersion
+    ) internal {
+        if (addr == address(0)) return;
+
+        registeredKeys.push(key);
+        registeredAddrs.push(addr);
+        registeredTypes.push(entryType);
+        registeredCompatVersions.push(compatibilityVersion);
+    }
+
+    function _buildRegistryUpdates() internal view returns (IOctantRegistry.Update[] memory updates) {
+        uint256 entriesLength = registeredKeys.length;
+        updates = new IOctantRegistry.Update[](entriesLength);
+        for (uint256 i = 0; i < entriesLength; ++i) {
+            updates[i] = IOctantRegistry.Update({
+                key: registeredKeys[i],
+                addr: registeredAddrs[i],
+                entryType: registeredTypes[i],
+                status: IOctantRegistry.EntryStatus.ACTIVE,
+                compatibilityVersion: registeredCompatVersions[i]
+            });
+        }
+    }
+
+    function _addSingletonDeployment() internal {
+        console.log("\n=== SECOND BATCH: YieldSkimming + YieldDonating singletons ===\n");
+        _addCreate2Deployment(YIELD_SKIMMING_SINGLETON_SALT, type(YieldSkimmingTokenizedStrategy).creationCode);
+        console.log("- YieldSkimmingTokenizedStrategy:", yieldSkimmingSingleton);
+        _addCreate2Deployment(YIELD_DONATING_SINGLETON_SALT, type(YieldDonatingTokenizedStrategy).creationCode);
+        console.log("- YieldDonatingTokenizedStrategy:", yieldDonatingSingleton);
+    }
+
+    /// @dev Epoch-2 publication: both fresh 1.1.0 singletons become the canonical keys and
+    ///      every superseded-generation entry (registered ACTIVE in epoch 1, since new keys
+    ///      must start ACTIVE) is flipped to DEPRECATED - a discovery signal only.
+    function _addSingletonPublication() internal {
+        uint256 legacyCount = legacyKeys.length;
+        IOctantRegistry.Update[] memory updates = new IOctantRegistry.Update[](2 + legacyCount);
+        updates[0] = IOctantRegistry.Update({
+            key: RegistryKeys.YIELD_SKIMMING_STRATEGY,
+            addr: yieldSkimmingSingleton,
+            entryType: IOctantRegistry.EntryType.CONTRACT,
+            status: IOctantRegistry.EntryStatus.ACTIVE,
+            compatibilityVersion: COMPAT_VERSION_1_1_0
+        });
+        updates[1] = IOctantRegistry.Update({
+            key: RegistryKeys.YIELD_DONATING_STRATEGY,
+            addr: yieldDonatingSingleton,
+            entryType: IOctantRegistry.EntryType.CONTRACT,
+            status: IOctantRegistry.EntryStatus.ACTIVE,
+            compatibilityVersion: COMPAT_VERSION_1_1_0
+        });
+        for (uint256 i = 0; i < legacyCount; ++i) {
+            updates[2 + i] = IOctantRegistry.Update({
+                key: legacyKeys[i],
+                addr: legacyAddrs[i],
+                entryType: legacyTypes[i],
+                status: IOctantRegistry.EntryStatus.DEPRECATED,
+                compatibilityVersion: legacyCompatVersions[i]
+            });
+        }
+
+        singletonManifestHash = RegistryManifest.hash(
+            block.chainid,
+            octantRegistry,
+            SINGLETON_REGISTRY_EPOCH,
+            updates,
+            registryReleaseLabel
+        );
+        _addRegistryPublication(octantRegistry, SINGLETON_REGISTRY_EPOCH, updates, registryReleaseLabel);
+        console.logBytes32(singletonManifestHash);
+    }
+
+    function _assertSingletonRegistration() internal view {
+        IOctantRegistry registry = IOctantRegistry(octantRegistry);
+
+        _assertActiveSingleton(registry, RegistryKeys.YIELD_SKIMMING_STRATEGY, yieldSkimmingSingleton);
+        _assertActiveSingleton(registry, RegistryKeys.YIELD_DONATING_STRATEGY, yieldDonatingSingleton);
+
+        // Every superseded generation keeps its address but no longer resolves as active
+        uint256 legacyCount = legacyKeys.length;
+        for (uint256 i = 0; i < legacyCount; ++i) {
+            bytes32 key = legacyKeys[i];
+            IOctantRegistry.Entry memory legacy = registry.getEntry(key);
+            require(legacy.addr == legacyAddrs[i], DeployFactories__RegistryEntryMismatch(key));
+            require(
+                legacy.status == IOctantRegistry.EntryStatus.DEPRECATED &&
+                    legacy.entryType == legacyTypes[i] &&
+                    legacy.compatibilityVersion == legacyCompatVersions[i] &&
+                    registry.tryGetAddress(key) == address(0),
+                DeployFactories__RegistryMetadataMismatch(key)
+            );
+        }
+
+        require(registry.epoch() == SINGLETON_REGISTRY_EPOCH + 1, DeployFactories__RegistryEpochMismatch());
+        require(registry.manifestHash() == singletonManifestHash, DeployFactories__RegistryManifestMismatch());
+    }
+
+    function _assertActiveSingleton(IOctantRegistry registry, bytes32 key, address expected) internal view {
+        IOctantRegistry.Entry memory entry = registry.getEntry(key);
+        require(entry.addr == expected, DeployFactories__RegistryEntryMismatch(key));
+        require(
+            entry.entryType == IOctantRegistry.EntryType.CONTRACT &&
+                entry.status == IOctantRegistry.EntryStatus.ACTIVE &&
+                entry.compatibilityVersion == COMPAT_VERSION_1_1_0 &&
+                entry.runtimeCodeHash == expected.codehash,
+            DeployFactories__RegistryMetadataMismatch(key)
+        );
+    }
+
+    function _assertRegistrations() internal view {
+        require(registeredKeys.length >= 4, DeployFactories__FactoriesNotStaged());
+
+        IOctantRegistry registry = IOctantRegistry(octantRegistry);
+        uint256 entriesLength = registeredKeys.length;
+        for (uint256 i = 0; i < entriesLength; ++i) {
+            bytes32 key = registeredKeys[i];
+            IOctantRegistry.Entry memory entry = registry.getEntry(key);
+            require(entry.addr == registeredAddrs[i], DeployFactories__RegistryEntryMismatch(key));
+            require(
+                entry.entryType == registeredTypes[i] &&
+                    entry.status == IOctantRegistry.EntryStatus.ACTIVE &&
+                    entry.compatibilityVersion == registeredCompatVersions[i] &&
+                    entry.runtimeCodeHash == registeredAddrs[i].codehash,
+                DeployFactories__RegistryMetadataMismatch(key)
+            );
+        }
+
+        require(registry.epoch() == INITIAL_REGISTRY_EPOCH + 1, DeployFactories__RegistryEpochMismatch());
+        require(registry.manifestHash() == registryManifestHash, DeployFactories__RegistryManifestMismatch());
+        require(
+            keccak256(bytes(registry.releaseLabel())) == keccak256(bytes(registryReleaseLabel)),
+            DeployFactories__RegistryReleaseLabelMismatch()
+        );
+    }
 
     function _logDeploymentSummary() internal view {
         console.log("\n=== DEPLOYMENT SUMMARY ===");
         console.log("Safe Address:", safe);
-        console.log("Contracts: 4 (one Safe transaction)");
+        console.log("Contracts: 7 (two Safe transactions, sequential nonces)");
+        console.log("  OctantRegistry:", octantRegistry);
         console.log("  AaveV3StrategyFactory:", aaveV3Factory);
         console.log("  SparkStrategyFactory:", sparkFactory);
         console.log("  LidoStrategyFactory:", lidoFactory);
         console.log("  RocketPoolStrategyFactory:", rocketPoolFactory);
-        console.log("\nBatch transaction created:");
-        console.log("- Safe will call execTransaction once");
-        console.log("- execTransaction calls MultiSendCallOnly");
-        console.log("- MultiSendCallOnly makes 4 calls to the CREATE2 factory");
-        console.log("- CREATE2 factory deploys each contract deterministically");
-        console.log("\nTransaction sent to Safe for signing.");
+        console.log("  YieldSkimmingTokenizedStrategy (1.1.0):", yieldSkimmingSingleton);
+        console.log("  YieldDonatingTokenizedStrategy (1.1.0):", yieldDonatingSingleton);
+        console.log("Batch 1 (epoch 1) entries:", registeredKeys.length);
+        console.logBytes32(registryManifestHash);
+        console.log("Batch 2 (epoch 2) updates:", 2 + legacyKeys.length);
+        console.log("  (YSS + YDS active 1.1.0; legacy generations deprecated:", legacyKeys.length, ")");
+        console.logBytes32(singletonManifestHash);
+        console.log("Registry release label:", registryReleaseLabel);
+        console.log("\nBoth batch transactions were sent to the Safe backend for signing.");
+        console.log("Execute them in nonce order; batch 2 reverts unless batch 1 executed first.");
         console.log("==========================\n");
     }
 }

--- a/script/deploy/DeployAaveSparkLidoFactories.s.sol
+++ b/script/deploy/DeployAaveSparkLidoFactories.s.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Script.sol";
+import { BatchScript } from "../helpers/BatchScript.sol";
+
+// Factory contracts
+import { AaveV3StrategyFactory } from "src/factories/AaveV3StrategyFactory.sol";
+import { SparkStrategyFactory } from "src/factories/SparkStrategyFactory.sol";
+import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
+
+/**
+ * @title DeployAaveSparkLidoFactories
+ * @author Golem Foundation
+ * @notice Deploys the AaveV3, Spark, and Lido strategy factories in ONE Safe transaction
+ * @dev Safe calls MultiSendCallOnly which makes three calls to the CREATE2 factory.
+ *
+ *      Gas budget (EIP-7825 per-transaction cap: 16,777,216):
+ *        - AaveV3StrategyFactory: ~15.3KB runtime -> ~3.4M gas
+ *        - SparkStrategyFactory:  ~10.5KB runtime -> ~2.4M gas
+ *        - LidoStrategyFactory:    ~7.9KB runtime -> ~1.8M gas
+ *      Total ~8M gas including Safe/MultiSend overhead - fits in a single transaction.
+ *
+ *      The factories embed their strategy creation code and hardcode Ethereum mainnet
+ *      protocol addresses (Aave AddressesProvider, wstETH, USDC), so this script targets
+ *      Ethereum mainnet (or a mainnet fork such as Tenderly staging).
+ *
+ *      TokenizedStrategy implementations (YieldDonating / YieldSkimming) are NOT deployed
+ *      here - factories receive the implementation address as a parameter at
+ *      createStrategy() time. Use the addresses from the 11022026 deployment.
+ *
+ * Usage:
+ * ```bash
+ * export SAFE_ADDRESS=0x...
+ * export WALLET_TYPE=local  # or ledger
+ * export PRIVATE_KEY=0x...  # required for WALLET_TYPE=local
+ * export SENDER=0x...       # must be a Safe owner or delegate
+ * export ETH_RPC_URL=https://...
+ *
+ * forge script script/deploy/DeployAaveSparkLidoFactories.s.sol \
+ *   --rpc-url $ETH_RPC_URL --ffi --sender $SENDER
+ * ```
+ */
+contract DeployAaveSparkLidoFactories is Script, BatchScript {
+    // Deployment salts for deterministic addresses (date-based: DDMMYYYY format)
+    bytes32 public constant AAVE_V3_FACTORY_SALT = keccak256("AAVE_V3_STRATEGY_FACTORY_21072026");
+    bytes32 public constant SPARK_FACTORY_SALT = keccak256("SPARK_STRATEGY_FACTORY_21072026");
+    bytes32 public constant LIDO_FACTORY_SALT = keccak256("LIDO_STRATEGY_FACTORY_21072026");
+
+    // Deployed addresses (computed, logged after proposal)
+    address public aaveV3Factory;
+    address public sparkFactory;
+    address public lidoFactory;
+
+    address public safe;
+
+    function setUp() public {
+        safe = _loadSafeAddress();
+        console.log("Using Safe:", safe);
+    }
+
+    function run() public isBatch(safe) {
+        _calculateExpectedAddresses();
+        _addFactoryDeployments();
+
+        // Propose the single batch transaction to the Safe backend
+        executeBatch(true);
+
+        _logDeploymentSummary();
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // ADDRESS PRECOMPUTATION
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function _calculateExpectedAddresses() internal {
+        aaveV3Factory = _computeCreate2AddressViaFactory(
+            AAVE_V3_FACTORY_SALT,
+            keccak256(type(AaveV3StrategyFactory).creationCode)
+        );
+        sparkFactory = _computeCreate2AddressViaFactory(
+            SPARK_FACTORY_SALT,
+            keccak256(type(SparkStrategyFactory).creationCode)
+        );
+        lidoFactory = _computeCreate2AddressViaFactory(
+            LIDO_FACTORY_SALT,
+            keccak256(type(LidoStrategyFactory).creationCode)
+        );
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // BATCH DEPLOYMENT LOGIC
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function _addFactoryDeployments() internal {
+        console.log("\n=== SINGLE BATCH: AaveV3 + Spark + Lido Factories ===\n");
+
+        _addCreate2Deployment(AAVE_V3_FACTORY_SALT, type(AaveV3StrategyFactory).creationCode);
+        console.log("- AaveV3StrategyFactory:", aaveV3Factory);
+
+        _addCreate2Deployment(SPARK_FACTORY_SALT, type(SparkStrategyFactory).creationCode);
+        console.log("- SparkStrategyFactory:", sparkFactory);
+
+        _addCreate2Deployment(LIDO_FACTORY_SALT, type(LidoStrategyFactory).creationCode);
+        console.log("- LidoStrategyFactory:", lidoFactory);
+    }
+
+    // ═══════════════════════════════════════════════════════════════════════
+    // LOGGING
+    // ═══════════════════════════════════════════════════════════════════════
+
+    function _logDeploymentSummary() internal view {
+        console.log("\n=== DEPLOYMENT SUMMARY ===");
+        console.log("Safe Address:", safe);
+        console.log("Contracts: 3 (one Safe transaction)");
+        console.log("  AaveV3StrategyFactory:", aaveV3Factory);
+        console.log("  SparkStrategyFactory:", sparkFactory);
+        console.log("  LidoStrategyFactory:", lidoFactory);
+        console.log("\nBatch transaction created:");
+        console.log("- Safe will call execTransaction once");
+        console.log("- execTransaction calls MultiSendCallOnly");
+        console.log("- MultiSendCallOnly makes 3 calls to the CREATE2 factory");
+        console.log("- CREATE2 factory deploys each contract deterministically");
+        console.log("\nTransaction sent to Safe for signing.");
+        console.log("==========================\n");
+    }
+}

--- a/script/helpers/BatchScript.sol
+++ b/script/helpers/BatchScript.sol
@@ -9,6 +9,8 @@ import { Script, console2, StdChains, stdJson, stdMath, StdStorage, stdStorageSa
 
 import { Surl } from "surl/Surl.sol";
 
+import { IOctantRegistry } from "src/interfaces/IOctantRegistry.sol";
+
 // ⭐️ SCRIPT
 abstract contract BatchScript is Script {
     using stdJson for string;
@@ -92,6 +94,13 @@ abstract contract BatchScript is Script {
     }
 
     bytes[] public encodedTxns;
+
+    // Sequential-batch support: the Safe nonce is fetched once per script run and each
+    // proposed batch consumes the next nonce, so one run can propose several ordered
+    // Safe transactions without racing the Safe API's read-after-write consistency.
+    uint256 private cachedBaseNonce;
+    bool private nonceCached;
+    uint256 private proposedBatchCount;
 
     // Modifiers
 
@@ -222,7 +231,15 @@ abstract contract BatchScript is Script {
         if (send_) {
             batch = _signBatch(safe, batch);
             _sendBatch(safe, batch);
+            proposedBatchCount++;
         }
+    }
+
+    // Clears staged transactions so the script can build a subsequent Safe batch.
+    // Simulation state from earlier batches persists, so later batches can assume
+    // the earlier batches executed (they are proposed with sequential nonces).
+    function _startNewBatch() internal {
+        delete encodedTxns;
     }
 
     // Shared helpers for Safe-based deployment scripts
@@ -268,6 +285,18 @@ abstract contract BatchScript is Script {
             return address(0);
         }
         revert("Unexpected CREATE2 return");
+    }
+
+    // Appends one atomic OctantRegistry publication to the current MultiSend batch.
+    // Deploy scripts MUST publish CREATE2-precomputed addresses in the same Safe
+    // transaction that deploys them so deployment and discovery state cannot drift.
+    function _addRegistryPublication(
+        address registry,
+        uint64 expectedEpoch,
+        IOctantRegistry.Update[] memory updates,
+        string memory releaseLabel
+    ) internal {
+        addToBatch(registry, abi.encodeCall(IOctantRegistry.publishBatch, (expectedEpoch, updates, releaseLabel)));
     }
 
     // Private functions
@@ -324,11 +353,19 @@ abstract contract BatchScript is Script {
 
         // Batch gas parameters can all be zero and don't need to be set
 
-        // Get the safe nonce
-        batch.nonce = _getNonce(safe_);
+        // Get the safe nonce; sequential batches in one run consume consecutive nonces
+        batch.nonce = _nextBatchNonce(safe_);
 
         // Get the transaction hash
         batch.txHash = _getTransactionHash(safe_, batch);
+    }
+
+    function _nextBatchNonce(address safe_) private returns (uint256) {
+        if (!nonceCached) {
+            cachedBaseNonce = _getNonce(safe_);
+            nonceCached = true;
+        }
+        return cachedBaseNonce + proposedBatchCount;
     }
 
     function _signBatch(address safe_, Batch memory batch_) private returns (Batch memory) {

--- a/script/helpers/DeployedAddresses.sol
+++ b/script/helpers/DeployedAddresses.sol
@@ -5,8 +5,14 @@ import { Script } from "forge-std/Script.sol";
 
 /**
  * @title DeployedAddresses
- * @notice Centralized registry of previously deployed contract addresses across different networks
- * @dev This contract provides network-specific addresses to enable reusing deployed contracts
+ * @notice Cache of previously deployed contract addresses across different networks
+ * @dev SOURCE OF TRUTH: the on-chain OctantRegistry (src/registry/OctantRegistry.sol) is the
+ *      authoritative record of production deployments; this file is a hand-maintained CACHE
+ *      of it for script convenience and may lag behind. Regenerate off-chain views with
+ *      `yarn registry:export` (scripts/export-registry.mjs), which reads the registry
+ *      on-chain and writes deployments/<chainId>.json.
+ *
+ *      This contract provides network-specific addresses to enable reusing deployed contracts
  *      instead of redeploying them. When an address is set to address(0), the deployment
  *      script will deploy a new instance of that contract.
  *
@@ -79,17 +85,20 @@ contract DeployedAddresses is Script {
         return
             ContractAddresses({
                 linearAllowanceSingleton: address(0),
-                // Factory contracts - existing mainnet deployments
-                paymentSplitterFactory: 0x5711765E0756B45224fc1FdA1B41ab344682bBcb,
-                skyCompounderStrategyFactory: 0xbe5352d0eCdB13D9f74c244B634FdD729480Bb6F,
-                morphoCompounderStrategyFactory: 0x052d20B0e0b141988bD32772C735085e45F357c1,
+                // Factory contracts - latest mainnet generation (11022026 batch, Feb 2026).
+                // First-generation (05112025 batch) addresses live in OctantRegistry
+                // under the *_V1 keys - see DeployAaveSparkLidoFactories.s.sol.
+                paymentSplitterFactory: 0x6584165BB905dD2513CC81C4ef609Ee78FBDFEf9,
+                skyCompounderStrategyFactory: 0x2a3fd5D3ab48cDE74Cb0b179d3C67155119141cC,
+                morphoCompounderStrategyFactory: 0x1eE8Af6604d7e80f155D45a863128Bc79f015275,
                 regenEarningPowerCalculatorFactory: 0xD916da52d277b28CaDFfEE5350bA98cf3d8fa441,
                 regenStakerFactory: 0x6a8250C95d2e866e95fe4749eD540357B8e44a9a,
                 allocationMechanismFactory: address(0),
-                // External strategy contracts - existing mainnet deployments
-                yieldDonatingTokenizedStrategy: 0xb27064A2C51b8C5b39A5Bb911AD34DB039C3aB9c,
-                yearnV3StrategyFactory: 0x6D8c4E4A158083E30B53ba7df3cFB885fC096fF6,
-                lidoStrategyFactory: address(0),
+                // External strategy contracts - latest existing mainnet deployments
+                // (apiVersion 1.0.0; release 1.3.0 deploys fresh 1.1.0 singletons)
+                yieldDonatingTokenizedStrategy: 0xE8797A98710518A6973Cc8612f98154EECF2C711,
+                yearnV3StrategyFactory: 0x9A6c9aA80D4A0d8Da29EcbA62c40ccBBB321abB6,
+                lidoStrategyFactory: 0xc69288F65647DDf8FDBfDc905bdBD21b034b61b8,
                 // AddressSet factory and contracts - to be deployed
                 addressSetFactory: 0x908FA1747a5E12708c0e575875F2685750CFEfD1,
                 stakerAllowset: 0x4FFAb2c015d9dCd5D20d489E644D99ae67a57270,

--- a/scripts/export-registry.mjs
+++ b/scripts/export-registry.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * export-registry.mjs
+ *
+ * Reads one block-consistent snapshot of the on-chain OctantRegistry and regenerates the
+ * `deployments/<chainId>.json` artifact. The on-chain registry is the source of truth for
+ * production deployments; generated JSON files (and script/helpers/DeployedAddresses.sol)
+ * are caches derived from it.
+ *
+ * Requires Foundry's `cast` on the PATH (no npm dependencies).
+ *
+ * Usage:
+ *   REGISTRY_ADDRESS=0x... ETH_RPC_URL=https://... yarn registry:export
+ *   REGISTRY_SNAPSHOT=latest REGISTRY_ADDRESS=0x... ETH_RPC_URL=https://... yarn registry:export
+ */
+import { execFileSync } from "node:child_process";
+import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const ENTRY_TYPES = ["UNSET", "CONTRACT", "FACTORY", "REGISTRY"];
+const ENTRY_STATUSES = ["UNSET", "ACTIVE", "DEPRECATED", "DISABLED"];
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+/** Run a `cast` command and return stdout. */
+function defaultCastRunner(args) {
+  return execFileSync("cast", args, { encoding: "utf8" });
+}
+
+/** Decode a bytes32 short-string (right-padded with zero bytes) to ASCII. */
+function decodeShortString(hex) {
+  const bytes = Buffer.from(hex.replace(/^0x/, ""), "hex");
+  let end = bytes.length;
+  while (end > 0 && bytes[end - 1] === 0) end--;
+  return bytes.subarray(0, end).toString("ascii");
+}
+
+/**
+ * Export one registry snapshot.
+ *
+ * `finalized` is the default snapshot tag. Callers that intentionally need newer state may
+ * select `safe`, `latest`, or an explicit block through REGISTRY_SNAPSHOT; the mandatory
+ * before/after hash check still prevents a replaced numeric height from being written.
+ */
+export function exportRegistry({
+  registry,
+  rpcUrl,
+  snapshotTag = "finalized",
+  outputDirectory = resolve(process.cwd(), "deployments"),
+  generatedAt = new Date(),
+  castRunner = defaultCastRunner,
+}) {
+  if (!registry || !rpcUrl) {
+    throw new Error("REGISTRY_ADDRESS and ETH_RPC_URL are required");
+  }
+
+  /** Run a `cast` subcommand against the configured RPC and return trimmed stdout. */
+  function cast(...args) {
+    return castRunner([...args, "--rpc-url", rpcUrl]).trim();
+  }
+
+  const chainId = Number(cast("chain-id"));
+  const snapshotBlockNumber = BigInt(cast("block", snapshotTag, "--field", "number"));
+  const snapshotBlockHash = cast("block", snapshotBlockNumber.toString(), "--field", "hash");
+
+  /** Read a registry function at the pinned numeric snapshot height. */
+  function registryCall(signature, ...args) {
+    return cast("call", registry, signature, ...args, "--block", snapshotBlockNumber.toString());
+  }
+
+  const count = Number(registryCall("count()(uint256)"));
+  const epoch = Number(registryCall("epoch()(uint64)"));
+  const manifestHash = registryCall("manifestHash()(bytes32)");
+  const releaseLabel = JSON.parse(registryCall("releaseLabel()(string)", "--json"))[0];
+  const registryApiVersion = JSON.parse(registryCall("API_VERSION()(string)", "--json"))[0];
+  const successor = registryCall("getSuccessor()(address)");
+
+  if (successor.toLowerCase() !== ZERO_ADDRESS) {
+    throw new Error(`Registry ${registry} is superseded by ${successor}; export the successor instead.`);
+  }
+
+  const entries = [];
+  for (let i = 0; i < count; i++) {
+    const key = registryCall("keyAt(uint256)(bytes32)", String(i));
+    const [address, updatedAt, bump, entryEpoch, entryType, status, compatibilityVersion, runtimeCodeHash] = JSON.parse(
+      registryCall("getEntry(bytes32)(address,uint64,uint32,uint64,uint8,uint8,bytes32,bytes32)", key, "--json"),
+    );
+
+    const entryTypeNumber = Number(entryType);
+    const statusNumber = Number(status);
+    entries.push({
+      key,
+      label: decodeShortString(key),
+      address,
+      updatedAt: Number(updatedAt),
+      bump: Number(bump),
+      epoch: Number(entryEpoch),
+      entryType: ENTRY_TYPES[entryTypeNumber] ?? `UNKNOWN_${entryTypeNumber}`,
+      status: ENTRY_STATUSES[statusNumber] ?? `UNKNOWN_${statusNumber}`,
+      compatibilityVersion,
+      runtimeCodeHash,
+    });
+  }
+
+  const verifiedSnapshotBlockHash = cast("block", snapshotBlockNumber.toString(), "--field", "hash");
+  if (verifiedSnapshotBlockHash.toLowerCase() !== snapshotBlockHash.toLowerCase()) {
+    throw new Error(
+      `Snapshot block ${snapshotBlockNumber} was replaced during export ` +
+        `(${snapshotBlockHash} -> ${verifiedSnapshotBlockHash}); retry after finality.`,
+    );
+  }
+
+  const artifact = {
+    chainId,
+    registry,
+    snapshot: {
+      tag: snapshotTag,
+      blockNumber: Number(snapshotBlockNumber),
+      blockHash: snapshotBlockHash,
+    },
+    epoch,
+    manifestHash,
+    releaseLabel,
+    registryApiVersion,
+    successor,
+    generatedAt: generatedAt.toISOString(),
+    entries: entries.sort((a, b) => a.key.localeCompare(b.key)),
+  };
+
+  mkdirSync(outputDirectory, { recursive: true });
+  const outFile = resolve(outputDirectory, `${chainId}.json`);
+  const temporaryOutFile = `${outFile}.${process.pid}.tmp`;
+  try {
+    writeFileSync(temporaryOutFile, `${JSON.stringify(artifact, null, 2)}\n`);
+    renameSync(temporaryOutFile, outFile);
+  } catch (error) {
+    rmSync(temporaryOutFile, { force: true });
+    throw error;
+  }
+
+  return { artifact, outFile };
+}
+
+function main() {
+  try {
+    const { artifact, outFile } = exportRegistry({
+      registry: process.env.REGISTRY_ADDRESS,
+      rpcUrl: process.env.ETH_RPC_URL,
+      snapshotTag: process.env.REGISTRY_SNAPSHOT ?? "finalized",
+    });
+    console.log(
+      `Wrote ${artifact.entries.length} entries to ${outFile} ` +
+        `(epoch ${artifact.epoch}, block ${artifact.snapshot.blockNumber})`,
+    );
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main();
+}

--- a/scripts/export-registry.test.mjs
+++ b/scripts/export-registry.test.mjs
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { exportRegistry } from "./export-registry.mjs";
+
+const REGISTRY = "0x1111111111111111111111111111111111111111";
+const BLOCK_HASH_A = `0x${"aa".repeat(32)}`;
+const BLOCK_HASH_B = `0x${"bb".repeat(32)}`;
+const MANIFEST_HASH = `0x${"cc".repeat(32)}`;
+
+function registryFixtureRunner(blockHashes, calls) {
+  return args => {
+    calls.push(args);
+    const command = args[0];
+
+    if (command === "chain-id") return "1\n";
+    if (command === "block" && args[2] === "--field" && args[3] === "number") return "123\n";
+    if (command === "block" && args[2] === "--field" && args[3] === "hash") {
+      return `${blockHashes.shift()}\n`;
+    }
+
+    if (command !== "call") throw new Error(`Unexpected cast command: ${args.join(" ")}`);
+    switch (args[2]) {
+      case "count()(uint256)":
+        return "0\n";
+      case "epoch()(uint64)":
+        return "1\n";
+      case "manifestHash()(bytes32)":
+        return `${MANIFEST_HASH}\n`;
+      case "releaseLabel()(string)":
+        return '["1.3.0"]\n';
+      case "API_VERSION()(string)":
+        return '["1.0.0"]\n';
+      case "getSuccessor()(address)":
+        return "0x0000000000000000000000000000000000000000\n";
+      default:
+        throw new Error(`Unexpected registry call: ${args[2]}`);
+    }
+  };
+}
+
+test("exports a finalized, hash-verified snapshot atomically", () => {
+  const outputDirectory = mkdtempSync(join(tmpdir(), "octant-registry-export-"));
+  const calls = [];
+
+  try {
+    const { artifact, outFile } = exportRegistry({
+      registry: REGISTRY,
+      rpcUrl: "https://rpc.invalid",
+      outputDirectory,
+      generatedAt: new Date("2026-07-28T00:00:00.000Z"),
+      castRunner: registryFixtureRunner([BLOCK_HASH_A, BLOCK_HASH_A], calls),
+    });
+
+    assert.equal(artifact.snapshot.tag, "finalized");
+    assert.equal(artifact.snapshot.blockNumber, 123);
+    assert.equal(artifact.snapshot.blockHash, BLOCK_HASH_A);
+    assert.equal(artifact.manifestHash, MANIFEST_HASH);
+    assert.deepEqual(JSON.parse(readFileSync(outFile, "utf8")), artifact);
+
+    const registryCalls = calls.filter(([command]) => command === "call");
+    assert.ok(registryCalls.length > 0);
+    for (const call of registryCalls) {
+      assert.deepEqual(call.slice(-4), ["--block", "123", "--rpc-url", "https://rpc.invalid"]);
+    }
+  } finally {
+    rmSync(outputDirectory, { recursive: true, force: true });
+  }
+});
+
+test("aborts without writing when the snapshot height is replaced", () => {
+  const outputDirectory = mkdtempSync(join(tmpdir(), "octant-registry-reorg-"));
+  const existingArtifact = '{"preserved":true}\n';
+  writeFileSync(join(outputDirectory, "1.json"), existingArtifact);
+
+  try {
+    assert.throws(
+      () =>
+        exportRegistry({
+          registry: REGISTRY,
+          rpcUrl: "https://rpc.invalid",
+          snapshotTag: "latest",
+          outputDirectory,
+          castRunner: registryFixtureRunner([BLOCK_HASH_A, BLOCK_HASH_B], []),
+        }),
+      /Snapshot block 123 was replaced during export/,
+    );
+    assert.equal(readFileSync(join(outputDirectory, "1.json"), "utf8"), existingArtifact);
+  } finally {
+    rmSync(outputDirectory, { recursive: true, force: true });
+  }
+});

--- a/src/interfaces/IOctantRegistry.sol
+++ b/src/interfaces/IOctantRegistry.sol
@@ -1,0 +1,229 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/**
+ * @title IOctantRegistry
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice Canonical on-chain discovery registry for Octant production contracts
+ * @dev Registry history is represented by indexed events. Current state remains small and
+ *      directly queryable, while every publication is tied to one monotonic epoch and a
+ *      canonical, contract-computed publication manifest.
+ */
+interface IOctantRegistry is IERC165 {
+    /**
+     * @notice Semantic category fixed when a key is first published
+     */
+    enum EntryType {
+        UNSET,
+        CONTRACT,
+        FACTORY,
+        REGISTRY
+    }
+
+    /**
+     * @notice Current lifecycle state of a registry entry
+     * @dev DEPRECATED means intentionally superseded but retained for historical discovery.
+     *      DISABLED means explicitly unsupported or unsafe. Neither inactive state controls
+     *      the registered contract itself; this registry is a discovery layer only.
+     */
+    enum EntryStatus {
+        UNSET,
+        ACTIVE,
+        DEPRECATED,
+        DISABLED
+    }
+
+    /**
+     * @notice Current state stored for a registry key
+     * @param addr Registered contract address
+     * @param updatedAt Timestamp of the latest publication affecting the key
+     * @param bump Monotonic per-key publication counter
+     * @param epoch Registry epoch that last changed the key
+     * @param entryType Semantic category fixed on first publication
+     * @param status Current lifecycle status
+     * @param compatibilityVersion Optional API compatibility version; zero when unspecified
+     * @param runtimeCodeHash Runtime bytecode hash observed at publication
+     */
+    struct Entry {
+        address addr;
+        uint64 updatedAt;
+        uint32 bump;
+        uint64 epoch;
+        EntryType entryType;
+        EntryStatus status;
+        bytes32 compatibilityVersion;
+        bytes32 runtimeCodeHash;
+    }
+
+    /**
+     * @notice One entry change included in an atomic publication
+     * @param key Canonical bytes32 short-string key
+     * @param addr Contract address to activate or whose status is changing
+     * @param entryType Semantic category; immutable after first publication
+     * @param status New lifecycle status
+     * @param compatibilityVersion Optional API compatibility version; zero when unspecified
+     */
+    struct Update {
+        bytes32 key;
+        address addr;
+        EntryType entryType;
+        EntryStatus status;
+        bytes32 compatibilityVersion;
+    }
+
+    /**
+     * @notice Emitted for every entry changed by a publication
+     * @param key Registry key
+     * @param addr New contract address
+     * @param previousAddr Previously registered address
+     * @param entryType Semantic category
+     * @param status New lifecycle status
+     * @param epoch Registry epoch containing the change
+     * @param bump Per-key publication counter
+     * @param compatibilityVersion Optional API compatibility version
+     * @param runtimeCodeHash Runtime bytecode hash observed at publication
+     */
+    event EntryPublished(
+        bytes32 indexed key,
+        address indexed addr,
+        address indexed previousAddr,
+        EntryType entryType,
+        EntryStatus status,
+        uint64 epoch,
+        uint32 bump,
+        bytes32 compatibilityVersion,
+        bytes32 runtimeCodeHash
+    );
+
+    /**
+     * @notice Emitted after all entry changes in an epoch are applied
+     * @param epoch New registry epoch
+     * @param manifestHash Hash of the complete registry publication manifest
+     * @param releaseLabel Human-readable software or deployment release label
+     */
+    event BatchPublished(uint64 indexed epoch, bytes32 indexed manifestHash, string releaseLabel);
+
+    /**
+     * @notice Emitted when this registry is permanently superseded
+     * @param successor Successor registry
+     * @param epoch Final epoch of this registry
+     */
+    event SuccessorSet(address indexed successor, uint64 indexed epoch);
+
+    error OctantRegistry__EmptyBatch();
+    error OctantRegistry__EmptyKey();
+    error OctantRegistry__InvalidKey(bytes32 key);
+    error OctantRegistry__InvalidCompatibilityVersion(bytes32 compatibilityVersion);
+    error OctantRegistry__InvalidEntryType();
+    error OctantRegistry__InvalidEntryStatus();
+    error OctantRegistry__NewEntryMustBeActive(bytes32 key);
+    error OctantRegistry__EntryTypeMismatch(bytes32 key, EntryType expected, EntryType provided);
+    error OctantRegistry__InactiveAddressChange(bytes32 key);
+    error OctantRegistry__NoEntryChange(bytes32 key);
+    error OctantRegistry__DuplicateKey(bytes32 key);
+    error OctantRegistry__ZeroAddress();
+    error OctantRegistry__NotAContract(address addr);
+    error OctantRegistry__KeyNotFound(bytes32 key);
+    error OctantRegistry__KeyNotActive(bytes32 key, EntryStatus status);
+    error OctantRegistry__IndexOutOfBounds(uint256 index, uint256 count);
+    error OctantRegistry__StaleEpoch(uint64 expected, uint64 actual);
+    error OctantRegistry__EpochOverflow();
+    error OctantRegistry__BumpOverflow(bytes32 key);
+    error OctantRegistry__InvalidReleaseLabelLength(uint256 length);
+    error OctantRegistry__AlreadySuperseded(address successor);
+    error OctantRegistry__InvalidSuccessor(address successor);
+    error OctantRegistry__OwnershipRenunciationDisabled();
+
+    /**
+     * @notice Atomically publishes a new registry epoch
+     * @param expectedEpoch Current epoch expected by the proposal
+     * @param updates Entry changes to publish
+     * @param releaseLabel_ Human-readable software or deployment release label
+     * @dev The canonical manifest hash is computed from the chain, this registry, the expected
+     *      epoch, release label, and complete ordered update array.
+     * @custom:security Only callable by the owner while this registry has no successor
+     */
+    function publishBatch(uint64 expectedEpoch, Update[] calldata updates, string calldata releaseLabel_) external;
+
+    /**
+     * @notice Permanently points this registry at its successor and freezes publications
+     * @param expectedEpoch Current epoch expected by the proposal
+     * @param successor_ Successor registry implementing this interface
+     * @custom:security Only callable once by the owner
+     */
+    function setSuccessorOnce(uint64 expectedEpoch, address successor_) external;
+
+    /**
+     * @notice Returns the active address registered for a key
+     * @param key Registry key
+     * @return Registered contract address
+     */
+    function getAddress(bytes32 key) external view returns (address);
+
+    /**
+     * @notice Returns the active address for a key, or zero when absent or inactive
+     * @param key Registry key
+     * @return Registered active address or zero
+     */
+    function tryGetAddress(bytes32 key) external view returns (address);
+
+    /**
+     * @notice Returns the complete current state for a known key
+     * @param key Registry key
+     * @return entry Current entry state
+     */
+    function getEntry(bytes32 key) external view returns (Entry memory entry);
+
+    /**
+     * @notice Returns the number of keys ever published
+     * @return Number of known keys
+     */
+    function count() external view returns (uint256);
+
+    /**
+     * @notice Returns a known key by enumeration index
+     * @param index Index in the append-only key list
+     * @return Registry key
+     */
+    function keyAt(uint256 index) external view returns (bytes32);
+
+    /**
+     * @notice Returns every key ever published
+     * @return Append-only known-key list
+     * @dev Intended for off-chain callers. Use count and keyAt for bounded on-chain iteration.
+     */
+    function list() external view returns (bytes32[] memory);
+
+    /**
+     * @notice Returns the registry interface implementation version
+     * @return Semantic API version, independent of deployment release labels
+     */
+    function API_VERSION() external view returns (string memory);
+
+    /**
+     * @notice Returns the current monotonic registry epoch
+     * @return Current epoch
+     */
+    function epoch() external view returns (uint64);
+
+    /**
+     * @notice Returns the manifest hash associated with the current epoch
+     * @return Current deployment manifest hash
+     */
+    function manifestHash() external view returns (bytes32);
+
+    /**
+     * @notice Returns the release label associated with the current epoch
+     * @return Current human-readable release label
+     */
+    function releaseLabel() external view returns (string memory);
+
+    /**
+     * @notice Returns the successor registry
+     * @return Successor address or zero while this registry is current
+     */
+    function getSuccessor() external view returns (address);
+}

--- a/src/registry/OctantRegistry.sol
+++ b/src/registry/OctantRegistry.sol
@@ -1,0 +1,278 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { Ownable2Step } from "@openzeppelin/contracts/access/Ownable2Step.sol";
+import { ERC165 } from "@openzeppelin/contracts/utils/introspection/ERC165.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { IOctantRegistry } from "../interfaces/IOctantRegistry.sol";
+import { RegistryManifest } from "./RegistryManifest.sol";
+
+/**
+ * @title OctantRegistry
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice Canonical on-chain discovery registry for Octant production contracts
+ * @dev Production contracts must not resolve runtime dependencies through this registry.
+ *      Deployments and their registry publication are bundled in one Safe transaction.
+ *
+ *      Every successful publication increments a global epoch and records a canonical,
+ *      contract-computed commitment to its complete input. Per-key history is available from
+ *      EntryPublished events, while current state stays directly queryable. Keys are
+ *      append-only and entries use explicit lifecycle states instead of destructive deletion.
+ *
+ *      This contract intentionally uses migration rather than proxy upgradeability. Setting
+ *      a validated successor is irreversible and freezes all future publications.
+ */
+contract OctantRegistry is IOctantRegistry, Ownable2Step, ERC165 {
+    /// @notice Contract API version used by repository semver tooling
+    string public constant override API_VERSION = "1.0.0";
+
+    uint256 internal constant MAX_RELEASE_LABEL_LENGTH = 64;
+
+    mapping(bytes32 key => Entry entry) internal _entries;
+    bytes32[] internal _keys;
+
+    uint64 internal _epoch;
+    bytes32 internal _manifestHash;
+    string internal _releaseLabel;
+    address internal _successor;
+
+    /**
+     * @notice Deploys the registry with an explicit initial owner
+     * @param initialOwner Owner of the registry
+     */
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    /// @inheritdoc IOctantRegistry
+    function publishBatch(
+        uint64 expectedEpoch,
+        Update[] calldata updates,
+        string calldata releaseLabel_
+    ) external onlyOwner {
+        require(_successor == address(0), OctantRegistry__AlreadySuperseded(_successor));
+        require(expectedEpoch == _epoch, OctantRegistry__StaleEpoch(expectedEpoch, _epoch));
+        require(expectedEpoch != type(uint64).max, OctantRegistry__EpochOverflow());
+        require(updates.length != 0, OctantRegistry__EmptyBatch());
+
+        uint256 releaseLabelLength = bytes(releaseLabel_).length;
+        require(
+            releaseLabelLength != 0 && releaseLabelLength <= MAX_RELEASE_LABEL_LENGTH,
+            OctantRegistry__InvalidReleaseLabelLength(releaseLabelLength)
+        );
+
+        bytes32 publicationHash = RegistryManifest.hash(
+            block.chainid,
+            address(this),
+            expectedEpoch,
+            updates,
+            releaseLabel_
+        );
+        uint64 nextEpoch = expectedEpoch + 1;
+        _epoch = nextEpoch;
+        _manifestHash = publicationHash;
+        _releaseLabel = releaseLabel_;
+
+        uint256 updatesLength = updates.length;
+        for (uint256 i = 0; i < updatesLength; ++i) {
+            _publishEntry(updates[i], nextEpoch);
+        }
+
+        emit BatchPublished(nextEpoch, publicationHash, releaseLabel_);
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function setSuccessorOnce(uint64 expectedEpoch, address successor_) external onlyOwner {
+        require(_successor == address(0), OctantRegistry__AlreadySuperseded(_successor));
+        require(expectedEpoch == _epoch, OctantRegistry__StaleEpoch(expectedEpoch, _epoch));
+        require(
+            successor_ != address(0) && successor_ != address(this) && successor_.code.length != 0,
+            OctantRegistry__InvalidSuccessor(successor_)
+        );
+
+        (bool supportsInterfaceCallSucceeded, bytes memory supportsInterfaceData) = successor_.staticcall(
+            abi.encodeCall(IERC165.supportsInterface, (type(IOctantRegistry).interfaceId))
+        );
+        require(
+            supportsInterfaceCallSucceeded &&
+                supportsInterfaceData.length == 32 &&
+                abi.decode(supportsInterfaceData, (bool)),
+            OctantRegistry__InvalidSuccessor(successor_)
+        );
+
+        (bool successorCallSucceeded, bytes memory successorData) = successor_.staticcall(
+            abi.encodeCall(IOctantRegistry.getSuccessor, ())
+        );
+        require(
+            successorCallSucceeded && successorData.length == 32 && abi.decode(successorData, (address)) == address(0),
+            OctantRegistry__InvalidSuccessor(successor_)
+        );
+
+        _successor = successor_;
+        emit SuccessorSet(successor_, _epoch);
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function getAddress(bytes32 key) external view returns (address) {
+        Entry storage entry = _entries[key];
+        require(entry.bump != 0, OctantRegistry__KeyNotFound(key));
+        require(entry.status == EntryStatus.ACTIVE, OctantRegistry__KeyNotActive(key, entry.status));
+        return entry.addr;
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function tryGetAddress(bytes32 key) external view returns (address) {
+        Entry storage entry = _entries[key];
+        return entry.status == EntryStatus.ACTIVE ? entry.addr : address(0);
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function getEntry(bytes32 key) external view returns (Entry memory entry) {
+        entry = _entries[key];
+        require(entry.bump != 0, OctantRegistry__KeyNotFound(key));
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function count() external view returns (uint256) {
+        return _keys.length;
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function keyAt(uint256 index) external view returns (bytes32) {
+        uint256 keysLength = _keys.length;
+        require(index < keysLength, OctantRegistry__IndexOutOfBounds(index, keysLength));
+        return _keys[index];
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function list() external view returns (bytes32[] memory) {
+        return _keys;
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function epoch() external view returns (uint64) {
+        return _epoch;
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function manifestHash() external view returns (bytes32) {
+        return _manifestHash;
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function releaseLabel() external view returns (string memory) {
+        return _releaseLabel;
+    }
+
+    /// @inheritdoc IOctantRegistry
+    function getSuccessor() external view returns (address) {
+        return _successor;
+    }
+
+    /// @inheritdoc IERC165
+    function supportsInterface(bytes4 interfaceId) public view override(ERC165, IERC165) returns (bool) {
+        return interfaceId == type(IOctantRegistry).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /**
+     * @notice Ownership renunciation is disabled; use setSuccessorOnce to freeze this registry
+     */
+    function renounceOwnership() public pure override {
+        require(false, OctantRegistry__OwnershipRenunciationDisabled());
+    }
+
+    function _publishEntry(Update calldata update, uint64 nextEpoch) internal {
+        bytes32 key = update.key;
+        _validateKey(key);
+        _validateCompatibilityVersion(update.compatibilityVersion);
+
+        require(update.addr != address(0), OctantRegistry__ZeroAddress());
+        require(update.addr.code.length != 0, OctantRegistry__NotAContract(update.addr));
+        require(update.entryType != EntryType.UNSET, OctantRegistry__InvalidEntryType());
+        require(update.status != EntryStatus.UNSET, OctantRegistry__InvalidEntryStatus());
+
+        Entry storage entry = _entries[key];
+        require(entry.epoch != nextEpoch, OctantRegistry__DuplicateKey(key));
+
+        address previousAddr = entry.addr;
+        bytes32 runtimeCodeHash = update.addr.codehash;
+        if (entry.bump == 0) {
+            require(update.status == EntryStatus.ACTIVE, OctantRegistry__NewEntryMustBeActive(key));
+            _keys.push(key);
+            entry.entryType = update.entryType;
+        } else {
+            require(
+                update.entryType == entry.entryType,
+                OctantRegistry__EntryTypeMismatch(key, entry.entryType, update.entryType)
+            );
+            require(
+                update.status == EntryStatus.ACTIVE || update.addr == previousAddr,
+                OctantRegistry__InactiveAddressChange(key)
+            );
+            require(entry.bump != type(uint32).max, OctantRegistry__BumpOverflow(key));
+            require(
+                update.addr != previousAddr ||
+                    update.status != entry.status ||
+                    update.compatibilityVersion != entry.compatibilityVersion ||
+                    runtimeCodeHash != entry.runtimeCodeHash,
+                OctantRegistry__NoEntryChange(key)
+            );
+        }
+
+        entry.addr = update.addr;
+        entry.updatedAt = uint64(block.timestamp);
+        entry.bump += 1;
+        entry.epoch = nextEpoch;
+        entry.status = update.status;
+        entry.compatibilityVersion = update.compatibilityVersion;
+        entry.runtimeCodeHash = runtimeCodeHash;
+
+        emit EntryPublished(
+            key,
+            update.addr,
+            previousAddr,
+            entry.entryType,
+            update.status,
+            nextEpoch,
+            entry.bump,
+            update.compatibilityVersion,
+            runtimeCodeHash
+        );
+    }
+
+    function _validateKey(bytes32 key) internal pure {
+        require(key != bytes32(0), OctantRegistry__EmptyKey());
+
+        bool encounteredPadding = false;
+        for (uint256 i = 0; i < 32; ++i) {
+            uint8 character = uint8(key[i]);
+            if (character == 0) {
+                encounteredPadding = true;
+            } else {
+                bool isUppercaseLetter = character >= 65 && character <= 90;
+                bool isDigit = character >= 48 && character <= 57;
+                require(
+                    !encounteredPadding && (isUppercaseLetter || isDigit || character == 95),
+                    OctantRegistry__InvalidKey(key)
+                );
+            }
+        }
+    }
+
+    function _validateCompatibilityVersion(bytes32 compatibilityVersion) internal pure {
+        if (compatibilityVersion == bytes32(0)) return;
+
+        bool encounteredPadding = false;
+        for (uint256 i = 0; i < 32; ++i) {
+            uint8 character = uint8(compatibilityVersion[i]);
+            if (character == 0) {
+                encounteredPadding = true;
+            } else {
+                require(
+                    !encounteredPadding && character >= 33 && character <= 126,
+                    OctantRegistry__InvalidCompatibilityVersion(compatibilityVersion)
+                );
+            }
+        }
+    }
+}

--- a/src/registry/RegistryKeys.sol
+++ b/src/registry/RegistryKeys.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+/**
+ * @title RegistryKeys
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice Canonical keys used by OctantRegistry publishers and consumers
+ */
+library RegistryKeys {
+    bytes32 internal constant AAVE_V3_STRATEGY_FACTORY = "AAVE_V3_STRATEGY_FACTORY";
+    bytes32 internal constant SPARK_STRATEGY_FACTORY = "SPARK_STRATEGY_FACTORY";
+    bytes32 internal constant LIDO_STRATEGY_FACTORY = "LIDO_STRATEGY_FACTORY";
+    bytes32 internal constant ROCKET_POOL_STRATEGY_FACTORY = "ROCKET_POOL_STRATEGY_FACTORY";
+    bytes32 internal constant PAYMENT_SPLITTER_FACTORY = "PAYMENT_SPLITTER_FACTORY";
+    bytes32 internal constant PAYMENT_SPLITTER_FACTORY_V1 = "PAYMENT_SPLITTER_FACTORY_V1";
+    bytes32 internal constant SKY_COMPOUNDER_FACTORY = "SKY_COMPOUNDER_FACTORY";
+    bytes32 internal constant SKY_COMPOUNDER_FACTORY_V1 = "SKY_COMPOUNDER_FACTORY_V1";
+    bytes32 internal constant MORPHO_COMPOUNDER_FACTORY = "MORPHO_COMPOUNDER_FACTORY";
+    bytes32 internal constant MORPHO_COMPOUNDER_FACTORY_V1 = "MORPHO_COMPOUNDER_FACTORY_V1";
+    bytes32 internal constant LIDO_STRATEGY_FACTORY_V1 = "LIDO_STRATEGY_FACTORY_V1";
+    bytes32 internal constant YEARN_V3_STRATEGY_FACTORY_V1 = "YEARN_V3_STRATEGY_FACTORY_V1";
+    bytes32 internal constant EARNING_POWER_CALCULATOR_FACTORY = "EARNING_POWER_CALCULATOR_FACTORY";
+    bytes32 internal constant REGEN_STAKER_FACTORY = "REGEN_STAKER_FACTORY";
+    bytes32 internal constant YIELD_DONATING_STRATEGY = "YIELD_DONATING_STRATEGY";
+    bytes32 internal constant YIELD_DONATING_STRATEGY_V1 = "YIELD_DONATING_STRATEGY_V1";
+    bytes32 internal constant YIELD_DONATING_STRATEGY_V2 = "YIELD_DONATING_STRATEGY_V2";
+    bytes32 internal constant YIELD_SKIMMING_STRATEGY = "YIELD_SKIMMING_STRATEGY";
+    bytes32 internal constant YEARN_V3_STRATEGY_FACTORY = "YEARN_V3_STRATEGY_FACTORY";
+    bytes32 internal constant ADDRESS_SET_FACTORY = "ADDRESS_SET_FACTORY";
+    bytes32 internal constant STAKER_ALLOWSET = "STAKER_ALLOWSET";
+    bytes32 internal constant STAKER_BLOCKSET = "STAKER_BLOCKSET";
+    bytes32 internal constant ALLOCATION_MECHANISM_ALLOWSET = "ALLOCATION_MECHANISM_ALLOWSET";
+    bytes32 internal constant REGEN_EARNING_POWER_CALCULATOR = "REGEN_EARNING_POWER_CALCULATOR";
+}

--- a/src/registry/RegistryManifest.sol
+++ b/src/registry/RegistryManifest.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import { IOctantRegistry } from "../interfaces/IOctantRegistry.sol";
+
+/**
+ * @title RegistryManifest
+ * @author [Golem Foundation](https://golem.foundation)
+ * @custom:security-contact security@golem.foundation
+ * @notice Canonical digest scheme for OctantRegistry publication manifests
+ */
+library RegistryManifest {
+    bytes32 internal constant PUBLICATION_DOMAIN = keccak256("OCTANT_REGISTRY_PUBLICATION_V1");
+
+    /**
+     * @notice Hashes a complete registry publication with chain and registry replay protection
+     * @param chainId Chain on which the publication will execute
+     * @param registry Registry receiving the publication
+     * @param expectedEpoch Current epoch expected by the publication
+     * @param updates Ordered entry changes
+     * @param releaseLabel Human-readable software or deployment release label
+     * @return Canonical publication manifest hash
+     */
+    function hash(
+        uint256 chainId,
+        address registry,
+        uint64 expectedEpoch,
+        IOctantRegistry.Update[] memory updates,
+        string memory releaseLabel
+    ) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    PUBLICATION_DOMAIN,
+                    chainId,
+                    registry,
+                    expectedEpoch,
+                    keccak256(bytes(releaseLabel)),
+                    updates
+                )
+            );
+    }
+}

--- a/test/unit/registry/OctantRegistry.t.sol
+++ b/test/unit/registry/OctantRegistry.t.sol
@@ -1,0 +1,665 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import { Ownable } from "@openzeppelin/contracts/access/Ownable.sol";
+import { IERC165 } from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+import { OctantRegistry } from "src/registry/OctantRegistry.sol";
+import { IOctantRegistry } from "src/interfaces/IOctantRegistry.sol";
+import { RegistryManifest } from "src/registry/RegistryManifest.sol";
+
+contract RegistryTarget {}
+
+contract OctantRegistryTest is Test {
+    OctantRegistry public registry;
+
+    address public owner;
+    address public stranger;
+    address public targetA;
+    address public targetB;
+    address public targetC;
+
+    bytes32 internal constant KEY_A = "AAVE_V3_STRATEGY_FACTORY";
+    bytes32 internal constant KEY_B = "SPARK_STRATEGY_FACTORY";
+    bytes32 internal constant KEY_C = "LIDO_STRATEGY_FACTORY";
+    bytes32 internal constant COMPATIBILITY_VERSION = "3.0.4";
+
+    event EntryPublished(
+        bytes32 indexed key,
+        address indexed addr,
+        address indexed previousAddr,
+        IOctantRegistry.EntryType entryType,
+        IOctantRegistry.EntryStatus status,
+        uint64 epoch,
+        uint32 bump,
+        bytes32 compatibilityVersion,
+        bytes32 runtimeCodeHash
+    );
+    event BatchPublished(uint64 indexed epoch, bytes32 indexed manifestHash, string releaseLabel);
+    event SuccessorSet(address indexed successor, uint64 indexed epoch);
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        stranger = makeAddr("stranger");
+        targetA = address(new RegistryTarget());
+        targetB = address(new RegistryTarget());
+        targetC = address(new RegistryTarget());
+        registry = new OctantRegistry(owner);
+    }
+
+    function test_publishBatch_CreatesEntryAndEpochMetadata() public {
+        // Arrange
+        IOctantRegistry.Update[] memory updates = _singleUpdate(
+            KEY_A,
+            targetA,
+            IOctantRegistry.EntryType.FACTORY,
+            IOctantRegistry.EntryStatus.ACTIVE,
+            COMPATIBILITY_VERSION
+        );
+        bytes32 expectedManifest = RegistryManifest.hash(block.chainid, address(registry), 0, updates, "1.3.0");
+
+        vm.expectEmit(true, true, true, true);
+        emit EntryPublished(
+            KEY_A,
+            targetA,
+            address(0),
+            IOctantRegistry.EntryType.FACTORY,
+            IOctantRegistry.EntryStatus.ACTIVE,
+            1,
+            1,
+            COMPATIBILITY_VERSION,
+            targetA.codehash
+        );
+        vm.expectEmit(true, true, true, true);
+        emit BatchPublished(1, expectedManifest, "1.3.0");
+
+        // Act
+        vm.prank(owner);
+        registry.publishBatch(0, updates, "1.3.0");
+
+        // Assert
+        assertEq(registry.getAddress(KEY_A), targetA, "active address mismatch");
+        assertEq(registry.tryGetAddress(KEY_A), targetA, "tryGetAddress mismatch");
+        assertEq(registry.count(), 1, "known-key count mismatch");
+        assertEq(registry.keyAt(0), KEY_A, "enumerated key mismatch");
+        assertEq(registry.epoch(), 1, "epoch mismatch");
+        assertEq(registry.manifestHash(), expectedManifest, "manifest hash mismatch");
+        assertEq(registry.releaseLabel(), "1.3.0", "release label mismatch");
+
+        IOctantRegistry.Entry memory entry = registry.getEntry(KEY_A);
+        assertEq(entry.addr, targetA, "entry address mismatch");
+        assertEq(entry.updatedAt, uint64(block.timestamp), "entry timestamp mismatch");
+        assertEq(entry.bump, 1, "initial bump mismatch");
+        assertEq(entry.epoch, 1, "entry epoch mismatch");
+        assertEq(uint8(entry.entryType), uint8(IOctantRegistry.EntryType.FACTORY), "entry type mismatch");
+        assertEq(uint8(entry.status), uint8(IOctantRegistry.EntryStatus.ACTIVE), "entry status mismatch");
+        assertEq(entry.compatibilityVersion, COMPATIBILITY_VERSION, "compatibility version mismatch");
+        assertEq(entry.runtimeCodeHash, targetA.codehash, "runtime code hash mismatch");
+    }
+
+    function test_publishBatch_ManifestBindsExactPublicationInputs() public {
+        // Arrange
+        IOctantRegistry.Update[] memory updates = _singleActiveUpdate(KEY_A, targetA);
+        bytes32 expectedManifest = RegistryManifest.hash(block.chainid, address(registry), 0, updates, "1.3.0");
+        bytes32 otherChainManifest = RegistryManifest.hash(block.chainid + 1, address(registry), 0, updates, "1.3.0");
+        bytes32 otherRegistryManifest = RegistryManifest.hash(block.chainid, address(this), 0, updates, "1.3.0");
+        bytes32 otherEpochManifest = RegistryManifest.hash(block.chainid, address(registry), 1, updates, "1.3.0");
+        bytes32 otherLabelManifest = RegistryManifest.hash(block.chainid, address(registry), 0, updates, "1.3.1");
+        IOctantRegistry.Update[] memory otherUpdates = _singleActiveUpdate(KEY_A, targetB);
+        bytes32 otherUpdatesManifest = RegistryManifest.hash(
+            block.chainid,
+            address(registry),
+            0,
+            otherUpdates,
+            "1.3.0"
+        );
+
+        // Act
+        vm.prank(owner);
+        registry.publishBatch(0, updates, "1.3.0");
+
+        // Assert
+        assertEq(registry.manifestHash(), expectedManifest, "canonical manifest mismatch");
+        assertNotEq(registry.manifestHash(), otherChainManifest, "manifest must bind chain");
+        assertNotEq(registry.manifestHash(), otherRegistryManifest, "manifest must bind registry");
+        assertNotEq(registry.manifestHash(), otherEpochManifest, "manifest must bind epoch");
+        assertNotEq(registry.manifestHash(), otherLabelManifest, "manifest must bind release label");
+        assertNotEq(registry.manifestHash(), otherUpdatesManifest, "manifest must bind updates");
+    }
+
+    function test_publishBatch_UpdatesAddressAndAllowsSameCompatibilityVersion() public {
+        // Arrange
+        _publish(
+            _singleUpdate(
+                KEY_A,
+                targetA,
+                IOctantRegistry.EntryType.FACTORY,
+                IOctantRegistry.EntryStatus.ACTIVE,
+                COMPATIBILITY_VERSION
+            ),
+            "1.3.0"
+        );
+        vm.warp(block.timestamp + 100);
+
+        IOctantRegistry.Update[] memory updates = _singleUpdate(
+            KEY_A,
+            targetB,
+            IOctantRegistry.EntryType.FACTORY,
+            IOctantRegistry.EntryStatus.ACTIVE,
+            COMPATIBILITY_VERSION
+        );
+
+        // Act
+        vm.prank(owner);
+        registry.publishBatch(1, updates, "1.3.1");
+
+        // Assert
+        IOctantRegistry.Entry memory entry = registry.getEntry(KEY_A);
+        assertEq(entry.addr, targetB, "updated address mismatch");
+        assertEq(entry.updatedAt, uint64(block.timestamp), "updated timestamp mismatch");
+        assertEq(entry.bump, 2, "updated bump mismatch");
+        assertEq(entry.epoch, 2, "updated epoch mismatch");
+        assertEq(entry.compatibilityVersion, COMPATIBILITY_VERSION, "compatibility version should be reusable");
+        assertEq(registry.count(), 1, "address replacement should not add a key");
+    }
+
+    function test_publishBatch_PublishesMultipleEntriesAtomically() public {
+        // Arrange
+        IOctantRegistry.Update[] memory updates = _threeActiveUpdates();
+
+        // Act
+        _publish(updates, "1.3.0");
+
+        // Assert
+        assertEq(registry.count(), 3, "known-key count mismatch");
+        assertEq(registry.epoch(), 1, "batch should use one epoch");
+        assertEq(registry.getAddress(KEY_A), targetA, "KEY_A address mismatch");
+        assertEq(registry.getAddress(KEY_B), targetB, "KEY_B address mismatch");
+        assertEq(registry.getAddress(KEY_C), targetC, "KEY_C address mismatch");
+    }
+
+    function test_publishBatch_RevertsForStaleEpoch() public {
+        // Arrange
+        _publish(_singleActiveUpdate(KEY_A, targetA), "1.3.0");
+        IOctantRegistry.Update[] memory updates = _singleActiveUpdate(KEY_B, targetB);
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__StaleEpoch.selector, uint64(0), uint64(1))
+        );
+        registry.publishBatch(0, updates, "1.3.1");
+    }
+
+    function test_publishBatch_RevertsForDuplicateKeyAndRollsBackEpoch() public {
+        // Arrange
+        IOctantRegistry.Update[] memory updates = new IOctantRegistry.Update[](2);
+        updates[0] = _activeUpdate(KEY_A, targetA);
+        updates[1] = _activeUpdate(KEY_A, targetB);
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__DuplicateKey.selector, KEY_A));
+        registry.publishBatch(0, updates, "1.3.0");
+
+        assertEq(registry.epoch(), 0, "reverted batch must not advance epoch");
+        assertEq(registry.count(), 0, "reverted batch must not retain keys");
+    }
+
+    function test_publishBatch_RevertsForEmptyBatch() public {
+        // Arrange
+        IOctantRegistry.Update[] memory updates = new IOctantRegistry.Update[](0);
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(IOctantRegistry.OctantRegistry__EmptyBatch.selector);
+        registry.publishBatch(0, updates, "1.3.0");
+    }
+
+    function test_publishBatch_RevertsForInvalidReleaseLabelLength() public {
+        // Arrange
+        IOctantRegistry.Update[] memory updates = _singleActiveUpdate(KEY_A, targetA);
+
+        // Act and assert: empty
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InvalidReleaseLabelLength.selector, uint256(0))
+        );
+        registry.publishBatch(0, updates, "");
+
+        // Act and assert: too long
+        string memory longLabel = new string(65);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InvalidReleaseLabelLength.selector, uint256(65))
+        );
+        registry.publishBatch(0, updates, longLabel);
+    }
+
+    function test_publishBatch_RevertsForInvalidKeys() public {
+        // Arrange
+        IOctantRegistry.Update[] memory emptyKeyUpdate = _singleActiveUpdate(bytes32(0), targetA);
+        IOctantRegistry.Update[] memory lowercaseKeyUpdate = _singleActiveUpdate(bytes32("invalid"), targetA);
+        bytes32 embeddedPaddingKey = hex"4141004200000000000000000000000000000000000000000000000000000000";
+        IOctantRegistry.Update[] memory paddedKeyUpdate = _singleActiveUpdate(embeddedPaddingKey, targetA);
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(IOctantRegistry.OctantRegistry__EmptyKey.selector);
+        registry.publishBatch(0, emptyKeyUpdate, "1.3.0");
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InvalidKey.selector, bytes32("invalid"))
+        );
+        registry.publishBatch(0, lowercaseKeyUpdate, "1.3.0");
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InvalidKey.selector, embeddedPaddingKey)
+        );
+        registry.publishBatch(0, paddedKeyUpdate, "1.3.0");
+    }
+
+    function test_publishBatch_RevertsForInvalidCompatibilityVersion() public {
+        // Arrange
+        bytes32 invalidVersion = bytes32(uint256(1) << 248);
+        IOctantRegistry.Update[] memory updates = _singleUpdate(
+            KEY_A,
+            targetA,
+            IOctantRegistry.EntryType.FACTORY,
+            IOctantRegistry.EntryStatus.ACTIVE,
+            invalidVersion
+        );
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InvalidCompatibilityVersion.selector, invalidVersion)
+        );
+        registry.publishBatch(0, updates, "1.3.0");
+    }
+
+    function test_publishBatch_RevertsForZeroOrCodelessAddress() public {
+        // Arrange
+        IOctantRegistry.Update[] memory zeroAddressUpdate = _singleActiveUpdate(KEY_A, address(0));
+        address eoa = makeAddr("eoa");
+        IOctantRegistry.Update[] memory eoaUpdate = _singleActiveUpdate(KEY_A, eoa);
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(IOctantRegistry.OctantRegistry__ZeroAddress.selector);
+        registry.publishBatch(0, zeroAddressUpdate, "1.3.0");
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__NotAContract.selector, eoa));
+        registry.publishBatch(0, eoaUpdate, "1.3.0");
+    }
+
+    function test_publishBatch_RevertsForUnsetTypeOrStatus() public {
+        // Arrange
+        IOctantRegistry.Update[] memory unsetTypeUpdate = _singleUpdate(
+            KEY_A,
+            targetA,
+            IOctantRegistry.EntryType.UNSET,
+            IOctantRegistry.EntryStatus.ACTIVE,
+            bytes32(0)
+        );
+        IOctantRegistry.Update[] memory unsetStatusUpdate = _singleUpdate(
+            KEY_A,
+            targetA,
+            IOctantRegistry.EntryType.FACTORY,
+            IOctantRegistry.EntryStatus.UNSET,
+            bytes32(0)
+        );
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(IOctantRegistry.OctantRegistry__InvalidEntryType.selector);
+        registry.publishBatch(0, unsetTypeUpdate, "1.3.0");
+
+        vm.prank(owner);
+        vm.expectRevert(IOctantRegistry.OctantRegistry__InvalidEntryStatus.selector);
+        registry.publishBatch(0, unsetStatusUpdate, "1.3.0");
+    }
+
+    function test_publishBatch_RevertsWhenNewEntryIsInactive() public {
+        // Arrange
+        IOctantRegistry.Update[] memory updates = _singleUpdate(
+            KEY_A,
+            targetA,
+            IOctantRegistry.EntryType.FACTORY,
+            IOctantRegistry.EntryStatus.DEPRECATED,
+            bytes32(0)
+        );
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__NewEntryMustBeActive.selector, KEY_A));
+        registry.publishBatch(0, updates, "1.3.0");
+    }
+
+    function test_publishBatch_RevertsWhenEntryTypeChanges() public {
+        // Arrange
+        _publish(_singleActiveUpdate(KEY_A, targetA), "1.3.0");
+        IOctantRegistry.Update[] memory updates = _singleUpdate(
+            KEY_A,
+            targetB,
+            IOctantRegistry.EntryType.CONTRACT,
+            IOctantRegistry.EntryStatus.ACTIVE,
+            bytes32(0)
+        );
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOctantRegistry.OctantRegistry__EntryTypeMismatch.selector,
+                KEY_A,
+                IOctantRegistry.EntryType.FACTORY,
+                IOctantRegistry.EntryType.CONTRACT
+            )
+        );
+        registry.publishBatch(1, updates, "1.3.1");
+    }
+
+    function test_publishBatch_RevertsWhenInactiveUpdateChangesAddress() public {
+        // Arrange
+        _publish(_singleActiveUpdate(KEY_A, targetA), "1.3.0");
+        IOctantRegistry.Update[] memory updates = _singleUpdate(
+            KEY_A,
+            targetB,
+            IOctantRegistry.EntryType.FACTORY,
+            IOctantRegistry.EntryStatus.DISABLED,
+            bytes32(0)
+        );
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InactiveAddressChange.selector, KEY_A));
+        registry.publishBatch(1, updates, "1.3.1");
+    }
+
+    function test_publishBatch_RevertsForNoOpAndRollsBackMetadata() public {
+        // Arrange
+        IOctantRegistry.Update[] memory updates = _singleActiveUpdate(KEY_A, targetA);
+        _publish(updates, "1.3.0");
+        bytes32 initialManifest = registry.manifestHash();
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__NoEntryChange.selector, KEY_A));
+        registry.publishBatch(1, updates, "1.3.1");
+
+        assertEq(registry.epoch(), 1, "no-op revert must preserve epoch");
+        assertEq(registry.manifestHash(), initialManifest, "no-op revert must preserve manifest");
+        assertEq(registry.releaseLabel(), "1.3.0", "no-op revert must preserve label");
+    }
+
+    function test_publishBatch_DeprecatesWithoutDeletingHistoryMetadata() public {
+        // Arrange
+        _publish(_singleActiveUpdate(KEY_A, targetA), "1.3.0");
+        IOctantRegistry.Update[] memory updates = _singleUpdate(
+            KEY_A,
+            targetA,
+            IOctantRegistry.EntryType.FACTORY,
+            IOctantRegistry.EntryStatus.DEPRECATED,
+            bytes32(0)
+        );
+
+        // Act
+        vm.warp(block.timestamp + 100);
+        _publish(updates, "1.3.1");
+
+        // Assert
+        IOctantRegistry.Entry memory entry = registry.getEntry(KEY_A);
+        assertEq(entry.addr, targetA, "deprecated entry should retain address");
+        assertEq(entry.bump, 2, "deprecation should increment bump");
+        assertEq(entry.epoch, 2, "deprecation epoch mismatch");
+        assertEq(uint8(entry.status), uint8(IOctantRegistry.EntryStatus.DEPRECATED), "status mismatch");
+        assertEq(registry.count(), 1, "deprecated key should remain enumerable");
+        assertEq(registry.tryGetAddress(KEY_A), address(0), "deprecated key must not resolve through try getter");
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IOctantRegistry.OctantRegistry__KeyNotActive.selector,
+                KEY_A,
+                IOctantRegistry.EntryStatus.DEPRECATED
+            )
+        );
+        registry.getAddress(KEY_A);
+    }
+
+    function test_publishBatch_ReactivatesEntryWithoutResettingBump() public {
+        // Arrange
+        _publish(_singleActiveUpdate(KEY_A, targetA), "1.3.0");
+        _publish(
+            _singleUpdate(
+                KEY_A,
+                targetA,
+                IOctantRegistry.EntryType.FACTORY,
+                IOctantRegistry.EntryStatus.DISABLED,
+                bytes32(0)
+            ),
+            "1.3.1"
+        );
+
+        // Act
+        _publish(_singleActiveUpdate(KEY_A, targetA), "1.3.2");
+
+        // Assert
+        IOctantRegistry.Entry memory entry = registry.getEntry(KEY_A);
+        assertEq(entry.bump, 3, "reactivation must preserve monotonic bump");
+        assertEq(entry.epoch, 3, "reactivation epoch mismatch");
+        assertEq(uint8(entry.status), uint8(IOctantRegistry.EntryStatus.ACTIVE), "reactivation status mismatch");
+        assertEq(registry.getAddress(KEY_A), targetA, "reactivated key should resolve");
+        assertEq(registry.count(), 1, "reactivation must not duplicate key");
+    }
+
+    function test_publishBatch_RevertsForNonOwner() public {
+        // Arrange
+        IOctantRegistry.Update[] memory updates = _singleActiveUpdate(KEY_A, targetA);
+
+        // Act and assert
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stranger));
+        registry.publishBatch(0, updates, "1.3.0");
+    }
+
+    function test_getters_RevertForUnknownKeyOrIndex() public {
+        // Act and assert
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__KeyNotFound.selector, KEY_A));
+        registry.getAddress(KEY_A);
+
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__KeyNotFound.selector, KEY_A));
+        registry.getEntry(KEY_A);
+
+        assertEq(registry.tryGetAddress(KEY_A), address(0), "unknown key should return zero");
+
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__IndexOutOfBounds.selector, 0, 0));
+        registry.keyAt(0);
+    }
+
+    function test_setSuccessorOnce_FreezesRegistry() public {
+        // Arrange
+        _publish(_singleActiveUpdate(KEY_A, targetA), "1.3.0");
+        OctantRegistry successor = new OctantRegistry(owner);
+
+        vm.expectEmit(true, true, true, true);
+        emit SuccessorSet(address(successor), 1);
+
+        // Act
+        vm.prank(owner);
+        registry.setSuccessorOnce(1, address(successor));
+
+        // Assert
+        assertEq(registry.getSuccessor(), address(successor), "successor mismatch");
+
+        IOctantRegistry.Update[] memory updates = _singleActiveUpdate(KEY_B, targetB);
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__AlreadySuperseded.selector, address(successor))
+        );
+        registry.publishBatch(1, updates, "1.3.1");
+    }
+
+    function test_setSuccessorOnce_RevertsForInvalidTargets() public {
+        // Arrange
+        address eoa = makeAddr("successorEoa");
+        address nonRegistryContract = address(new RegistryTarget());
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InvalidSuccessor.selector, address(0)));
+        registry.setSuccessorOnce(0, address(0));
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InvalidSuccessor.selector, address(registry))
+        );
+        registry.setSuccessorOnce(0, address(registry));
+
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InvalidSuccessor.selector, eoa));
+        registry.setSuccessorOnce(0, eoa);
+
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InvalidSuccessor.selector, nonRegistryContract)
+        );
+        registry.setSuccessorOnce(0, nonRegistryContract);
+    }
+
+    function test_setSuccessorOnce_RevertsForSupersededSuccessorCycle() public {
+        // Arrange
+        OctantRegistry successor = new OctantRegistry(owner);
+        vm.prank(owner);
+        registry.setSuccessorOnce(0, address(successor));
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__InvalidSuccessor.selector, address(registry))
+        );
+        successor.setSuccessorOnce(0, address(registry));
+    }
+
+    function test_setSuccessorOnce_RevertsForStaleEpochOrNonOwner() public {
+        // Arrange
+        OctantRegistry successor = new OctantRegistry(owner);
+
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(
+            abi.encodeWithSelector(IOctantRegistry.OctantRegistry__StaleEpoch.selector, uint64(1), uint64(0))
+        );
+        registry.setSuccessorOnce(1, address(successor));
+
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, stranger));
+        registry.setSuccessorOnce(0, address(successor));
+    }
+
+    function test_renounceOwnership_IsDisabled() public {
+        // Act and assert
+        vm.prank(owner);
+        vm.expectRevert(IOctantRegistry.OctantRegistry__OwnershipRenunciationDisabled.selector);
+        registry.renounceOwnership();
+    }
+
+    function test_Ownable2Step_Handover() public {
+        // Arrange
+        address newOwner = makeAddr("newOwner");
+        vm.prank(owner);
+        registry.transferOwnership(newOwner);
+
+        assertEq(registry.owner(), owner, "owner should remain until acceptance");
+        assertEq(registry.pendingOwner(), newOwner, "pending owner mismatch");
+
+        // Act
+        vm.prank(newOwner);
+        registry.acceptOwnership();
+
+        // Assert
+        assertEq(registry.owner(), newOwner, "new owner mismatch");
+
+        IOctantRegistry.Update[] memory updates = _singleActiveUpdate(KEY_A, targetA);
+        vm.prank(owner);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, owner));
+        registry.publishBatch(0, updates, "1.3.0");
+
+        vm.prank(newOwner);
+        registry.publishBatch(0, updates, "1.3.0");
+        assertEq(registry.getAddress(KEY_A), targetA, "new owner should publish");
+    }
+
+    function test_supportsInterface_ReportsRegistryAndERC165() public view {
+        assertTrue(
+            registry.supportsInterface(type(IOctantRegistry).interfaceId),
+            "registry interface should be supported"
+        );
+        assertTrue(registry.supportsInterface(type(IERC165).interfaceId), "ERC165 should be supported");
+        assertFalse(registry.supportsInterface(0xffffffff), "invalid interface should not be supported");
+    }
+
+    function test_API_VERSION_IsIndependentFromReleaseLabel() public {
+        // Arrange
+        IOctantRegistry.Update[] memory updates = _singleActiveUpdate(KEY_A, targetA);
+
+        // Act
+        _publish(updates, "octant-v1.3.0");
+
+        // Assert
+        assertEq(registry.API_VERSION(), "1.0.0", "registry API version mismatch");
+        assertEq(registry.releaseLabel(), "octant-v1.3.0", "release label mismatch");
+    }
+
+    function _publish(IOctantRegistry.Update[] memory updates, string memory label) internal {
+        uint64 expectedEpoch = registry.epoch();
+        vm.prank(owner);
+        registry.publishBatch(expectedEpoch, updates, label);
+    }
+
+    function _singleActiveUpdate(
+        bytes32 key,
+        address addr
+    ) internal pure returns (IOctantRegistry.Update[] memory updates) {
+        return
+            _singleUpdate(key, addr, IOctantRegistry.EntryType.FACTORY, IOctantRegistry.EntryStatus.ACTIVE, bytes32(0));
+    }
+
+    function _singleUpdate(
+        bytes32 key,
+        address addr,
+        IOctantRegistry.EntryType entryType,
+        IOctantRegistry.EntryStatus status,
+        bytes32 compatibilityVersion
+    ) internal pure returns (IOctantRegistry.Update[] memory updates) {
+        updates = new IOctantRegistry.Update[](1);
+        updates[0] = IOctantRegistry.Update({
+            key: key,
+            addr: addr,
+            entryType: entryType,
+            status: status,
+            compatibilityVersion: compatibilityVersion
+        });
+    }
+
+    function _activeUpdate(bytes32 key, address addr) internal pure returns (IOctantRegistry.Update memory update) {
+        return
+            IOctantRegistry.Update({
+                key: key,
+                addr: addr,
+                entryType: IOctantRegistry.EntryType.FACTORY,
+                status: IOctantRegistry.EntryStatus.ACTIVE,
+                compatibilityVersion: bytes32(0)
+            });
+    }
+
+    function _threeActiveUpdates() internal view returns (IOctantRegistry.Update[] memory updates) {
+        updates = new IOctantRegistry.Update[](3);
+        updates[0] = _activeUpdate(KEY_A, targetA);
+        updates[1] = _activeUpdate(KEY_B, targetB);
+        updates[2] = _activeUpdate(KEY_C, targetC);
+    }
+}

--- a/test/unit/registry/OctantRegistryInvariant.t.sol
+++ b/test/unit/registry/OctantRegistryInvariant.t.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import { OctantRegistry } from "src/registry/OctantRegistry.sol";
+import { IOctantRegistry } from "src/interfaces/IOctantRegistry.sol";
+
+contract InvariantRegistryTarget {}
+
+contract OctantRegistryHandler is Test {
+    OctantRegistry public registry;
+    address public owner;
+
+    bytes32[] public keyUniverse;
+    address[] public targetUniverse;
+    mapping(bytes32 key => bool known) public known;
+    mapping(bytes32 key => address addr) public lastAddr;
+    mapping(bytes32 key => IOctantRegistry.EntryStatus status) public lastStatus;
+    mapping(bytes32 key => bytes32 compatibilityVersion) public lastCompatibilityVersion;
+    uint256 public knownCount;
+    uint256 public publicationCount;
+
+    constructor(OctantRegistry registry_, address owner_) {
+        registry = registry_;
+        owner = owner_;
+
+        keyUniverse.push("KEY_ALPHA");
+        keyUniverse.push("KEY_BRAVO");
+        keyUniverse.push("KEY_CHARLIE");
+        keyUniverse.push("KEY_DELTA");
+        keyUniverse.push("KEY_ECHO");
+        keyUniverse.push("KEY_FOXTROT");
+        keyUniverse.push("KEY_GOLF");
+        keyUniverse.push("KEY_HOTEL");
+
+        for (uint256 i = 0; i < keyUniverse.length; ++i) {
+            targetUniverse.push(address(new InvariantRegistryTarget()));
+        }
+    }
+
+    function universeLength() external view returns (uint256) {
+        return keyUniverse.length;
+    }
+
+    function publish(uint256 keySeed, uint256 targetSeed, uint256 statusSeed) external {
+        bytes32 key = keyUniverse[bound(keySeed, 0, keyUniverse.length - 1)];
+        address target = targetUniverse[bound(targetSeed, 0, targetUniverse.length - 1)];
+        IOctantRegistry.EntryStatus status = IOctantRegistry.EntryStatus(
+            bound(
+                statusSeed,
+                uint256(IOctantRegistry.EntryStatus.ACTIVE),
+                uint256(IOctantRegistry.EntryStatus.DISABLED)
+            )
+        );
+
+        if (!known[key]) {
+            known[key] = true;
+            knownCount++;
+            status = IOctantRegistry.EntryStatus.ACTIVE;
+        } else if (status != IOctantRegistry.EntryStatus.ACTIVE) {
+            target = lastAddr[key];
+        }
+
+        bytes32 compatibilityVersion = lastCompatibilityVersion[key] == bytes32("1.0.0")
+            ? bytes32("1.0.1")
+            : bytes32("1.0.0");
+
+        IOctantRegistry.Update[] memory updates = new IOctantRegistry.Update[](1);
+        updates[0] = IOctantRegistry.Update({
+            key: key,
+            addr: target,
+            entryType: IOctantRegistry.EntryType.FACTORY,
+            status: status,
+            compatibilityVersion: compatibilityVersion
+        });
+
+        uint64 expectedEpoch = registry.epoch();
+        vm.prank(owner);
+        registry.publishBatch(expectedEpoch, updates, "INVARIANT");
+
+        lastAddr[key] = target;
+        lastStatus[key] = status;
+        lastCompatibilityVersion[key] = compatibilityVersion;
+        publicationCount++;
+    }
+}
+
+contract OctantRegistryInvariantTest is Test {
+    OctantRegistry public registry;
+    OctantRegistryHandler public handler;
+    address public owner;
+
+    function setUp() public {
+        owner = makeAddr("owner");
+        registry = new OctantRegistry(owner);
+        handler = new OctantRegistryHandler(registry, owner);
+        targetContract(address(handler));
+    }
+
+    function invariant_CountMatchesKnownKeys() public view {
+        assertEq(registry.count(), handler.knownCount(), "known-key count mismatch");
+    }
+
+    function invariant_EpochMatchesSuccessfulPublicationCount() public view {
+        assertEq(registry.epoch(), handler.publicationCount(), "epoch must match successful publications");
+    }
+
+    function invariant_EnumerationHasNoDuplicatesAndMatchesGhostState() public view {
+        uint256 total = registry.count();
+        bytes32[] memory seen = new bytes32[](total);
+        for (uint256 i = 0; i < total; ++i) {
+            bytes32 key = registry.keyAt(i);
+            IOctantRegistry.Entry memory entry = registry.getEntry(key);
+
+            assertTrue(handler.known(key), "enumerated key must be known");
+            assertEq(entry.addr, handler.lastAddr(key), "entry address mismatch");
+            assertEq(uint8(entry.status), uint8(handler.lastStatus(key)), "entry status mismatch");
+            assertEq(
+                entry.compatibilityVersion,
+                handler.lastCompatibilityVersion(key),
+                "compatibility version mismatch"
+            );
+            assertGt(entry.bump, 0, "known entry bump must be positive");
+            assertLe(entry.epoch, registry.epoch(), "entry epoch cannot exceed global epoch");
+            assertEq(entry.runtimeCodeHash, entry.addr.codehash, "runtime code hash mismatch");
+
+            address expectedResolved = entry.status == IOctantRegistry.EntryStatus.ACTIVE ? entry.addr : address(0);
+            assertEq(registry.tryGetAddress(key), expectedResolved, "resolution status mismatch");
+
+            for (uint256 j = 0; j < i; ++j) {
+                assertTrue(seen[j] != key, "duplicate enumerated key");
+            }
+            seen[i] = key;
+        }
+    }
+
+    function invariant_EveryKnownUniverseKeyIsEnumerable() public view {
+        uint256 universe = handler.universeLength();
+        for (uint256 i = 0; i < universe; ++i) {
+            bytes32 key = handler.keyUniverse(i);
+            if (handler.known(key)) {
+                IOctantRegistry.Entry memory entry = registry.getEntry(key);
+                assertEq(entry.addr, handler.lastAddr(key), "known universe address mismatch");
+            } else {
+                assertEq(registry.tryGetAddress(key), address(0), "unknown universe key must not resolve");
+            }
+        }
+    }
+}

--- a/test/unit/registry/RegistryBatchFlow.t.sol
+++ b/test/unit/registry/RegistryBatchFlow.t.sol
@@ -1,0 +1,216 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+pragma solidity ^0.8.25;
+
+import "forge-std/Test.sol";
+import { OctantRegistry } from "src/registry/OctantRegistry.sol";
+import { IOctantRegistry } from "src/interfaces/IOctantRegistry.sol";
+import { RegistryManifest } from "src/registry/RegistryManifest.sol";
+import { LidoStrategyFactory } from "src/factories/LidoStrategyFactory.sol";
+import { RocketPoolStrategyFactory } from "src/factories/yieldSkimming/RocketPoolStrategyFactory.sol";
+import { YieldSkimmingTokenizedStrategy } from "src/strategies/yieldSkimming/YieldSkimmingTokenizedStrategy.sol";
+import { YieldDonatingTokenizedStrategy } from "src/strategies/yieldDonating/YieldDonatingTokenizedStrategy.sol";
+
+contract MockCreate2Deployer {
+    fallback(bytes calldata data) external payable returns (bytes memory) {
+        bytes32 salt = bytes32(data[:32]);
+        bytes memory initCode = data[32:];
+        address deployed;
+        assembly {
+            deployed := create2(callvalue(), add(initCode, 32), mload(initCode), salt)
+        }
+        require(deployed != address(0), "create2 failed");
+        return abi.encodePacked(deployed);
+    }
+}
+
+contract RegistryBatchFlowTest is Test {
+    address public safe;
+
+    bytes32 internal constant REGISTRY_SALT = keccak256("OCTANT_REGISTRY_22072026");
+    bytes32 internal constant LIDO_SALT = keccak256("LIDO_STRATEGY_FACTORY_21072026");
+    bytes32 internal constant ROCKET_POOL_SALT = keccak256("ROCKET_POOL_STRATEGY_FACTORY_21072026");
+    bytes32 internal constant LIDO_KEY = "LIDO_STRATEGY_FACTORY";
+    bytes32 internal constant ROCKET_POOL_KEY = "ROCKET_POOL_STRATEGY_FACTORY";
+    bytes32 internal constant YS_SINGLETON_SALT = keccak256("OCTANT_YIELD_SKIMMING_STRATEGY_07082026");
+    bytes32 internal constant YS_SINGLETON_KEY = "YIELD_SKIMMING_STRATEGY";
+    bytes32 internal constant YD_SINGLETON_SALT = keccak256("OCTANT_YIELD_DONATING_STRATEGY_07082026");
+    bytes32 internal constant YD_SINGLETON_KEY = "YIELD_DONATING_STRATEGY";
+    bytes32 internal constant YD_LEGACY_KEY = "YIELD_DONATING_STRATEGY_V1";
+
+    function setUp() public {
+        safe = makeAddr("safe");
+        vm.etch(CREATE2_FACTORY, address(new MockCreate2Deployer()).code);
+    }
+
+    function test_BatchFlow_DeploysAndPublishesAtomically() public {
+        // Arrange: precompute and deploy contracts as the Safe batch does
+        bytes memory registryInitCode = abi.encodePacked(type(OctantRegistry).creationCode, abi.encode(safe));
+        address expectedRegistry = _computeCreate2AddressViaFactory(REGISTRY_SALT, keccak256(registryInitCode));
+        address expectedLido = _computeCreate2AddressViaFactory(
+            LIDO_SALT,
+            keccak256(type(LidoStrategyFactory).creationCode)
+        );
+        address expectedRocketPool = _computeCreate2AddressViaFactory(
+            ROCKET_POOL_SALT,
+            keccak256(type(RocketPoolStrategyFactory).creationCode)
+        );
+
+        address deployedRegistry = _deployViaFactory(REGISTRY_SALT, registryInitCode);
+        address deployedLido = _deployViaFactory(LIDO_SALT, type(LidoStrategyFactory).creationCode);
+        address deployedRocketPool = _deployViaFactory(ROCKET_POOL_SALT, type(RocketPoolStrategyFactory).creationCode);
+
+        assertEq(deployedRegistry, expectedRegistry, "registry CREATE2 address mismatch");
+        assertEq(deployedLido, expectedLido, "lido factory CREATE2 address mismatch");
+        assertEq(deployedRocketPool, expectedRocketPool, "rocketpool factory CREATE2 address mismatch");
+
+        OctantRegistry registry = OctantRegistry(deployedRegistry);
+        assertEq(registry.owner(), safe, "Safe should own the registry");
+
+        IOctantRegistry.Update[] memory updates = new IOctantRegistry.Update[](2);
+        updates[0] = _factoryUpdate(LIDO_KEY, expectedLido);
+        updates[1] = _factoryUpdate(ROCKET_POOL_KEY, expectedRocketPool);
+        bytes32 manifest = RegistryManifest.hash(block.chainid, deployedRegistry, 0, updates, "1.3.0");
+
+        // Act: publish from the Safe in the same logical batch
+        vm.prank(safe);
+        registry.publishBatch(0, updates, "1.3.0");
+
+        // Assert: addresses and batch metadata describe one atomic state
+        assertEq(registry.count(), 2, "registry should hold both factories");
+        assertEq(registry.epoch(), 1, "initial publication epoch mismatch");
+        assertEq(registry.manifestHash(), manifest, "manifest hash mismatch");
+        assertEq(registry.releaseLabel(), "1.3.0", "release label mismatch");
+
+        for (uint256 i = 0; i < updates.length; ++i) {
+            IOctantRegistry.Entry memory entry = registry.getEntry(updates[i].key);
+            assertEq(entry.addr, updates[i].addr, "registered address mismatch");
+            assertEq(entry.runtimeCodeHash, updates[i].addr.codehash, "registered code hash mismatch");
+            assertEq(uint8(entry.status), uint8(IOctantRegistry.EntryStatus.ACTIVE), "entry should be active");
+        }
+    }
+
+    /// @dev Mirrors the production flow: batch 1 (registry + factories + epoch-1 publication)
+    ///      then batch 2 (YieldSkimming singleton + epoch-2 publication) at the next Safe nonce.
+    ///      Batch 2 must be unexecutable before batch 1 (stale epoch) and atomic after it.
+    function test_BatchFlow_SecondBatchDeploysAndPublishesSingletons() public {
+        // Batch 1: deploy registry + one factory; the legacy 1.0.0 YieldDonating singleton
+        // (stand-in) registers ACTIVE under the versioned key (new keys must start ACTIVE)
+        bytes memory registryInitCode = abi.encodePacked(type(OctantRegistry).creationCode, abi.encode(safe));
+        OctantRegistry registry = OctantRegistry(_deployViaFactory(REGISTRY_SALT, registryInitCode));
+        address deployedLido = _deployViaFactory(LIDO_SALT, type(LidoStrategyFactory).creationCode);
+        address legacyYds = address(new YieldDonatingTokenizedStrategy());
+
+        IOctantRegistry.Update[] memory batch1 = new IOctantRegistry.Update[](2);
+        batch1[0] = _factoryUpdate(LIDO_KEY, deployedLido);
+        batch1[1] = IOctantRegistry.Update({
+            key: YD_LEGACY_KEY,
+            addr: legacyYds,
+            entryType: IOctantRegistry.EntryType.CONTRACT,
+            status: IOctantRegistry.EntryStatus.ACTIVE,
+            compatibilityVersion: bytes32("1.0.0")
+        });
+
+        // Batch 2: fresh 1.1.0 singleton deployments + epoch-2 publication
+        address deployedYss = _deployViaFactory(YS_SINGLETON_SALT, type(YieldSkimmingTokenizedStrategy).creationCode);
+        address deployedYds = _deployViaFactory(YD_SINGLETON_SALT, type(YieldDonatingTokenizedStrategy).creationCode);
+        assertEq(
+            deployedYss,
+            _computeCreate2AddressViaFactory(
+                YS_SINGLETON_SALT,
+                keccak256(type(YieldSkimmingTokenizedStrategy).creationCode)
+            ),
+            "YSS CREATE2 address mismatch"
+        );
+        assertEq(
+            deployedYds,
+            _computeCreate2AddressViaFactory(
+                YD_SINGLETON_SALT,
+                keccak256(type(YieldDonatingTokenizedStrategy).creationCode)
+            ),
+            "YDS CREATE2 address mismatch"
+        );
+
+        IOctantRegistry.Update[] memory batch2 = new IOctantRegistry.Update[](3);
+        batch2[0] = IOctantRegistry.Update({
+            key: YS_SINGLETON_KEY,
+            addr: deployedYss,
+            entryType: IOctantRegistry.EntryType.CONTRACT,
+            status: IOctantRegistry.EntryStatus.ACTIVE,
+            compatibilityVersion: bytes32("1.1.0")
+        });
+        batch2[1] = IOctantRegistry.Update({
+            key: YD_SINGLETON_KEY,
+            addr: deployedYds,
+            entryType: IOctantRegistry.EntryType.CONTRACT,
+            status: IOctantRegistry.EntryStatus.ACTIVE,
+            compatibilityVersion: bytes32("1.1.0")
+        });
+        batch2[2] = IOctantRegistry.Update({
+            key: YD_LEGACY_KEY,
+            addr: legacyYds,
+            entryType: IOctantRegistry.EntryType.CONTRACT,
+            status: IOctantRegistry.EntryStatus.DEPRECATED,
+            compatibilityVersion: bytes32("1.0.0")
+        });
+
+        // Out-of-order execution: batch 2 (expectedEpoch 1) must revert before batch 1 ran
+        vm.prank(safe);
+        vm.expectRevert(abi.encodeWithSelector(IOctantRegistry.OctantRegistry__StaleEpoch.selector, 1, 0));
+        registry.publishBatch(1, batch2, "1.3.0");
+
+        // In-order execution: batch 1 then batch 2
+        vm.prank(safe);
+        registry.publishBatch(0, batch1, "1.3.0");
+        assertEq(registry.tryGetAddress(YD_LEGACY_KEY), legacyYds, "legacy should resolve while sole implementation");
+
+        bytes32 manifest2 = RegistryManifest.hash(block.chainid, address(registry), 1, batch2, "1.3.0");
+        vm.prank(safe);
+        registry.publishBatch(1, batch2, "1.3.0");
+
+        assertEq(registry.epoch(), 2, "epoch should advance once per batch");
+        assertEq(registry.manifestHash(), manifest2, "manifest should reflect the latest batch");
+
+        // Canonical keys point at the fresh 1.1.0 singletons
+        IOctantRegistry.Entry memory yss = registry.getEntry(YS_SINGLETON_KEY);
+        assertEq(yss.addr, deployedYss, "YSS address mismatch");
+        assertEq(yss.compatibilityVersion, bytes32("1.1.0"), "YSS compat version mismatch");
+        assertEq(yss.runtimeCodeHash, deployedYss.codehash, "YSS code hash mismatch");
+        IOctantRegistry.Entry memory yds = registry.getEntry(YD_SINGLETON_KEY);
+        assertEq(yds.addr, deployedYds, "YDS address mismatch");
+        assertEq(yds.compatibilityVersion, bytes32("1.1.0"), "YDS compat version mismatch");
+        assertEq(registry.tryGetAddress(YD_SINGLETON_KEY), deployedYds, "canonical YDS should resolve as active");
+
+        // Legacy entry is deprecated: address retained, no longer resolves as active
+        IOctantRegistry.Entry memory legacy = registry.getEntry(YD_LEGACY_KEY);
+        assertEq(legacy.addr, legacyYds, "legacy address must be retained");
+        assertEq(uint8(legacy.status), uint8(IOctantRegistry.EntryStatus.DEPRECATED), "legacy should be deprecated");
+        assertEq(legacy.compatibilityVersion, bytes32("1.0.0"), "legacy compat version mismatch");
+        assertEq(registry.tryGetAddress(YD_LEGACY_KEY), address(0), "deprecated legacy must not resolve");
+    }
+
+    function _factoryUpdate(bytes32 key, address addr) internal pure returns (IOctantRegistry.Update memory update) {
+        return
+            IOctantRegistry.Update({
+                key: key,
+                addr: addr,
+                entryType: IOctantRegistry.EntryType.FACTORY,
+                status: IOctantRegistry.EntryStatus.ACTIVE,
+                compatibilityVersion: bytes32(0)
+            });
+    }
+
+    function _computeCreate2AddressViaFactory(bytes32 salt, bytes32 initCodeHash) internal pure returns (address) {
+        return address(uint160(uint256(keccak256(abi.encodePacked(hex"ff", CREATE2_FACTORY, salt, initCodeHash)))));
+    }
+
+    function _deployViaFactory(bytes32 salt, bytes memory creationCode) internal returns (address) {
+        vm.prank(safe);
+        (bool success, bytes memory result) = CREATE2_FACTORY.call(abi.encodePacked(salt, creationCode));
+        require(success, "CREATE2 deploy failed");
+        address deployed;
+        assembly {
+            deployed := shr(96, mload(add(result, 32)))
+        }
+        return deployed;
+    }
+}


### PR DESCRIPTION
## Summary

Two Safe transactions (sequential nonces, proposed by one script run) that bootstrap on-chain discovery for Octant production contracts:

**Batch 1** (~13M gas, epoch 0→1)
1. CREATE2-deploys **`OctantRegistry`** — the new canonical on-chain registry;
2. CREATE2-deploys four strategy factories: **AaveV3**, **Spark**, **Lido**, **RocketPool**;
3. atomically publishes **registry epoch 1** (22 entries): the 4 new factories, the **latest existing mainnet generation** (11022026 batch) under canonical keys, and the **superseded generations** under versioned `*_V1`/`*_V2` keys.

**Batch 2** (~8.4M gas, epoch 1→2)
1. CREATE2-deploys the fresh **1.1.0 singletons**: `YieldSkimmingTokenizedStrategy` (~20KB, never deployed before) and `YieldDonatingTokenizedStrategy` (~16KB — the deployed mainnet one reports apiVersion **1.0.0** and lacks `reportAndDisableBurning()`, so release 1.3.0 needs a fresh deployment);
2. atomically publishes **registry epoch 2** (9 updates): both new singletons take the canonical `YIELD_SKIMMING_STRATEGY` / `YIELD_DONATING_STRATEGY` keys (compatibility `1.1.0`), and all 7 legacy-generation entries flip to **DEPRECATED** (addresses retained, no longer resolve as active — discovery signal only).

Two transactions because one would exceed the **EIP-7825 per-transaction gas cap (16,777,216)**: code deposits alone are ~16.9M across the seven contracts. Each batch is internally atomic (`execTransaction` → `MultiSendCallOnly`): its deployments and its registry entries land together or the transaction reverts. Batch 2's `expectedEpoch = 1` makes it executable only after batch 1 — out-of-order execution reverts on the epoch check instead of corrupting state. An earlier iteration split this into two contracts (address book + Yearn-style `ReleaseRegistry`); that split was dropped — see [ADR-001](../blob/feature/deploy-aave-spark-lido-factories/doc/adr/ADR-001-unified-production-registry.md) and "Design rationale" below.

---

## How the registry works

`OctantRegistry` is a **Safe-owned, non-upgradeable address book**, for discovery only (deploy tooling, frontends, auditors, indexers). Production contracts never resolve dependencies through it at runtime.

**Reading.** Each entry is keyed by a readable `bytes32` short-string (`"AAVE_V3_STRATEGY_FACTORY"` — shared constants in `src/registry/RegistryKeys.sol`) and stores:

| Field | Meaning |
|---|---|
| `addr` | current contract address |
| `entryType` | `CONTRACT` / `FACTORY` / `REGISTRY` — immutable once set |
| `status` | `ACTIVE` / `DEPRECATED` / `DISABLED` — only `ACTIVE` resolves via `getAddress`/`tryGetAddress`; others stay inspectable via `getEntry` |
| `bump`, `epoch`, `updatedAt` | per-key revision counter, epoch of last change, timestamp |
| `compatibilityVersion` | optional API-compat version of the registered contract |
| `runtimeCodeHash` | target's code hash observed at publication |

Keys are **append-only** — entries are never deleted, only status-changed, so enumeration and counters stay stable.

**Writing.** There is exactly one write path:

```solidity
publishBatch(expectedEpoch, updates[], releaseLabel)   // onlyOwner (the Safe)
```

- Every successful batch increments a **global epoch** by exactly 1. `expectedEpoch` is optimistic concurrency control: a Safe proposal built against stale state reverts instead of silently overwriting newer state.
- Each update is validated: target has code, valid key/type/status, no duplicate keys, no no-ops, new keys must start `ACTIVE`.
- The registry itself computes a **manifest hash** (`RegistryManifest`) binding chain id + registry address + epoch + release label + the complete ordered update set. Callers cannot supply or substitute it, and a publication can't be replayed on another chain, registry, or epoch.

**History.** Current state lives in storage; complete history lives in events — `EntryPublished` per changed entry, `BatchPublished(epoch, manifestHash, releaseLabel)` per batch. Replaying events reconstructs every revision without unbounded on-chain arrays.

**End of life.** No proxy. `setSuccessorOnce(expectedEpoch, successor)` validates the successor (has code, implements `IOctantRegistry` via ERC-165, not itself superseded), points at it **irreversibly**, and permanently freezes the old registry. Ownership renunciation is disabled so the registry can never become ungoverned.

> Mental model: a git repo owned by the Safe — `publishBatch` is a signed commit (epoch = commit number, manifest hash = commit hash, release label = commit message); storage is the checked-out tree; the event log is `git log`.

---

## What the deploy script does

`script/deploy/DeployAaveSparkLidoFactories.s.sol` **proposes both batches** to the Safe Transaction Service in one run (nothing executes on-chain until Safe signers approve; execute them in nonce order):

1. **Guard** — refuses to run unless `chainid == 1` (factories hardcode mainnet protocol addresses; mainnet forks keep chainid 1, so simulation works).
2. **Precompute** — derives all six CREATE2 addresses from salt + bytecode. The registry's init-code embeds the Safe address as constructor arg.
3. **Batch 1: stage deployments** — registry + four factories via the Arachnid CREATE2 factory (`0x4e59…956C`).
4. **Batch 1: stage the publication** — builds the epoch-1 update set (4 new factories + all non-zero entries of `DeployedAddresses.getMainnetAddresses()`; the deployed 1.0.0 YieldDonating singleton registers under `YIELD_DONATING_STRATEGY_V1` with compatibility `1.0.0` — the registry requires new keys to start ACTIVE, so its deprecation happens in batch 2), computes the expected manifest hash locally, appends `publishBatch(0, updates, releaseLabel)`. The release label is read from `package.json` `.version` at run time.
5. **Self-check** — every staged call executes in the forked simulation, so `_assertRegistrations()` re-reads the simulated registry and reverts the script on any mismatch of entry address, type, status, code hash, epoch (must be 1), manifest hash, or release label. **A batch that deploys without registering cannot be proposed.**
6. **Propose batch 1** — signs the EIP-712 SafeTx via `cast wallet sign` (FFI) and POSTs it to the Safe backend.
7. **Batch 2** — `_startNewBatch()` clears the staged calls (simulation state persists), stages both 1.1.0 singleton deployments plus one `publishBatch(1, …)` with three updates (two new ACTIVE entries + the `YIELD_DONATING_STRATEGY_V1` DEPRECATED flip), runs the same self-check against epoch 2 (including that the deprecated entry no longer resolves via `tryGetAddress`), and proposes it at the **next Safe nonce** (the nonce is fetched once and incremented locally, so the two proposals can't collide).

## Epoch-1 registry entries (batch 1 — 22 entries)

**Generation model**: canonical keys point at the **latest** deployment of each kind; superseded generations keep versioned keys (`*_V1`, `*_V2` in deployment order). Legacy entries enter ACTIVE (registry rule: new keys must start ACTIVE) and are flipped to DEPRECATED in epoch 2. `DeployedAddresses.getMainnetAddresses()` was updated to the latest (11022026) generation as part of this PR — it previously held the superseded 05112025 set.

**Canonical — new deployments (CREATE2-predicted from this revision):**

| Key | Type | Address |
|---|---|---|
| `AAVE_V3_STRATEGY_FACTORY` | FACTORY | `0xD761787605a11AB4bf87eb80D50c3debd5b21cd3` |
| `SPARK_STRATEGY_FACTORY` | FACTORY | `0x5FfaDB348bF3D46543ca449D2F5337a7a9B8bD23` |
| `LIDO_STRATEGY_FACTORY` | FACTORY | `0xB4C54fD75eae00D360b884948b5903FBE3dd4656` |
| `ROCKET_POOL_STRATEGY_FACTORY` | FACTORY | `0x55c16775Cfe671B68416c2BD64e9100747940772` |

**Canonical — latest existing mainnet generation (11022026 batch, Feb 2026):**

| Key | Type | Address |
|---|---|---|
| `PAYMENT_SPLITTER_FACTORY` | FACTORY | `0x6584165BB905dD2513CC81C4ef609Ee78FBDFEf9` |
| `SKY_COMPOUNDER_FACTORY` | FACTORY | `0x2a3fd5D3ab48cDE74Cb0b179d3C67155119141cC` |
| `MORPHO_COMPOUNDER_FACTORY` | FACTORY | `0x1eE8Af6604d7e80f155D45a863128Bc79f015275` |
| `YEARN_V3_STRATEGY_FACTORY` | FACTORY | `0x9A6c9aA80D4A0d8Da29EcbA62c40ccBBB321abB6` |
| `EARNING_POWER_CALCULATOR_FACTORY` | FACTORY | `0xD916da52d277b28CaDFfEE5350bA98cf3d8fa441` |
| `REGEN_STAKER_FACTORY` | FACTORY | `0x6a8250C95d2e866e95fe4749eD540357B8e44a9a` |
| `ADDRESS_SET_FACTORY` | FACTORY | `0x908FA1747a5E12708c0e575875F2685750CFEfD1` |
| `STAKER_ALLOWSET` | CONTRACT | `0x4FFAb2c015d9dCd5D20d489E644D99ae67a57270` |
| `STAKER_BLOCKSET` | CONTRACT | `0xD65B1936D497be8e2f56862664833eB64D1e2d7e` |
| `ALLOCATION_MECHANISM_ALLOWSET` | CONTRACT | `0xE000b30E2BC08A39BD863d4df6c42148439A1D1B` |
| `REGEN_EARNING_POWER_CALCULATOR` | CONTRACT | `0xEa8AEe52411f153547744e98E592dd9FF14b76B0` |

**Legacy generations (ACTIVE in epoch 1 → DEPRECATED in epoch 2):**

| Key | Type | Address | Generation | Compat |
|---|---|---|---|---|
| `YIELD_DONATING_STRATEGY_V1` | CONTRACT | `0xb27064A2C51b8C5b39A5Bb911AD34DB039C3aB9c` | 05112025 (Nov 2025) | `1.0.0` |
| `YIELD_DONATING_STRATEGY_V2` | CONTRACT | `0xE8797A98710518A6973Cc8612f98154EECF2C711` | 11022026 (Feb 2026) | `1.0.0` |
| `PAYMENT_SPLITTER_FACTORY_V1` | FACTORY | `0x5711765E0756B45224fc1FdA1B41ab344682bBcb` | 05112025 | — |
| `SKY_COMPOUNDER_FACTORY_V1` | FACTORY | `0xbe5352d0eCdB13D9f74c244B634FdD729480Bb6F` | 05112025 | — |
| `MORPHO_COMPOUNDER_FACTORY_V1` | FACTORY | `0x052d20B0e0b141988bD32772C735085e45F357c1` | 05112025 | — |
| `YEARN_V3_STRATEGY_FACTORY_V1` | FACTORY | `0x6D8c4E4A158083E30B53ba7df3cFB885fC096fF6` | 05112025 | — |
| `LIDO_STRATEGY_FACTORY_V1` | FACTORY | `0xc69288F65647DDf8FDBfDc905bdBD21b034b61b8` | 11022026 (superseded by this PR's Lido factory) | — |

Notes: new-deployment addresses hold only for this exact bytecode + salts (`_assertRegistrations()` enforces consistency at proposal time); zero-valued `getMainnetAddresses()` fields (`linearAllowanceSingleton`, `allocationMechanismFactory`) are skipped; the `OctantRegistry` itself is not an entry (its address depends on `SAFE_ADDRESS`).

### Epoch-2 updates (batch 2 — 9 updates)

| Key | Type | Address | Compat | Update |
|---|---|---|---|---|
| `YIELD_SKIMMING_STRATEGY` | CONTRACT | `0xE0a0f0b259e9254cd936aD31d57d345507fd7136` | `1.1.0` | new (CREATE2, salt `OCTANT_YIELD_SKIMMING_STRATEGY_07082026`) |
| `YIELD_DONATING_STRATEGY` | CONTRACT | `0xC5215df958696F6dF1648320E86D0fe797B3aaa6` | `1.1.0` | new (CREATE2, salt `OCTANT_YIELD_DONATING_STRATEGY_07082026`) |
| all 7 legacy keys above | — | (addresses retained) | — | status flip → **DEPRECATED** |

Why fresh singletons: **no 1.1.0-compatible singleton of either kind exists on mainnet** — every deployed one reports `apiVersion() = "1.0.0"` and lacks the `reportAndDisableBurning()` selector required by release 1.3.0 (verified on-chain). Final registry state after both batches: **24 keys, epoch 2** (17 ACTIVE + 7 DEPRECATED).

## Pre-run checklist

- [ ] **`SAFE_ADDRESS` is final** — it's baked into the registry init-code; a different Safe ⇒ a different registry address.
- [ ] **Bytecode is final** — any contract change (even metadata) shifts every predicted CREATE2 address; regenerate recorded addresses from the final build.
- [ ] **Salt dates** — currently `OCTANT_REGISTRY_22072026` / `*_21072026` / `OCTANT_YIELD_{SKIMMING,DONATING}_STRATEGY_07082026`; re-date if deploying on another day (new salt = new address), and note a consumed salt makes the CREATE2 call revert.
- [ ] **`DeployedAddresses.getMainnetAddresses()` is accurate** — those addresses become canonical at epoch 1.
- [ ] **`package.json` version** is the intended release label (deploy from a release commit, not `-develop.x`, unless intended).

## How to run

One script run simulates everything, then proposes **both Safe transactions** (consecutive nonces) to the Safe Transaction Service:

```bash
export SAFE_ADDRESS=0x...        # the owner Safe (final! — it determines the registry address)
export CHAIN=mainnet             # selects Safe API + MultiSend for chainid 1
export WALLET_TYPE=local         # or: ledger (then set MNEMONIC_INDEX instead of PRIVATE_KEY)
export PRIVATE_KEY=0x...         # proposer key — must be a Safe owner or delegate
export SENDER=0x...              # proposer address
export ETH_RPC_URL=https://...   # mainnet RPC (or mainnet fork)

forge script script/deploy/DeployAaveSparkLidoFactories.s.sol \
  --rpc-url $ETH_RPC_URL --ffi --sender $SENDER
```

Notes:

- `--ffi` is required — EIP-712 signing shells out to `cast wallet sign`.
- The script refuses to run unless `chainid == 1`; it reads the release label from `package.json` at run time (needs the repo checkout it runs from).
- The console output ends with a **deployment summary**: all six predicted addresses plus both manifest hashes — save it; signers can check the manifest hashes against the `BatchPublished` events after execution.
- For a Tenderly dry-run: `CHAIN=tenderly` plus `CHAIN_ID` and `SAFE_API_BASE_URL`.
- Nothing executes on-chain at this stage — the run only creates two pending proposals.

**Then, in the Safe UI:** review, sign, and execute the two transactions **in nonce order** —

1. **Batch 1** (nonce *n*): registry + 4 factories + epoch-1 publication (16 entries).
2. **Batch 2** (nonce *n+1*): both 1.1.0 singletons + epoch-2 publication (canonical keys + V1 deprecation).

The Safe enforces nonce order, and batch 2 additionally self-protects: its `publishBatch(expectedEpoch = 1)` reverts unless batch 1 already executed. If the run is repeated after a partial execution, already-consumed CREATE2 salts revert — re-dating the salts (new addresses) is the recovery path.

## After execution

Once **both** batches are executed:

```bash
REGISTRY_ADDRESS=0x<registry> ETH_RPC_URL=https://... yarn registry:export
```

Regenerates `deployments/1.json` (expect **24 entries, epoch 2** — 17 ACTIVE + 7 DEPRECATED legacy generations) from one pinned, reorg-checked block (defaults to `finalized`; override with `REGISTRY_SNAPSHOT=safe|latest|<block>`); refuses to export a superseded registry. `deployments/*.json` and `script/helpers/DeployedAddresses.sol` are **caches** — on-chain state is authoritative.

Future deploy batches follow the same pattern via the `BatchScript` helpers: CREATE2 deploys + one `publishBatch(currentEpoch, …)` in the same Safe transaction, splitting into sequential batches with `_startNewBatch()` whenever one transaction would exceed the EIP-7825 gas cap.

---

## Design rationale: why one registry

An earlier revision used two contracts: a flat address book ("current") and an append-only `ReleaseRegistry` ("history"). Every factory deployment then required coordinated writes to two independently administered contracts that could diverge through later governance actions or tooling mistakes, duplicated version concepts, and consumers had to know which was authoritative. The unified design keeps canonical current state in storage and full history in events — one authority, one key namespace, one atomic consistency boundary. Alternatives considered are recorded in ADR-001.

**Version semantics** (three deliberately separate concepts): `API_VERSION()` = the registry interface version; `Entry.compatibilityVersion` = optional API version of a registered contract; `releaseLabel` = human-readable deployment metadata (the repo package version).

## Canonical keys

Keys are uppercase `A–Z`, `0–9`, `_` short-strings matching the CREATE2 salt name without its date suffix, declared once in `RegistryKeys.sol`. Names longer than 32 bytes are shortened there, e.g. `REGEN_EARNING_POWER_CALCULATOR_FACTORY` → `EARNING_POWER_CALCULATOR_FACTORY`.

## Gas

Code-deposit gas (200/byte, before calldata and Safe overhead): registry ~1.44M, AaveV3 ~3.05M, Spark ~2.09M, Lido ~1.57M, RocketPool ~1.57M, YieldSkimming singleton ~4.0M, YieldDonating singleton ~3.18M — ~16.9M total, which is why the deployment is split across two transactions under the EIP-7825 cap (16,777,216). Batch 1 ≈ 13.5M (deploys + 22-entry publication), batch 2 ≈ 8.6M (two singletons + 9-update publication). The authoritative check is the final Safe simulation from this revision.

## Validation

- Unit + batch-flow tests: publication, lifecycle transitions, validation, authorization, stale epochs, atomic rollback, ownership handover, ERC-165, successor migration.
- Invariant tests: append-only enumeration, ghost-state agreement, epoch accounting, code-hash agreement, active-address resolution.
- Exporter tested via `yarn registry:test` (node test runner) and end-to-end against a disposable Anvil deployment, including superseded-registry rejection.
- Build, formatting, linting, NatSpec, and Slither pass in CI.

---

Replaces #467 (closed after the branch rename required by the `feature/*` branch-naming check).





